### PR TITLE
Replace `assert!` with `debug_assert!` and add a new profile `release-debug`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,10 @@ rpath = false
 lto = "thin"
 incremental = false
 codegen-units = 1
+
+[profile.release-debug]
+inherits = "release"
+debug = true
+debug-assertions = true
+overflow-checks = true
+incremental = true

--- a/bus-mapping/src/bytecode.rs
+++ b/bus-mapping/src/bytecode.rs
@@ -150,7 +150,7 @@ macro_rules! bytecode_internal {
     ($code:ident, ) => {};
     // PUSHX op codes
     ($code:ident, $x:ident ($v:expr) $($rest:tt)*) => {{
-        assert!($crate::evm::OpcodeId::$x.is_push(), "invalid push");
+        debug_assert!($crate::evm::OpcodeId::$x.is_push(), "invalid push");
         let n = $crate::evm::OpcodeId::$x.as_u8()
             - $crate::evm::OpcodeId::PUSH1.as_u8()
             + 1;
@@ -159,7 +159,7 @@ macro_rules! bytecode_internal {
     }};
     // Default opcode without any inputs
     ($code:ident, $x:ident $($rest:tt)*) => {{
-        assert!(!$crate::evm::OpcodeId::$x.is_push(), "invalid push");
+        debug_assert!(!$crate::evm::OpcodeId::$x.is_push(), "invalid push");
         $code.write_op($crate::evm::OpcodeId::$x);
         $crate::bytecode_internal!($code, $($rest)*);
     }};

--- a/bus-mapping/src/bytecode.rs
+++ b/bus-mapping/src/bytecode.rs
@@ -50,7 +50,7 @@ impl Bytecode {
 
     /// Push
     pub fn push(&mut self, n: usize, value: Word) -> &mut Self {
-        assert!((1..=32).contains(&n), "invalid push");
+        debug_assert!((1..=32).contains(&n), "invalid push");
 
         // Write the op code
         self.write_op_internal(OpcodeId::PUSH1.as_u8() + ((n - 1) as u8));
@@ -63,7 +63,12 @@ impl Bytecode {
         }
         // Check if the full value could be pushed
         for byte in bytes.iter().skip(n) {
-            assert!(*byte == 0u8, "value too big for PUSH{}: {}", n, value);
+            debug_assert!(
+                *byte == 0u8,
+                "value too big for PUSH{}: {}",
+                n,
+                value
+            );
         }
         self
     }
@@ -76,7 +81,7 @@ impl Bytecode {
 
     /// Insert marker
     pub fn insert_marker(&mut self, marker: &str, pos: usize) {
-        assert!(
+        debug_assert!(
             !self.markers.contains_key(marker),
             "marker already used: {}",
             marker
@@ -145,7 +150,7 @@ macro_rules! bytecode_internal {
     ($code:ident, ) => {};
     // PUSHX op codes
     ($code:ident, $x:ident ($v:expr) $($rest:tt)*) => {{
-        assert!($crate::evm::OpcodeId::$x.is_push(), "invalid push");
+        debug_assert!($crate::evm::OpcodeId::$x.is_push(), "invalid push");
         let n = $crate::evm::OpcodeId::$x.as_u8()
             - $crate::evm::OpcodeId::PUSH1.as_u8()
             + 1;
@@ -154,7 +159,7 @@ macro_rules! bytecode_internal {
     }};
     // Default opcode without any inputs
     ($code:ident, $x:ident $($rest:tt)*) => {{
-        assert!(!$crate::evm::OpcodeId::$x.is_push(), "invalid push");
+        debug_assert!(!$crate::evm::OpcodeId::$x.is_push(), "invalid push");
         $code.write_op($crate::evm::OpcodeId::$x);
         $crate::bytecode_internal!($code, $($rest)*);
     }};

--- a/bus-mapping/src/bytecode.rs
+++ b/bus-mapping/src/bytecode.rs
@@ -150,7 +150,7 @@ macro_rules! bytecode_internal {
     ($code:ident, ) => {};
     // PUSHX op codes
     ($code:ident, $x:ident ($v:expr) $($rest:tt)*) => {{
-        debug_assert!($crate::evm::OpcodeId::$x.is_push(), "invalid push");
+        assert!($crate::evm::OpcodeId::$x.is_push(), "invalid push");
         let n = $crate::evm::OpcodeId::$x.as_u8()
             - $crate::evm::OpcodeId::PUSH1.as_u8()
             + 1;
@@ -159,7 +159,7 @@ macro_rules! bytecode_internal {
     }};
     // Default opcode without any inputs
     ($code:ident, $x:ident $($rest:tt)*) => {{
-        debug_assert!(!$crate::evm::OpcodeId::$x.is_push(), "invalid push");
+        assert!(!$crate::evm::OpcodeId::$x.is_push(), "invalid push");
         $code.write_op($crate::evm::OpcodeId::$x);
         $crate::bytecode_internal!($code, $($rest)*);
     }};

--- a/keccak256/src/arith_helpers.rs
+++ b/keccak256/src/arith_helpers.rs
@@ -63,8 +63,8 @@ impl StateBigInt {
 impl Index<(usize, usize)> for StateBigInt {
     type Output = BigUint;
     fn index(&self, xy: (usize, usize)) -> &Self::Output {
-        assert!(xy.0 < 5);
-        assert!(xy.1 < 5);
+        debug_assert!(xy.0 < 5);
+        debug_assert!(xy.1 < 5);
 
         &self.xy[xy.0 * 5 + xy.1]
     }
@@ -72,8 +72,8 @@ impl Index<(usize, usize)> for StateBigInt {
 
 impl IndexMut<(usize, usize)> for StateBigInt {
     fn index_mut(&mut self, xy: (usize, usize)) -> &mut Self::Output {
-        assert!(xy.0 < 5);
-        assert!(xy.1 < 5);
+        debug_assert!(xy.0 < 5);
+        debug_assert!(xy.1 < 5);
 
         &mut self.xy[xy.0 * 5 + xy.1]
     }
@@ -113,7 +113,7 @@ pub fn convert_b2_to_b9(a: u64) -> Lane9 {
 /// For example, if we have 5 bits set and 7 bits unset, then we have `x` as 5
 /// and the xor result to be 1.
 pub fn convert_b13_coef(x: u8) -> u8 {
-    assert!(x < 13);
+    debug_assert!(x < 13);
     x & 1
 }
 
@@ -123,7 +123,7 @@ pub fn convert_b13_coef(x: u8) -> u8 {
 /// The input `x` is a chunk of a base 9 number and it represents the arithmatic
 /// result of `2*a + b + 3*c + 2*d`, where `a`, `b`, `c`, and `d` each is a bit.
 pub fn convert_b9_coef(x: u8) -> u8 {
-    assert!(x < 9);
+    debug_assert!(x < 9);
     let bit_table: [u8; 9] = [0, 0, 1, 1, 0, 0, 1, 1, 0];
     bit_table[x as usize]
 }
@@ -219,7 +219,7 @@ pub fn state_to_state_bigint<F: FieldExt, const N: usize>(
         // and refactoring `State` will be done once the
         // keccak_all_togheter is done.
         .map(|bytes| {
-            assert!(bytes[8..32] == vec![0u8; 24]);
+            debug_assert!(bytes[8..32] == vec![0u8; 24]);
             let mut arr = [0u8; 8];
             arr.copy_from_slice(&bytes[0..8]);
             u64::from_le_bytes(arr)

--- a/keccak256/src/gates/gate_helpers.rs
+++ b/keccak256/src/gates/gate_helpers.rs
@@ -16,7 +16,7 @@ pub type BlockCount2<F> = (BlockCount<F>, BlockCount<F>);
 /// We assume the input value is smaller than the field size
 pub fn biguint_to_f<F: FieldExt>(x: &BigUint) -> F {
     let mut x_bytes = x.to_bytes_le();
-    assert!(
+    debug_assert!(
         x_bytes.len() <= 32,
         "expect len <=32 but got {}",
         x_bytes.len()

--- a/keccak256/src/gates/rho_helpers.rs
+++ b/keccak256/src/gates/rho_helpers.rs
@@ -136,7 +136,7 @@ pub struct RhoLane {
 
 impl RhoLane {
     pub fn new(input: BigUint, rotation: u32) -> Self {
-        assert!(
+        debug_assert!(
             input.lt(&BigUint::from(B13).pow(RHO_LANE_SIZE as u32)),
             "lane too big"
         );
@@ -145,7 +145,10 @@ impl RhoLane {
         let chunks: [u8; RHO_LANE_SIZE] = chunks.try_into().unwrap();
         let special_high = *chunks.get(64).unwrap();
         let special_low = *chunks.get(0).unwrap();
-        assert!(special_high + special_low < B13, "invalid Rho input lane");
+        debug_assert!(
+            special_high + special_low < B13,
+            "invalid Rho input lane"
+        );
         let output = convert_b13_lane_to_b9(input.clone(), rotation);
         let output_b2 =
             *BigUint::from_radix_le(&output.to_radix_le(B9.into()), B2.into())

--- a/keccak256/src/gates/tables.rs
+++ b/keccak256/src/gates/tables.rs
@@ -233,7 +233,7 @@ impl<F: FieldExt> BaseInfo<F> {
         let input_chunks: Vec<u8> = {
             let raw = f_to_biguint(input);
             let mut v = raw.to_radix_le(self.input_base.into());
-            assert!(v.len() <= self.max_chunks);
+            debug_assert!(v.len() <= self.max_chunks);
             // fill 0 to max chunks
             v.resize(self.max_chunks, 0);
             // v is big-endian now

--- a/keccak256/src/keccak_arith.rs
+++ b/keccak256/src/keccak_arith.rs
@@ -179,7 +179,7 @@ impl Sponge {
     }
 
     pub fn absorb(&self, state: &mut State, message: &[u8]) {
-        assert!(
+        debug_assert!(
             message.len() % self.rate == 0,
             "Message is not divisible entirely by bytes rate"
         );

--- a/keccak256/src/plain.rs
+++ b/keccak256/src/plain.rs
@@ -122,7 +122,7 @@ impl Sponge {
     }
 
     pub fn absorb(&self, state: &mut State, message: &[u8]) {
-        assert!(
+        debug_assert!(
             message.len() % self.rate == 0,
             "Message is not divisible entirely by bytes rate"
         );

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -274,7 +274,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
 
         let (constraints, constraints_first_step, lookups, presets) =
             cb.build();
-        assert!(
+        debug_assert!(
             presets_map.insert(G::EXECUTION_STATE, presets).is_none(),
             "execution state already configured"
         );

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -274,8 +274,10 @@ impl<F: FieldExt> ExecutionConfig<F> {
 
         let (constraints, constraints_first_step, lookups, presets) =
             cb.build();
+
+        let insert_result = presets_map.insert(G::EXECUTION_STATE, presets);
         debug_assert!(
-            presets_map.insert(G::EXECUTION_STATE, presets).is_none(),
+            insert_result.is_none(),
             "execution state already configured"
         );
 

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -90,7 +90,7 @@ impl<F: FieldExt, const N: usize> RandomLinearCombination<F, N> {
         bytes: [Expression<F>; N],
         power_of_randomness: &[Expression<F>],
     ) -> Expression<F> {
-        assert!(bytes.len() <= power_of_randomness.len() + 1);
+        debug_assert!(bytes.len() <= power_of_randomness.len() + 1);
 
         let mut rlc = bytes[0].clone();
         for (byte, randomness) in
@@ -222,7 +222,7 @@ pub(crate) mod from_bytes {
     use halo2::{arithmetic::FieldExt, plonk::Expression};
 
     pub(crate) fn expr<F: FieldExt, E: Expr<F>>(bytes: &[E]) -> Expression<F> {
-        assert!(
+        debug_assert!(
             bytes.len() <= MAX_N_BYTES_INTEGER,
             "Too many bytes to compose an integer in field"
         );
@@ -236,7 +236,7 @@ pub(crate) mod from_bytes {
     }
 
     pub(crate) fn value<F: FieldExt>(bytes: &[u8]) -> F {
-        assert!(
+        debug_assert!(
             bytes.len() <= MAX_N_BYTES_INTEGER,
             "Too many bytes to compose an integer in field"
         );

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -748,7 +748,7 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
     // Validation
 
     pub(crate) fn validate_degree(&self, degree: usize, name: &'static str) {
-        assert!(
+        debug_assert!(
             degree <= MAX_DEGREE,
             "Expression {} degree too high: {} > {}",
             name,
@@ -764,7 +764,7 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
         condition: Expression<F>,
         constraint: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        assert!(
+        debug_assert!(
             self.condition.is_none(),
             "Nested condition is not supported"
         );

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -559,7 +559,7 @@ impl From<&bus_mapping::circuit_input_builder::ExecStep> for ExecutionState {
     fn from(step: &bus_mapping::circuit_input_builder::ExecStep) -> Self {
         // TODO: error reporting. (errors are defined in
         // circuit_input_builder.rs)
-        assert!(step.error.is_none());
+        debug_assert!(step.error.is_none());
         if step.op.is_dup() {
             return ExecutionState::DUP;
         }


### PR DESCRIPTION
Close https://github.com/appliedzkp/zkevm-circuits/issues/288

### Summary

1. Only replace `assert!` with `debug_assert!` in no-test code.
2. Add a new profile `release-debug` inherited from `release` profile.

Reference comment https://github.com/appliedzkp/zkevm-circuits/issues/288#issuecomment-1015413048, I set `debug = true` for debug symbols. And `overflow-checks = true` for enabling integer overflow checks, `incremental = true` for incremental compilation.

It seems that the profile name `debug` is reserved. An error occurred when adding a custom profile named `debug` as below.

```
error: failed to parse manifest at `/zkevm-circuits/Cargo.toml`

Caused by:
  profile name `debug` is reserved
  To configure the default development profile, use the name `dev` as in [profile.dev]
  See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
```