### PR TITLE
GasGadget for GAS opcode

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -1,6 +1,7 @@
 //! Definition of each opcode of the EVM.
 mod coinbase;
 mod dup;
+mod gas;
 mod jump;
 mod jumpdest;
 mod jumpi;
@@ -25,6 +26,7 @@ use log::warn;
 use self::push::Push;
 use coinbase::Coinbase;
 use dup::Dup;
+use gas::Gas;
 use jump::Jump;
 use jumpdest::Jumpdest;
 use jumpi::Jumpi;
@@ -129,7 +131,7 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
         OpcodeId::JUMPI => Jumpi::gen_associated_ops,
         OpcodeId::PC => Pc::gen_associated_ops,
         OpcodeId::MSIZE => Msize::gen_associated_ops,
-        // OpcodeId::GAS => {},
+        OpcodeId::GAS => Gas::gen_associated_ops,
         OpcodeId::JUMPDEST => Jumpdest::gen_associated_ops,
         OpcodeId::PUSH1 => Push::<1>::gen_associated_ops,
         OpcodeId::PUSH2 => Push::<2>::gen_associated_ops,

--- a/bus-mapping/src/evm/opcodes/gas.rs
+++ b/bus-mapping/src/evm/opcodes/gas.rs
@@ -1,0 +1,151 @@
+use crate::{
+    circuit_input_builder::CircuitInputStateRef, eth_types::GethExecStep,
+    operation::RW, Error,
+};
+
+use super::Opcode;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Gas;
+
+impl Opcode for Gas {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        next_steps: &[GethExecStep],
+    ) -> Result<(), Error> {
+        let step = &next_steps[0];
+        // Get value result from next step and do stack write
+        let value = next_steps[1].stack.last()?;
+        state.push_stack_op(
+            RW::WRITE,
+            step.stack.last_filled().map(|a| a - 1),
+            value,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod gas_tests {
+    use crate::{
+        bytecode,
+        bytecode::Bytecode,
+        circuit_input_builder::{ExecStep, TransactionContext},
+        eth_types::Word,
+        evm::OpcodeId,
+        mock,
+        operation::StackAddress,
+    };
+
+    use super::*;
+
+    fn test_ok(code: Bytecode, gas_left: u64) -> Result<(), Error> {
+        let block = mock::BlockData::new_single_tx_trace_code_at_start(&code)?;
+
+        let mut builder = block.new_circuit_input_builder();
+        builder.handle_tx(&block.eth_tx, &block.geth_trace)?;
+
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx)?;
+        let mut tx_ctx = TransactionContext::new(&block.eth_tx);
+
+        let mut step = ExecStep::new(
+            &block.geth_trace.struct_logs[0],
+            0,
+            test_builder.block_ctx.rwc,
+            0,
+        );
+        let mut state_ref =
+            test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
+
+        state_ref.push_stack_op(
+            RW::WRITE,
+            StackAddress::from(1022),
+            Word::from(gas_left),
+        );
+
+        tx.steps_mut().push(step);
+        test_builder.block.txs_mut().push(tx);
+
+        assert_eq!(
+            builder.block.txs()[0].steps()[0].bus_mapping_instance,
+            test_builder.block.txs()[0].steps()[0].bus_mapping_instance,
+        );
+
+        assert_eq!(builder.block.container, test_builder.block.container);
+
+        Ok(())
+    }
+
+    #[test]
+    fn gas_opcode_impl() -> Result<(), Error> {
+        const GAS_LIMIT: u64 = 1_000_000;
+
+        const GAS_COST: u64 = OpcodeId::PUSH1.constant_gas_cost().as_u64()
+            + OpcodeId::PUSH1.constant_gas_cost().as_u64()
+            + OpcodeId::GAS.constant_gas_cost().as_u64();
+
+        let test_scenarios: [(Bytecode, u64); 4] = [
+            (
+                bytecode! {
+                    PUSH1(0x1)
+                    PUSH1(0x1)
+                    POP
+                    #[start]
+                    GAS
+                    STOP
+                },
+                GAS_LIMIT.saturating_sub(
+                    GAS_COST + OpcodeId::POP.constant_gas_cost().as_u64(),
+                ),
+            ),
+            (
+                bytecode! {
+                    PUSH1(0x1)
+                    PUSH1(0x1)
+                    ADD
+                    #[start]
+                    GAS
+                    STOP
+                },
+                GAS_LIMIT.saturating_sub(
+                    GAS_COST + OpcodeId::ADD.constant_gas_cost().as_u64(),
+                ),
+            ),
+            (
+                bytecode! {
+                    PUSH1(0x1)
+                    PUSH1(0x1)
+                    DIV
+                    #[start]
+                    GAS
+                    STOP
+                },
+                GAS_LIMIT.saturating_sub(
+                    GAS_COST + OpcodeId::DIV.constant_gas_cost().as_u64(),
+                ),
+            ),
+            (
+                bytecode! {
+                    PUSH1(0x1)
+                    PUSH1(0x1)
+                    EXP
+                    #[start]
+                    GAS
+                    STOP
+                },
+                GAS_LIMIT.saturating_sub(
+                    GAS_COST
+                        + OpcodeId::EXP.constant_gas_cost().as_u64()
+                        + 50u64, // dynamic gas cost
+                ),
+            ),
+        ];
+
+        for t in test_scenarios {
+            test_ok(t.0, t.1)?;
+        }
+
+        Ok(())
+    }
+}

--- a/bus-mapping/src/evm/opcodes/gas.rs
+++ b/bus-mapping/src/evm/opcodes/gas.rs
@@ -1,7 +1,7 @@
 use crate::{
-    circuit_input_builder::CircuitInputStateRef, eth_types::GethExecStep,
-    operation::RW, Error,
+    circuit_input_builder::CircuitInputStateRef, operation::RW, Error,
 };
+use eth_types::GethExecStep;
 
 use super::Opcode;
 
@@ -31,11 +31,11 @@ mod gas_tests {
         bytecode,
         bytecode::Bytecode,
         circuit_input_builder::{ExecStep, TransactionContext},
-        eth_types::Word,
         evm::OpcodeId,
         mock,
         operation::StackAddress,
     };
+    use eth_types::Word;
 
     use super::*;
 

--- a/eth-types/src/evm_types/opcode_ids.rs
+++ b/eth-types/src/evm_types/opcode_ids.rs
@@ -501,7 +501,7 @@ impl OpcodeId {
             OpcodeId::SMOD => GasCost::FAST,
             OpcodeId::ADDMOD => GasCost::MID,
             OpcodeId::MULMOD => GasCost::MID,
-            OpcodeId::EXP => GasCost::ZERO,
+            OpcodeId::EXP => GasCost::SLOW,
             OpcodeId::SIGNEXTEND => GasCost::FAST,
             OpcodeId::LT => GasCost::FASTEST,
             OpcodeId::GT => GasCost::FASTEST,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -24,6 +24,7 @@ mod coinbase;
 mod comparator;
 mod dup;
 mod error_oog_pure_memory;
+mod gas;
 mod jump;
 mod jumpdest;
 mod jumpi;
@@ -46,6 +47,7 @@ use coinbase::CoinbaseGadget;
 use comparator::ComparatorGadget;
 use dup::DupGadget;
 use error_oog_pure_memory::ErrorOOGPureMemoryGadget;
+use gas::GasGadget;
 use jump::JumpGadget;
 use jumpdest::JumpdestGadget;
 use jumpi::JumpiGadget;
@@ -95,6 +97,7 @@ pub(crate) struct ExecutionConfig<F> {
     jump_gadget: JumpGadget<F>,
     jumpdest_gadget: JumpdestGadget<F>,
     jumpi_gadget: JumpiGadget<F>,
+    gas_gadget: GasGadget<F>,
     memory_gadget: MemoryGadget<F>,
     pc_gadget: PcGadget<F>,
     pop_gadget: PopGadget<F>,
@@ -224,6 +227,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             jump_gadget: configure_gadget!(),
             jumpdest_gadget: configure_gadget!(),
             jumpi_gadget: configure_gadget!(),
+            gas_gadget: configure_gadget!(),
             memory_gadget: configure_gadget!(),
             pc_gadget: configure_gadget!(),
             pop_gadget: configure_gadget!(),
@@ -506,6 +510,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             ExecutionState::JUMPDEST => {
                 assign_exec_step!(self.jumpdest_gadget)
             }
+            ExecutionState::GAS => assign_exec_step!(self.gas_gadget),
             ExecutionState::PUSH => assign_exec_step!(self.push_gadget),
             ExecutionState::DUP => assign_exec_step!(self.dup_gadget),
             ExecutionState::SWAP => assign_exec_step!(self.swap_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -1,0 +1,103 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        param::NUM_BYTES_GAS,
+        step::ExecutionState,
+        util::{
+            common_gadget::SameContextGadget,
+            constraint_builder::{
+                ConstraintBuilder, StepStateTransition, Transition::Delta,
+            },
+            from_bytes, RandomLinearCombination,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
+
+#[derive(Clone, Debug)]
+pub(crate) struct GasGadget<F> {
+    same_context: SameContextGadget<F>,
+    value: RandomLinearCombination<F, NUM_BYTES_GAS>,
+}
+
+impl<F: FieldExt> ExecutionGadget<F> for GasGadget<F> {
+    const NAME: &'static str = "GAS";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::GAS;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let gas_bytes = array_init::array_init(|_| cb.query_cell());
+        cb.require_equal(
+            "Constraint: gas left equal to stack value",
+            from_bytes::expr(&gas_bytes),
+            cb.curr.state.gas_left.expr(),
+        );
+
+        let value =
+            RandomLinearCombination::new(gas_bytes, cb.power_of_randomness());
+        cb.stack_push(value.expr());
+
+        let step_state_transition = StepStateTransition {
+            rw_counter: Delta(1.expr()),
+            program_counter: Delta(1.expr()),
+            stack_pointer: Delta((-1).expr()),
+            ..Default::default()
+        };
+        let opcode = cb.query_cell();
+        let same_context = SameContextGadget::construct(
+            cb,
+            opcode,
+            step_state_transition,
+            None,
+        );
+
+        Self {
+            same_context,
+            value,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        _block: &Block<F>,
+        _transaction: &Transaction<F>,
+        _call: &Call<F>,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        self.same_context.assign_exec_step(region, offset, step)?;
+
+        self.value
+            .assign(region, offset, Some(step.gas_left.to_le_bytes()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::evm_circuit::{
+        test::run_test_circuit_incomplete_fixed_table, witness,
+    };
+    use bus_mapping::bytecode;
+
+    fn test_ok() {
+        let bytecode = bytecode! {
+            PUSH32(0)
+            #[start]
+            GAS
+            STOP
+        };
+        let block = witness::build_block_from_trace_code_at_start(&bytecode);
+        assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
+    }
+
+    #[test]
+    fn gas_gadget_simple() {
+        test_ok();
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::NUM_BYTES_GAS,
+        param::N_BYTES_GAS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -15,14 +15,13 @@ use crate::{
     util::Expr,
 };
 
-use array_init::array_init;
 use bus_mapping::evm::OpcodeId;
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct GasGadget<F> {
     same_context: SameContextGadget<F>,
-    value: RandomLinearCombination<F, NUM_BYTES_GAS>,
+    gas_left: RandomLinearCombination<F, N_BYTES_GAS>,
 }
 
 impl<F: FieldExt> ExecutionGadget<F> for GasGadget<F> {
@@ -32,21 +31,19 @@ impl<F: FieldExt> ExecutionGadget<F> for GasGadget<F> {
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
         // The gas passed to a transaction is a 64-bit number.
-        let gas_left = array_init(|_| cb.query_cell());
+        let gas_left = cb.query_rlc();
 
         // The `gas_left` in the current state has to be deducted by the gas
         // used by the `GAS` opcode itself.
         cb.require_equal(
             "Constraint: gas left equal to stack value",
-            from_bytes::expr(&gas_left),
+            from_bytes::expr(&gas_left.cells),
             cb.curr.state.gas_left.expr()
                 - OpcodeId::GAS.constant_gas_cost().expr(),
         );
 
         // Construct the value and push it to stack.
-        let value =
-            RandomLinearCombination::new(gas_left, cb.power_of_randomness());
-        cb.stack_push(value.expr());
+        cb.stack_push(gas_left.expr());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(1.expr()),
@@ -64,7 +61,7 @@ impl<F: FieldExt> ExecutionGadget<F> for GasGadget<F> {
 
         Self {
             same_context,
-            value,
+            gas_left,
         }
     }
 
@@ -81,7 +78,7 @@ impl<F: FieldExt> ExecutionGadget<F> for GasGadget<F> {
 
         // The GAS opcode takes into account the reduction of gas available due
         // to the instruction itself.
-        self.value.assign(
+        self.gas_left.assign(
             region,
             offset,
             Some(
@@ -97,9 +94,7 @@ impl<F: FieldExt> ExecutionGadget<F> for GasGadget<F> {
 
 #[cfg(test)]
 mod test {
-    use crate::evm_circuit::{
-        test::run_test_circuit_incomplete_fixed_table, witness,
-    };
+    use crate::test_util::run_test_circuits;
     use bus_mapping::bytecode;
 
     fn test_ok() {
@@ -108,8 +103,7 @@ mod test {
             GAS
             STOP
         };
-        let block = witness::build_block_from_trace_code_at_start(&bytecode);
-        assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
+        assert_eq!(run_test_circuits(bytecode), Ok(()));
     }
 
     #[test]

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -36,7 +36,8 @@ impl<F: FieldExt> ExecutionGadget<F> for GasGadget<F> {
         cb.require_equal(
             "Constraint: gas left equal to stack value",
             from_bytes::expr(&gas_left),
-            cb.curr.state.gas_left.expr() - 2.expr(),
+            cb.curr.state.gas_left.expr()
+                - OpcodeId::GAS.constant_gas_cost().expr(),
         );
 
         let value =

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -32,3 +32,5 @@ pub(crate) const STACK_CAPACITY: usize = 1024;
 // counter to u64 as go-ethereum in case transaction size is allowed larger in
 // the future.
 pub(crate) const N_BYTES_PROGRAM_COUNTER: usize = N_BYTES_U64;
+pub(crate) const NUM_BYTES_PROGRAM_COUNTER: usize = N_BYTES_U64;
+pub(crate) const NUM_BYTES_GAS: usize = N_BYTES_U64;

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -14,8 +14,6 @@ pub(crate) const N_BYTES_WORD: usize = 32;
 // Number of bytes an u64 has.
 pub(crate) const N_BYTES_U64: usize = 8;
 
-pub(crate) const N_BYTES_GAS: usize = N_BYTES_U64;
-
 pub(crate) const N_BYTES_ACCOUNT_ADDRESS: usize = 20;
 
 // Number of bytes that will be used of the memory address and size.
@@ -32,5 +30,4 @@ pub(crate) const STACK_CAPACITY: usize = 1024;
 // counter to u64 as go-ethereum in case transaction size is allowed larger in
 // the future.
 pub(crate) const N_BYTES_PROGRAM_COUNTER: usize = N_BYTES_U64;
-pub(crate) const NUM_BYTES_PROGRAM_COUNTER: usize = N_BYTES_U64;
-pub(crate) const NUM_BYTES_GAS: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_GAS: usize = N_BYTES_U64;

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -592,6 +592,7 @@ impl From<&bus_mapping::circuit_input_builder::ExecStep> for ExecutionState {
             OpcodeId::PC => ExecutionState::PC,
             OpcodeId::MSIZE => ExecutionState::MSIZE,
             OpcodeId::COINBASE => ExecutionState::COINBASE,
+            OpcodeId::GAS => ExecutionState::GAS,
             _ => unimplemented!("unimplemented opcode {:?}", step.op),
         }
     }


### PR DESCRIPTION
Implement the `GasGadget` for opcode `GAS` (5A).

Specs [here](https://github.com/scroll-tech/zkevm-specs/pull/25).

Other changes:
1. Fix constant gas cost for `OpcodeId::EXP` (comments below)