### PR TITLE
Signed comparator gadget (SLT, SGT)

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -32,6 +32,7 @@ mod msize;
 mod pc;
 mod pop;
 mod push;
+mod signed_comparator;
 mod signextend;
 mod stop;
 mod swap;
@@ -49,6 +50,7 @@ use msize::MsizeGadget;
 use pc::PcGadget;
 use pop::PopGadget;
 use push::PushGadget;
+use signed_comparator::SignedComparatorGadget;
 use signextend::SignextendGadget;
 use stop::StopGadget;
 use swap::SwapGadget;
@@ -89,6 +91,7 @@ pub(crate) struct ExecutionConfig<F> {
     pc_gadget: PcGadget<F>,
     pop_gadget: PopGadget<F>,
     push_gadget: PushGadget<F>,
+    signed_comparator_gadget: SignedComparatorGadget<F>,
     signextend_gadget: SignextendGadget<F>,
     stop_gadget: StopGadget<F>,
     swap_gadget: SwapGadget<F>,
@@ -202,6 +205,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             pc_gadget: configure_gadget!(),
             pop_gadget: configure_gadget!(),
             push_gadget: configure_gadget!(),
+            signed_comparator_gadget: configure_gadget!(),
             signextend_gadget: configure_gadget!(),
             stop_gadget: configure_gadget!(),
             swap_gadget: configure_gadget!(),
@@ -409,6 +413,9 @@ impl<F: FieldExt> ExecutionConfig<F> {
                 assign_exec_step!(self.signextend_gadget)
             }
             ExecutionState::CMP => assign_exec_step!(self.comparator_gadget),
+            ExecutionState::SCMP => {
+                assign_exec_step!(self.signed_comparator_gadget)
+            }
             ExecutionState::BYTE => assign_exec_step!(self.byte_gadget),
             ExecutionState::POP => assign_exec_step!(self.pop_gadget),
             ExecutionState::MEMORY => assign_exec_step!(self.memory_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -284,6 +284,13 @@ mod test {
     }
 
     #[test]
+    fn signed_comparator_gadget_a_eq_b() {
+        let a = rand_word();
+        test_ok(OpcodeId::SLT, a, a);
+        test_ok(OpcodeId::SGT, a, a);
+    }
+
+    #[test]
     fn signed_comparator_gadget_rand() {
         let a = rand_word();
         let b = rand_word();

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -59,9 +59,9 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // number is negative if the most significant cell >= 128
         // (0b10000000).
         let sign_check_a =
-            LtGadget::construct(cb, a.cells[0].expr(), 128u8.expr());
+            LtGadget::construct(cb, a.cells[0].expr(), 128.expr());
         let sign_check_b =
-            LtGadget::construct(cb, b.cells[0].expr(), 128u8.expr());
+            LtGadget::construct(cb, b.cells[0].expr(), 128.expr());
 
         // sign_check_a_lt expression implies a is positive since its MSB < 2**7
         // sign_check_b_lt expression implies b is positive since its MSB < 2**7
@@ -90,21 +90,21 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         let a_b_positive = sign_check_a_lt.clone() * sign_check_b_lt.clone();
         let a_lt_b = select::expr(
             a_b_positive,
-            select::expr(a_lt_b_hi.clone(), 1u8.expr(), a_lt_b_lo.clone()),
-            select::expr(a_lt_b_hi, 0u8.expr(), 1u8.expr() - a_lt_b_lo),
+            select::expr(a_lt_b_hi.clone(), 1.expr(), a_lt_b_lo.clone()),
+            select::expr(a_lt_b_hi, 0.expr(), 1.expr() - a_lt_b_lo),
         );
 
         // Add a trivial selector: if only a or only b is negative we have the
         // result. result = if a < 0 && b > 0, slt = 1.
         // result = if b < 0 && a < 0, slt = 0.
         let a_negative =
-            (1u8.expr() - sign_check_a_lt.expr()) * sign_check_b_lt.expr();
+            (1.expr() - sign_check_a_lt.expr()) * sign_check_b_lt.expr();
         let b_negative =
-            (1u8.expr() - sign_check_b_lt.expr()) * sign_check_a_lt.expr();
+            (1.expr() - sign_check_b_lt.expr()) * sign_check_a_lt.expr();
         let result = select::expr(
             a_negative,
-            0u8.expr(),
-            select::expr(b_negative, 1u8.expr(), a_lt_b),
+            0.expr(),
+            select::expr(b_negative, 1.expr(), a_lt_b),
         );
 
         // Pop a and b from the stack, push the result on the stack.
@@ -117,9 +117,9 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // and the since the stack now has one less word, the stack pointer also
         // shifts by one.
         let step_state_transition = StepStateTransition {
-            rw_counter: Transition::Delta(3u8.expr()),
-            program_counter: Transition::Delta(1u8.expr()),
-            stack_pointer: Transition::Delta(1u8.expr()),
+            rw_counter: Transition::Delta(3.expr()),
+            program_counter: Transition::Delta(1.expr()),
+            stack_pointer: Transition::Delta(1.expr()),
             ..Default::default()
         };
         let same_context = SameContextGadget::construct(
@@ -237,7 +237,7 @@ mod test {
         };
         let plus_1 = {
             let mut bytes = vec![0u8; 15];
-            bytes.push(1u8);
+            bytes.push(1);
             let bytes: [u8; 16] = bytes.try_into().unwrap();
             Word::from_big_endian(&bytes)
         };

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -172,13 +172,13 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         self.sign_check_a.assign(
             region,
             offset,
-            from_bytes::value(&a[0..1]),
+            F::from(a[0] as u64),
             F::from(128u64),
         )?;
         self.sign_check_b.assign(
             region,
             offset,
-            from_bytes::value(&b[0..1]),
+            F::from(b[0] as u64),
             F::from(128u64),
         )?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -3,12 +3,13 @@ use crate::{
         execution::ExecutionGadget,
         step::ExecutionState,
         util::{
+            and,
             common_gadget::SameContextGadget,
             constraint_builder::{
                 ConstraintBuilder, StepStateTransition, Transition,
             },
             from_bytes,
-            math_gadget::{IsEqualGadget, LtGadget},
+            math_gadget::{ComparisonGadget, IsEqualGadget, LtGadget},
             select, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
@@ -16,7 +17,7 @@ use crate::{
     util::Expr,
 };
 
-use bus_mapping::{eth_types::ToLittleEndian, evm::OpcodeId};
+use bus_mapping::{eth_types::ToBigEndian, evm::OpcodeId};
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 
 /// Gadget that implements the ExecutionGadget trait to handle the Opcodes SLT
@@ -31,7 +32,7 @@ pub(crate) struct SignedComparatorGadget<F> {
     sign_check_a: LtGadget<F, 1>,
     sign_check_b: LtGadget<F, 1>,
     lt_lo: LtGadget<F, 16>,
-    lt_hi: LtGadget<F, 16>,
+    comparison_hi: ComparisonGadget<F, 16>,
 
     is_sgt: IsEqualGadget<F>,
 }
@@ -57,7 +58,8 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // (32 cells) integers. This means, the first bit denotes the sign
         // of the absolute value in the rest of the 255 bits. This means the
         // number is negative if the most significant cell >= 128
-        // (0b10000000).
+        // (0b10000000). `a` and `b` being in the big-endian notation, the
+        // most-significant byte is the first byte.
         let sign_check_a =
             LtGadget::construct(cb, a.cells[0].expr(), 128.expr());
         let sign_check_b =
@@ -72,39 +74,66 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // (a < 0 && b < 0) || (a > 0 && b > 0).
         // We ignore the equality expression since we only care about the LT
         // check.
+        // By `lo` we mean the low bytes, and `hi` stands for the more
+        // significant bytes. While only considering the absolute
+        // values, we have: a < b == 1 iff ((a_hi < b_hi) || ((a_hi ==
+        // b_hi) && (a_lo < b_lo)))
         let lt_lo = LtGadget::construct(
-            cb,
-            from_bytes::expr(&a.cells[0..16]),
-            from_bytes::expr(&b.cells[0..16]),
-        );
-        let lt_hi = LtGadget::construct(
             cb,
             from_bytes::expr(&a.cells[16..32]),
             from_bytes::expr(&b.cells[16..32]),
         );
+        let comparison_hi = ComparisonGadget::construct(
+            cb,
+            from_bytes::expr(&a.cells[0..16]),
+            from_bytes::expr(&b.cells[0..16]),
+        );
         let a_lt_b_lo = lt_lo.expr();
-        let a_lt_b_hi = lt_hi.expr();
+        let (a_lt_b_hi, a_eq_b_hi) = comparison_hi.expr();
 
-        // If a and b both are positive, we do a standard comparison check. If
-        // both a and b are negative, we invert those outcomes.
-        let a_b_positive = sign_check_a_lt.clone() * sign_check_b_lt.clone();
+        // Add selector only for the cases where both a and b are positive or
+        // negative. This selector will be used after handling the cases
+        // where either only a or only b are negative.
+        //
+        // if a > 0 && b > 0:
+        //      a < b -> (a_hi < b_hi) ? 1 : (a_hi == b_hi) * (a_lo < b_lo)
+        // else if a < 0 && b < 0:
+        //      a < b -> (a_hi < b_hi) ? 0 : ~((a_hi == b_hi) * (a_lo < b_lo))
+        let a_b_positive =
+            and::expr(&[sign_check_a_lt.clone(), sign_check_b_lt.clone()]);
+        let a_b_negative = and::expr(&[
+            1.expr() - sign_check_a_lt.clone(),
+            1.expr() - sign_check_b_lt.clone(),
+        ]);
         let a_lt_b = select::expr(
             a_b_positive,
-            select::expr(a_lt_b_hi.clone(), 1.expr(), a_lt_b_lo.clone()),
-            select::expr(a_lt_b_hi, 0.expr(), 1.expr() - a_lt_b_lo),
+            select::expr(
+                a_lt_b_hi.clone(),
+                1.expr(),
+                a_eq_b_hi.clone() * a_lt_b_lo.clone(),
+            ),
+            and::expr(&[
+                a_b_negative,
+                select::expr(
+                    a_lt_b_hi,
+                    0.expr(),
+                    1.expr() - (a_eq_b_hi * a_lt_b_lo),
+                ),
+            ]),
         );
 
         // Add a trivial selector: if only a or only b is negative we have the
-        // result. result = if a < 0 && b > 0, slt = 1.
-        // result = if b < 0 && a < 0, slt = 0.
+        // result.
+        // result = if a < 0 && b > 0, slt = 1.
+        // result = if b < 0 && a > 0, slt = 0.
         let a_negative =
             (1.expr() - sign_check_a_lt.expr()) * sign_check_b_lt.expr();
         let b_negative =
             (1.expr() - sign_check_b_lt.expr()) * sign_check_a_lt.expr();
         let result = select::expr(
             a_negative,
-            0.expr(),
-            select::expr(b_negative, 1.expr(), a_lt_b),
+            1.expr(),
+            select::expr(b_negative, 0.expr(), a_lt_b),
         );
 
         // Pop a and b from the stack, push the result on the stack.
@@ -136,7 +165,7 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
             sign_check_a,
             sign_check_b,
             lt_lo,
-            lt_hi,
+            comparison_hi,
             is_sgt,
         }
     }
@@ -155,20 +184,22 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         let opcode = step.opcode.unwrap();
 
         // SLT opcode is the default check in the SCMP gadget. Swap rw for SGT.
-        let is_sgt = self.is_sgt.assign(
+        self.is_sgt.assign(
             region,
             offset,
             F::from(opcode.as_u8() as u64),
             F::from(OpcodeId::SGT.as_u8() as u64),
         )?;
-        let indices = if is_sgt == F::one() {
+        let indices = if opcode == OpcodeId::SGT {
             [step.rw_indices[1], step.rw_indices[0]]
         } else {
             [step.rw_indices[0], step.rw_indices[1]]
         };
         let [a, b] =
-            indices.map(|idx| block.rws[idx].stack_value().to_le_bytes());
+            indices.map(|idx| block.rws[idx].stack_value().to_be_bytes());
 
+        // Assign to the sign check gadgets. Since both a and b are in the
+        // big-endian form, the most significant byte is the first byte.
         self.sign_check_a.assign(
             region,
             offset,
@@ -182,17 +213,20 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
             F::from(128u64),
         )?;
 
+        // Assign to the comparison gadgets. The first 16 bytes are assigned to
+        // the `hi` comparison while the last 16 bytes are assigned to
+        // the `lo` less-than gadget.
         self.lt_lo.assign(
-            region,
-            offset,
-            from_bytes::value(&a[0..16]),
-            from_bytes::value(&b[0..16]),
-        )?;
-        self.lt_hi.assign(
             region,
             offset,
             from_bytes::value(&a[16..32]),
             from_bytes::value(&b[16..32]),
+        )?;
+        self.comparison_hi.assign(
+            region,
+            offset,
+            from_bytes::value(&a[0..16]),
+            from_bytes::value(&b[0..16]),
         )?;
 
         self.a.assign(region, offset, Some(a))?;
@@ -226,38 +260,85 @@ mod test {
     }
 
     #[test]
+    // TODO(rohit): rename this once lookup error is debugged
+    fn alice() {
+        let zero = Word::from_big_endian(&[0u8; 32]);
+        let minus_1 = Word::from_big_endian(&[255u8; 32]);
+        test_ok(OpcodeId::SLT, minus_1, zero);
+        test_ok(OpcodeId::SGT, zero, minus_1);
+    }
+
+    #[test]
+    // TODO(rohit): rename this once lookup error is debugged
+    fn bob() {
+        let zero = Word::from_big_endian(&[0u8; 32]);
+        let plus_1 = {
+            let mut bytes = vec![0u8; 32];
+            bytes[31] = 1u8;
+            let bytes: [u8; 32] = bytes.try_into().unwrap();
+            Word::from_big_endian(&bytes)
+        };
+        test_ok(OpcodeId::SLT, zero, plus_1);
+        test_ok(OpcodeId::SGT, plus_1, zero);
+    }
+
+    #[test]
+    // TODO(rohit): rename this once lookup error is debugged
+    fn charlie() {
+        let minus_1 = Word::from_big_endian(&[255u8; 32]);
+        let minus_2 = {
+            let mut bytes = vec![255u8; 32];
+            bytes[31] = 254u8;
+            let bytes: [u8; 32] = bytes.try_into().unwrap();
+            Word::from_big_endian(&bytes)
+        };
+        test_ok(OpcodeId::SLT, minus_2, minus_1);
+        test_ok(OpcodeId::SGT, minus_1, minus_2);
+    }
+
+    #[test]
+    #[ignore]
     fn signed_comparator_gadget_simple() {
         let zero = Word::from_big_endian(&[0u8; 32]);
-        let minus_1 = Word::from_big_endian(&[255u8; 16]);
+        let minus_1 = Word::from_big_endian(&[255u8; 32]);
         let minus_2 = {
-            let mut bytes = vec![255u8; 15];
-            bytes.push(254u8);
-            let bytes: [u8; 16] = bytes.try_into().unwrap();
+            let mut bytes = vec![255u8; 32];
+            bytes[31] = 254u8;
+            let bytes: [u8; 32] = bytes.try_into().unwrap();
             Word::from_big_endian(&bytes)
         };
         let plus_1 = {
-            let mut bytes = vec![0u8; 15];
-            bytes.push(1);
-            let bytes: [u8; 16] = bytes.try_into().unwrap();
+            let mut bytes = vec![0u8; 32];
+            bytes[31] = 1u8;
+            let bytes: [u8; 32] = bytes.try_into().unwrap();
+            Word::from_big_endian(&bytes)
+        };
+        let plus_2 = {
+            let mut bytes = vec![0u8; 32];
+            bytes[31] = 2u8;
+            let bytes: [u8; 32] = bytes.try_into().unwrap();
             Word::from_big_endian(&bytes)
         };
 
         // SLT
         test_ok(OpcodeId::SLT, minus_1, zero);
         test_ok(OpcodeId::SLT, zero, plus_1);
-        test_ok(OpcodeId::SLT, minus_1, zero);
+        test_ok(OpcodeId::SLT, plus_1, plus_2);
+        test_ok(OpcodeId::SLT, minus_2, zero);
         test_ok(OpcodeId::SLT, minus_2, plus_1);
         test_ok(OpcodeId::SLT, minus_2, minus_1);
 
-        // SGT
-        test_ok(OpcodeId::SGT, zero, minus_1);
+        //// SGT
         test_ok(OpcodeId::SGT, minus_1, minus_2);
+        test_ok(OpcodeId::SGT, zero, minus_1);
         test_ok(OpcodeId::SGT, plus_1, zero);
+        test_ok(OpcodeId::SGT, plus_2, plus_1);
         test_ok(OpcodeId::SGT, plus_1, minus_1);
         test_ok(OpcodeId::SGT, plus_1, minus_2);
     }
 
     #[test]
+    #[ignore]
     fn signed_comparator_gadget_rand() {
         let a = rand_word();
         let b = rand_word();

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -17,7 +17,7 @@ use crate::{
     util::Expr,
 };
 
-use bus_mapping::{eth_types::ToBigEndian, evm::OpcodeId};
+use bus_mapping::{eth_types::ToLittleEndian, evm::OpcodeId};
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 
 /// Gadget that implements the ExecutionGadget trait to handle the Opcodes SLT
@@ -196,7 +196,7 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
             [step.rw_indices[0], step.rw_indices[1]]
         };
         let [a, b] =
-            indices.map(|idx| block.rws[idx].stack_value().to_be_bytes());
+            indices.map(|idx| block.rws[idx].stack_value().to_le_bytes());
 
         // Assign to the sign check gadgets. Since both a and b are in the
         // big-endian form, the most significant byte is the first byte.

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -223,8 +223,6 @@ mod test {
         witness,
     };
 
-    use std::convert::TryInto;
-
     fn test_ok(opcode: OpcodeId, a: Word, b: Word) {
         let bytecode = bytecode! {
             PUSH32(b)
@@ -238,30 +236,7 @@ mod test {
     }
 
     #[test]
-    // TODO(rohit): rename this once lookup error is debugged
-    fn alice() {
-        let zero = Word::from_big_endian(&[0u8; 32]);
-        let minus_1 = Word::from_big_endian(&[255u8; 32]);
-        test_ok(OpcodeId::SLT, minus_1, zero);
-        test_ok(OpcodeId::SGT, zero, minus_1);
-    }
-
-    #[test]
-    // TODO(rohit): rename this once lookup error is debugged
-    fn bob() {
-        let zero = Word::from_big_endian(&[0u8; 32]);
-        let plus_1 = {
-            let mut bytes = vec![0u8; 32];
-            bytes[31] = 1u8;
-            Word::from_big_endian(&bytes)
-        };
-        test_ok(OpcodeId::SLT, zero, plus_1);
-        test_ok(OpcodeId::SGT, plus_1, zero);
-    }
-
-    #[test]
-    // TODO(rohit): rename this once lookup error is debugged
-    fn charlie() {
+    fn signed_comparator_gadget_a_b_neg() {
         let minus_1 = Word::from_big_endian(&[255u8; 32]);
         let minus_2 = {
             let mut bytes = vec![255u8; 32];
@@ -269,12 +244,13 @@ mod test {
             Word::from_big_endian(&bytes)
         };
         test_ok(OpcodeId::SLT, minus_2, minus_1);
+        test_ok(OpcodeId::SGT, minus_2, minus_1);
+        test_ok(OpcodeId::SLT, minus_1, minus_2);
         test_ok(OpcodeId::SGT, minus_1, minus_2);
     }
 
     #[test]
-    // TODO(rohit): rename this once lookup error is debugged
-    fn dave() {
+    fn signed_comparator_gadget_a_b_pos() {
         let plus_1 = {
             let mut bytes = vec![0u8; 32];
             bytes[31] = 1u8;
@@ -282,56 +258,38 @@ mod test {
         };
         let plus_2 = plus_1 + 1;
         test_ok(OpcodeId::SLT, plus_1, plus_2);
+        test_ok(OpcodeId::SGT, plus_1, plus_2);
+        test_ok(OpcodeId::SLT, plus_2, plus_1);
         test_ok(OpcodeId::SGT, plus_2, plus_1);
     }
 
     #[test]
-    #[ignore]
-    fn signed_comparator_gadget_simple() {
-        let zero = Word::from_big_endian(&[0u8; 32]);
-        let minus_1 = Word::from_big_endian(&[255u8; 32]);
-        let minus_2 = {
-            let mut bytes = vec![255u8; 32];
-            bytes[31] = 254u8;
-            let bytes: [u8; 32] = bytes.try_into().unwrap();
-            Word::from_big_endian(&bytes)
-        };
-        let plus_1 = {
-            let mut bytes = vec![0u8; 32];
-            bytes[31] = 1u8;
-            let bytes: [u8; 32] = bytes.try_into().unwrap();
-            Word::from_big_endian(&bytes)
-        };
-        let plus_2 = {
-            let mut bytes = vec![0u8; 32];
-            bytes[31] = 2u8;
-            let bytes: [u8; 32] = bytes.try_into().unwrap();
-            Word::from_big_endian(&bytes)
-        };
-
-        // SLT
-        test_ok(OpcodeId::SLT, minus_1, zero);
-        test_ok(OpcodeId::SLT, zero, plus_1);
-        test_ok(OpcodeId::SLT, plus_1, plus_2);
-        test_ok(OpcodeId::SLT, minus_2, zero);
-        test_ok(OpcodeId::SLT, minus_2, plus_1);
-        test_ok(OpcodeId::SLT, minus_2, minus_1);
-
-        //// SGT
-        test_ok(OpcodeId::SGT, minus_1, minus_2);
-        test_ok(OpcodeId::SGT, zero, minus_1);
-        test_ok(OpcodeId::SGT, plus_1, zero);
-        test_ok(OpcodeId::SGT, plus_2, plus_1);
-        test_ok(OpcodeId::SGT, plus_1, minus_1);
-        test_ok(OpcodeId::SGT, plus_1, minus_2);
+    fn signed_comparator_gadget_a_b_eq_hi_pos() {
+        let a = Word::from_big_endian(&[[1u8; 16], [2u8; 16]].concat());
+        let b = Word::from_big_endian(&[[1u8; 16], [3u8; 16]].concat());
+        test_ok(OpcodeId::SLT, a, b);
+        test_ok(OpcodeId::SGT, a, b);
+        test_ok(OpcodeId::SLT, b, a);
+        test_ok(OpcodeId::SGT, b, a);
     }
 
     #[test]
-    #[ignore]
+    fn signed_comparator_gadget_a_b_eq_hi_neg() {
+        let a = Word::from_big_endian(&[[129u8; 16], [2u8; 16]].concat());
+        let b = Word::from_big_endian(&[[129u8; 16], [3u8; 16]].concat());
+        test_ok(OpcodeId::SLT, a, b);
+        test_ok(OpcodeId::SGT, a, b);
+        test_ok(OpcodeId::SLT, b, a);
+        test_ok(OpcodeId::SGT, b, a);
+    }
+
+    #[test]
     fn signed_comparator_gadget_rand() {
         let a = rand_word();
         let b = rand_word();
         test_ok(OpcodeId::SLT, a, b);
         test_ok(OpcodeId::SGT, a, b);
+        test_ok(OpcodeId::SLT, b, a);
+        test_ok(OpcodeId::SGT, b, a);
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -1,0 +1,277 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        util::{
+            common_gadget::SameContextGadget,
+            constraint_builder::{
+                ConstraintBuilder, StepStateTransition, Transition,
+            },
+            from_bytes,
+            math_gadget::{ComparisonGadget, IsEqualGadget},
+            select, Word,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+
+use bus_mapping::{eth_types::ToLittleEndian, evm::OpcodeId};
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
+
+/// Gadget that implements the ExecutionGadget trait to handle the Opcodes SLT
+/// and SGT.
+#[derive(Clone, Debug)]
+pub(crate) struct SignedComparatorGadget<F> {
+    same_context: SameContextGadget<F>,
+
+    a: Word<F>,
+    b: Word<F>,
+
+    sign_check_a: ComparisonGadget<F, 1>,
+    sign_check_b: ComparisonGadget<F, 1>,
+    comparison_lo: ComparisonGadget<F, 16>,
+    comparison_hi: ComparisonGadget<F, 16>,
+
+    is_sgt: IsEqualGadget<F>,
+}
+
+impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
+    const NAME: &'static str = "SCMP";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::SCMP;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let opcode = cb.query_cell();
+
+        let a = cb.query_word();
+        let b = cb.query_word();
+
+        // The Signed Comparator gadget is used for both opcodes [SLT]() and
+        // [SGT](). Depending on whether the opcode is SLT or SGT, we
+        // swap the order in which the inputs are placed on the stack.
+        let is_sgt =
+            IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::SGT.expr());
+
+        // Both `a` and `b` are to be treated as two's complement signed 256-bit
+        // (32 cells) integers. This means, the first bit denotes the sign
+        // of the absolute value in the rest of the 255 bits. This means the
+        // number is negative if the most significant cell >= 128
+        // (0b10000000).
+        let sign_check_a = ComparisonGadget::construct(
+            cb,
+            from_bytes::expr(&a.cells[0..1]),
+            128u8.expr(),
+        );
+        let sign_check_b = ComparisonGadget::construct(
+            cb,
+            from_bytes::expr(&b.cells[0..1]),
+            128u8.expr(),
+        );
+
+        // sign_check_a_lt expression implies a is positive since its MSB < 2**7
+        // sign_check_b_lt expression implies b is positive since its MSB < 2**7
+        let (sign_check_a_lt, _sign_check_a_eq) = sign_check_a.expr();
+        let (sign_check_b_lt, _sign_check_b_eq) = sign_check_b.expr();
+
+        // We require the comparison check only for the cases where:
+        // (a < 0 && b < 0) || (a > 0 && b > 0).
+        // We ignore the equality expression since we only care about the LT
+        // check.
+        let comparison_lo = ComparisonGadget::construct(
+            cb,
+            from_bytes::expr(&a.cells[0..16]),
+            from_bytes::expr(&b.cells[0..16]),
+        );
+        let comparison_hi = ComparisonGadget::construct(
+            cb,
+            from_bytes::expr(&a.cells[16..32]),
+            from_bytes::expr(&b.cells[16..32]),
+        );
+        let (lt_lo, _eq_lo) = comparison_lo.expr();
+        let (lt_hi, eq_hi) = comparison_hi.expr();
+
+        // If a and b both are positive, we do a standard comparison check. If
+        // both a and b are negative, we invert those outcomes.
+        let a_b_positive = sign_check_a_lt.clone() * sign_check_b_lt.clone();
+        let a_lt_b = select::expr(
+            a_b_positive,
+            select::expr(
+                lt_hi.clone(),
+                1u8.expr(),
+                eq_hi.clone() * lt_lo.clone(),
+            ),
+            select::expr(lt_hi, 0u8.expr(), 1u8.expr() - (eq_hi * lt_lo)),
+        );
+
+        // Add a trivial selector: if only a or only b is negative we have the
+        // result. result = if a < 0 && b > 0, slt = 1.
+        // result = if b < 0 && a < 0, slt = 0.
+        let a_negative =
+            (1u8.expr() - sign_check_a_lt.expr()) * sign_check_b_lt.expr();
+        let b_negative =
+            (1u8.expr() - sign_check_b_lt.expr()) * sign_check_a_lt.expr();
+        let result = select::expr(
+            a_negative,
+            0u8.expr(),
+            select::expr(b_negative, 1u8.expr(), a_lt_b),
+        );
+
+        // Pop a and b from the stack, push the result on the stack.
+        cb.stack_pop(select::expr(is_sgt.expr(), b.expr(), a.expr()));
+        cb.stack_pop(select::expr(is_sgt.expr(), a.expr(), b.expr()));
+        cb.stack_push(result);
+
+        // The read-write counter changes by three since we're reading two words
+        // from stack and writing one. The program counter shifts only by one
+        // and the since the stack now has one less word, the stack pointer also
+        // shifts by one.
+        let step_state_transition = StepStateTransition {
+            rw_counter: Transition::Delta(3u8.expr()),
+            program_counter: Transition::Delta(1u8.expr()),
+            stack_pointer: Transition::Delta(1u8.expr()),
+            ..Default::default()
+        };
+        let same_context = SameContextGadget::construct(
+            cb,
+            opcode,
+            step_state_transition,
+            None,
+        );
+
+        Self {
+            same_context,
+            a,
+            b,
+            sign_check_a,
+            sign_check_b,
+            comparison_lo,
+            comparison_hi,
+            is_sgt,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _transaction: &Transaction<F>,
+        _call: &Call<F>,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        self.same_context.assign_exec_step(region, offset, step)?;
+
+        let opcode = step.opcode.unwrap();
+
+        // SLT opcode is the default check in the SCMP gadget. Swap rw for SGT.
+        let is_sgt = self.is_sgt.assign(
+            region,
+            offset,
+            F::from(opcode.as_u8() as u64),
+            F::from(OpcodeId::SGT.as_u8() as u64),
+        )?;
+        let indices = if is_sgt == F::one() {
+            [step.rw_indices[1], step.rw_indices[0]]
+        } else {
+            [step.rw_indices[0], step.rw_indices[1]]
+        };
+        let [a, b] =
+            indices.map(|idx| block.rws[idx].stack_value().to_le_bytes());
+
+        self.sign_check_a.assign(
+            region,
+            offset,
+            from_bytes::value(&a[0..1]),
+            F::from(128u64),
+        )?;
+        self.sign_check_b.assign(
+            region,
+            offset,
+            from_bytes::value(&b[0..1]),
+            F::from(128u64),
+        )?;
+
+        self.comparison_lo.assign(
+            region,
+            offset,
+            from_bytes::value(&a[0..16]),
+            from_bytes::value(&b[0..16]),
+        )?;
+        self.comparison_hi.assign(
+            region,
+            offset,
+            from_bytes::value(&a[16..32]),
+            from_bytes::value(&b[16..32]),
+        )?;
+
+        self.a.assign(region, offset, Some(a))?;
+        self.b.assign(region, offset, Some(b))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bus_mapping::{bytecode, eth_types::Word, evm::OpcodeId};
+
+    use crate::evm_circuit::{
+        test::{rand_word, run_test_circuit_incomplete_fixed_table},
+        witness,
+    };
+
+    use std::convert::TryInto;
+
+    fn test_ok(opcode: OpcodeId, a: Word, b: Word) {
+        let bytecode = bytecode! {
+            PUSH32(b)
+            PUSH32(a)
+            #[start]
+            .write_op(opcode)
+            STOP
+        };
+        let block = witness::build_block_from_trace_code_at_start(&bytecode);
+        assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
+    }
+
+    #[test]
+    fn signed_comparator_gadget_simple() {
+        let zero = Word::from_big_endian(&[0u8; 32]);
+        let minus_1 = Word::from_big_endian(&[255u8; 16]);
+        let minus_2 = {
+            let mut bytes = vec![255u8; 15];
+            bytes.push(254u8);
+            let bytes: [u8; 16] = bytes.try_into().unwrap();
+            Word::from_big_endian(&bytes)
+        };
+        let plus_1 = {
+            let mut bytes = vec![0u8; 15];
+            bytes.push(1u8);
+            let bytes: [u8; 16] = bytes.try_into().unwrap();
+            Word::from_big_endian(&bytes)
+        };
+
+        // SLT
+        test_ok(OpcodeId::SLT, minus_1, zero);
+        test_ok(OpcodeId::SLT, zero, plus_1);
+        test_ok(OpcodeId::SLT, minus_1, zero);
+        test_ok(OpcodeId::SLT, minus_2, plus_1);
+        test_ok(OpcodeId::SLT, minus_2, minus_1);
+
+        // SGT
+        test_ok(OpcodeId::SGT, zero, minus_1);
+        test_ok(OpcodeId::SGT, minus_1, minus_2);
+        test_ok(OpcodeId::SGT, plus_1, zero);
+        test_ok(OpcodeId::SGT, plus_1, minus_1);
+        test_ok(OpcodeId::SGT, plus_1, minus_2);
+    }
+
+    #[test]
+    fn signed_comparator_gadget_rand() {
+        let a = rand_word();
+        let b = rand_word();
+        test_ok(OpcodeId::SLT, a, b);
+        test_ok(OpcodeId::SGT, a, b);
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -8,7 +8,7 @@ use crate::{
                 ConstraintBuilder, StepStateTransition, Transition,
             },
             from_bytes,
-            math_gadget::{ComparisonGadget, IsEqualGadget},
+            math_gadget::{IsEqualGadget, LtGadget},
             select, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
@@ -28,10 +28,10 @@ pub(crate) struct SignedComparatorGadget<F> {
     a: Word<F>,
     b: Word<F>,
 
-    sign_check_a: ComparisonGadget<F, 1>,
-    sign_check_b: ComparisonGadget<F, 1>,
-    comparison_lo: ComparisonGadget<F, 16>,
-    comparison_hi: ComparisonGadget<F, 16>,
+    sign_check_a: LtGadget<F, 1>,
+    sign_check_b: LtGadget<F, 1>,
+    lt_lo: LtGadget<F, 16>,
+    lt_hi: LtGadget<F, 16>,
 
     is_sgt: IsEqualGadget<F>,
 }
@@ -58,50 +58,40 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // of the absolute value in the rest of the 255 bits. This means the
         // number is negative if the most significant cell >= 128
         // (0b10000000).
-        let sign_check_a = ComparisonGadget::construct(
-            cb,
-            from_bytes::expr(&a.cells[0..1]),
-            128u8.expr(),
-        );
-        let sign_check_b = ComparisonGadget::construct(
-            cb,
-            from_bytes::expr(&b.cells[0..1]),
-            128u8.expr(),
-        );
+        let sign_check_a =
+            LtGadget::construct(cb, a.cells[0].expr(), 128u8.expr());
+        let sign_check_b =
+            LtGadget::construct(cb, b.cells[0].expr(), 128u8.expr());
 
         // sign_check_a_lt expression implies a is positive since its MSB < 2**7
         // sign_check_b_lt expression implies b is positive since its MSB < 2**7
-        let (sign_check_a_lt, _sign_check_a_eq) = sign_check_a.expr();
-        let (sign_check_b_lt, _sign_check_b_eq) = sign_check_b.expr();
+        let sign_check_a_lt = sign_check_a.expr();
+        let sign_check_b_lt = sign_check_b.expr();
 
         // We require the comparison check only for the cases where:
         // (a < 0 && b < 0) || (a > 0 && b > 0).
         // We ignore the equality expression since we only care about the LT
         // check.
-        let comparison_lo = ComparisonGadget::construct(
+        let lt_lo = LtGadget::construct(
             cb,
             from_bytes::expr(&a.cells[0..16]),
             from_bytes::expr(&b.cells[0..16]),
         );
-        let comparison_hi = ComparisonGadget::construct(
+        let lt_hi = LtGadget::construct(
             cb,
             from_bytes::expr(&a.cells[16..32]),
             from_bytes::expr(&b.cells[16..32]),
         );
-        let (lt_lo, _eq_lo) = comparison_lo.expr();
-        let (lt_hi, eq_hi) = comparison_hi.expr();
+        let a_lt_b_lo = lt_lo.expr();
+        let a_lt_b_hi = lt_hi.expr();
 
         // If a and b both are positive, we do a standard comparison check. If
         // both a and b are negative, we invert those outcomes.
         let a_b_positive = sign_check_a_lt.clone() * sign_check_b_lt.clone();
         let a_lt_b = select::expr(
             a_b_positive,
-            select::expr(
-                lt_hi.clone(),
-                1u8.expr(),
-                eq_hi.clone() * lt_lo.clone(),
-            ),
-            select::expr(lt_hi, 0u8.expr(), 1u8.expr() - (eq_hi * lt_lo)),
+            select::expr(a_lt_b_hi.clone(), 1u8.expr(), a_lt_b_lo.clone()),
+            select::expr(a_lt_b_hi, 0u8.expr(), 1u8.expr() - a_lt_b_lo),
         );
 
         // Add a trivial selector: if only a or only b is negative we have the
@@ -145,8 +135,8 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
             b,
             sign_check_a,
             sign_check_b,
-            comparison_lo,
-            comparison_hi,
+            lt_lo,
+            lt_hi,
             is_sgt,
         }
     }
@@ -192,13 +182,13 @@ impl<F: FieldExt> ExecutionGadget<F> for SignedComparatorGadget<F> {
             F::from(128u64),
         )?;
 
-        self.comparison_lo.assign(
+        self.lt_lo.assign(
             region,
             offset,
             from_bytes::value(&a[0..16]),
             from_bytes::value(&b[0..16]),
         )?;
-        self.comparison_hi.assign(
+        self.lt_hi.assign(
             region,
             offset,
             from_bytes::value(&a[16..32]),

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -3,7 +3,6 @@ use crate::{
         execution::ExecutionGadget,
         step::ExecutionState,
         util::{
-            and,
             common_gadget::SameContextGadget,
             constraint_builder::{
                 ConstraintBuilder, StepStateTransition, Transition,

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -332,9 +332,8 @@ impl From<&bus_mapping::circuit_input_builder::ExecStep> for ExecutionState {
         match step.op {
             OpcodeId::ADD => ExecutionState::ADD,
             OpcodeId::SUB => ExecutionState::ADD,
-            OpcodeId::EQ => ExecutionState::CMP,
-            OpcodeId::GT => ExecutionState::CMP,
-            OpcodeId::LT => ExecutionState::CMP,
+            OpcodeId::EQ | OpcodeId::LT | OpcodeId::GT => ExecutionState::CMP,
+            OpcodeId::SLT | OpcodeId::SGT => ExecutionState::SCMP,
             OpcodeId::SIGNEXTEND => ExecutionState::SIGNEXTEND,
             OpcodeId::STOP => ExecutionState::STOP,
             OpcodeId::AND => ExecutionState::BITWISE,


### PR DESCRIPTION
This PR addresses the issue #47 , refactoring the signed comparator gadget that handles opcodes SLT and SGT.