### PR TITLE
public mod table

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -6,8 +6,9 @@ use halo2::{arithmetic::FieldExt, circuit::Layouter, plonk::*};
 mod execution;
 mod param;
 mod step;
-mod table;
 mod util;
+
+pub mod table;
 pub mod witness;
 
 use execution::ExecutionConfig;


### PR DESCRIPTION
we need use table::FixedTableTag in external project, so I think we should make `table` mod public