### PR TITLE
gitignore circuit-benchmarks/src/bench_params.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.png
+circuit-benchmarks/src/bench_params.rs


### PR DESCRIPTION
currently circuit-benchmarks/src/bench_params.rs (if ever generated) will be easily added to git by mistake. But this can depend on the ENV config of different people