### PR TITLE
Add circuits for CALLVALUE and CALLER opcodes

### DIFF
--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -60,7 +60,7 @@ pub trait ToBigEndian {
     fn to_be_bytes(&self) -> [u8; 32];
 }
 
-/// Trait used do convert a scalar value to a 32 byte array in little endian.
+/// Trait used to convert a scalar value to a 32 byte array in little endian.
 pub trait ToLittleEndian {
     /// Convert the value to a 32 byte array in little endian.
     fn to_le_bytes(&self) -> [u8; 32];

--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
-/// Trait used to define types that can be converted to a 256 bit scalar value.
+/// Trait used to define types that can be converted to a scalar value.
 pub trait ToScalar<F: FieldExt> {
     /// Convert the type to a scalar value.
     fn to_scalar(&self) -> Option<F>;
@@ -60,7 +60,7 @@ pub trait ToBigEndian {
     fn to_be_bytes(&self) -> [u8; 32];
 }
 
-/// Trait uset do convert a scalar value to a 32 byte array in little endian.
+/// Trait used do convert a scalar value to a 32 byte array in little endian.
 pub trait ToLittleEndian {
     /// Convert the value to a 32 byte array in little endian.
     fn to_le_bytes(&self) -> [u8; 32];

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -20,6 +20,7 @@ mod add;
 mod begin_tx;
 mod bitwise;
 mod byte;
+mod caller;
 mod callvalue;
 mod coinbase;
 mod comparator;
@@ -45,6 +46,7 @@ use add::AddGadget;
 use begin_tx::BeginTxGadget;
 use bitwise::BitwiseGadget;
 use byte::ByteGadget;
+use caller::CallerGadget;
 use callvalue::CallvalueGadget;
 use coinbase::CoinbaseGadget;
 use comparator::ComparatorGadget;
@@ -111,6 +113,7 @@ pub(crate) struct ExecutionConfig<F> {
     stop_gadget: StopGadget<F>,
     swap_gadget: SwapGadget<F>,
     msize_gadget: MsizeGadget<F>,
+    caller_gadget: CallerGadget<F>,
     callvalue_gadget: CallvalueGadget<F>,
     coinbase_gadget: CoinbaseGadget<F>,
     timestamp_gadget: TimestampGadget<F>,
@@ -242,6 +245,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             msize_gadget: configure_gadget!(),
             coinbase_gadget: configure_gadget!(),
             timestamp_gadget: configure_gadget!(),
+            caller_gadget: configure_gadget!(),
             callvalue_gadget: configure_gadget!(),
             step: step_curr,
             presets_map,
@@ -475,6 +479,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             ExecutionState::SCMP => {
                 assign_exec_step!(self.signed_comparator_gadget)
             }
+            ExecutionState::CALLER => assign_exec_step!(self.caller_gadget),
             ExecutionState::CALLVALUE => assign_exec_step!(self.callvalue_gadget),
             ExecutionState::BYTE => assign_exec_step!(self.byte_gadget),
             ExecutionState::POP => assign_exec_step!(self.pop_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -20,6 +20,7 @@ mod add;
 mod begin_tx;
 mod bitwise;
 mod byte;
+mod callvalue;
 mod coinbase;
 mod comparator;
 mod dup;
@@ -44,6 +45,7 @@ use add::AddGadget;
 use begin_tx::BeginTxGadget;
 use bitwise::BitwiseGadget;
 use byte::ByteGadget;
+use callvalue::CallvalueGadget;
 use coinbase::CoinbaseGadget;
 use comparator::ComparatorGadget;
 use dup::DupGadget;
@@ -109,6 +111,7 @@ pub(crate) struct ExecutionConfig<F> {
     stop_gadget: StopGadget<F>,
     swap_gadget: SwapGadget<F>,
     msize_gadget: MsizeGadget<F>,
+    callvalue_gadget: CallvalueGadget<F>,
     coinbase_gadget: CoinbaseGadget<F>,
     timestamp_gadget: TimestampGadget<F>,
 }
@@ -239,6 +242,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             msize_gadget: configure_gadget!(),
             coinbase_gadget: configure_gadget!(),
             timestamp_gadget: configure_gadget!(),
+            callvalue_gadget: configure_gadget!(),
             step: step_curr,
             presets_map,
         };
@@ -471,6 +475,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             ExecutionState::SCMP => {
                 assign_exec_step!(self.signed_comparator_gadget)
             }
+            ExecutionState::CALLVALUE => assign_exec_step!(self.callvalue_gadget),
             ExecutionState::BYTE => assign_exec_step!(self.byte_gadget),
             ExecutionState::POP => assign_exec_step!(self.pop_gadget),
             ExecutionState::MEMORY => assign_exec_step!(self.memory_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -65,7 +65,7 @@ impl<F: FieldExt> ExecutionGadget<F> for CallerGadget<F> {
         // endian encoding the EVM uses.
         let mut le_bytes = call.caller_address.0;
         le_bytes.reverse();
-        
+
         self.caller.assign(region, offset, Some(le_bytes))?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -1,0 +1,169 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        param::N_BYTES_ACCOUNT_ADDRESS,
+        step::ExecutionState,
+        table::CallContextFieldTag,
+        util::{
+            common_gadget::SameContextGadget,
+            constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
+            from_bytes, RandomLinearCombination,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
+
+#[derive(Clone, Debug)]
+pub(crate) struct CallerGadget<F> {
+    same_context: SameContextGadget<F>,
+    caller: RandomLinearCombination<F, N_BYTES_ACCOUNT_ADDRESS>,
+}
+
+impl<F: FieldExt> ExecutionGadget<F> for CallerGadget<F> {
+    const NAME: &'static str = "CALLER";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::CALLER;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let caller = cb.query_rlc();
+        cb.call_context_lookup(
+            None,
+            CallContextFieldTag::CallerAddress,
+            from_bytes::expr(&caller.cells),
+        );
+        cb.stack_push(caller.expr());
+
+        let opcode = cb.query_cell();
+        let step_state_transition = StepStateTransition {
+            rw_counter: Delta(2.expr()),
+            program_counter: Delta(1.expr()),
+            stack_pointer: Delta((-1).expr()),
+            ..Default::default()
+        };
+        let same_context = SameContextGadget::construct(cb, opcode, step_state_transition, None);
+
+        Self {
+            same_context,
+            caller,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        _: &Block<F>,
+        _: &Transaction<F>,
+        call: &Call<F>,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        self.same_context.assign_exec_step(region, offset, step)?;
+
+        // H160's are big endian, so we need to reverse the bytes to get the little
+        // endian encoding the EVM uses.
+        let mut le_bytes = call.caller_address.0;
+        le_bytes.reverse();
+        
+        self.caller.assign(region, offset, Some(le_bytes))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::evm_circuit::{
+        step::ExecutionState,
+        table::CallContextFieldTag,
+        test::run_test_circuit_incomplete_fixed_table,
+        util::RandomLinearCombination,
+        witness::{Block, Bytecode, Call, ExecStep, Rw, Transaction},
+    };
+    use bus_mapping::evm::OpcodeId;
+    use eth_types::{address, bytecode, ToLittleEndian, ToWord};
+    use halo2::arithmetic::BaseExt;
+    use pairing::bn256::Fr;
+
+    #[test]
+    fn caller_gadget_test() {
+        let bytecode = Bytecode::new(
+            bytecode! {
+                #[start]
+                CALLER
+                STOP
+            }
+            .to_vec(),
+        );
+
+        let caller = address!("0x11332200000000000000000023000400000000fe");
+
+        let tx_id = 1;
+        let call_id = 1;
+
+        let caller_gas_cost = OpcodeId::CALLER.constant_gas_cost().as_u64();
+
+        let randomness = Fr::rand();
+        let block = Block {
+            randomness,
+            txs: vec![Transaction {
+                id: tx_id,
+                caller_address: caller,
+                steps: vec![
+                    ExecStep {
+                        execution_state: ExecutionState::CALLER,
+                        rw_indices: vec![0, 1],
+                        rw_counter: 1,
+                        program_counter: 0,
+                        stack_pointer: 1024,
+                        gas_left: caller_gas_cost,
+                        gas_cost: caller_gas_cost,
+                        opcode: Some(OpcodeId::CALLER),
+                        ..Default::default()
+                    },
+                    ExecStep {
+                        execution_state: ExecutionState::STOP,
+                        rw_counter: 3,
+                        program_counter: 1,
+                        stack_pointer: 1023,
+                        opcode: Some(OpcodeId::STOP),
+                        ..Default::default()
+                    },
+                ],
+                calls: vec![Call {
+                    id: 1,
+                    is_root: true,
+                    is_create: false,
+                    caller_address: caller,
+                    opcode_source: RandomLinearCombination::random_linear_combine(
+                        bytecode.hash.to_le_bytes(),
+                        randomness,
+                    ),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            rws: vec![
+                Rw::CallContext {
+                    call_id,
+                    rw_counter: 1,
+                    is_write: false,
+                    field_tag: CallContextFieldTag::CallerAddress,
+                    value: caller.to_word(),
+                },
+                Rw::Stack {
+                    call_id,
+                    rw_counter: 2,
+                    is_write: true,
+                    stack_pointer: 1023,
+                    value: caller.to_word(),
+                },
+            ],
+            bytecodes: vec![bytecode],
+            ..Default::default()
+        };
+
+        assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
@@ -1,0 +1,171 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        table::CallContextFieldTag,
+        util::{
+            common_gadget::SameContextGadget,
+            constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
+            Word,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+use eth_types::ToLittleEndian;
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
+
+#[derive(Clone, Debug)]
+pub(crate) struct CallvalueGadget<F> {
+    same_context: SameContextGadget<F>,
+    call_value: Word<F>,
+}
+
+impl<F: FieldExt> ExecutionGadget<F> for CallvalueGadget<F> {
+    const NAME: &'static str = "CALLVALUE";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::CALLVALUE;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let call_value = cb.query_rlc();
+
+        cb.call_context_lookup(None, CallContextFieldTag::Value, call_value.expr());
+        cb.stack_push(call_value.expr());
+
+        let opcode = cb.query_cell();
+        let step_state_transition = StepStateTransition {
+            rw_counter: Delta(2.expr()),
+            program_counter: Delta(1.expr()),
+            stack_pointer: Delta((-1).expr()),
+            ..Default::default()
+        };
+        let same_context = SameContextGadget::construct(cb, opcode, step_state_transition, None);
+
+        Self {
+            same_context,
+            call_value,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _: &Transaction<F>,
+        _call: &Call<F>,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        self.same_context.assign_exec_step(region, offset, step)?;
+
+        let call_value = block.rws[step.rw_indices[1]].stack_value();
+        self.call_value
+            .assign(region, offset, Some(call_value.to_le_bytes()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::evm_circuit::{
+        step::ExecutionState,
+        table::CallContextFieldTag,
+        test::run_test_circuit_incomplete_fixed_table,
+        util::RandomLinearCombination,
+        witness::{Block, Bytecode, Call, ExecStep, Rw, Transaction},
+    };
+    use bus_mapping::evm::OpcodeId;
+    use eth_types::{bytecode, ToLittleEndian, Word, U256};
+    use halo2::arithmetic::BaseExt;
+    use pairing::bn256::Fr;
+
+    #[test]
+    fn callvalue_gadget_test() {
+        let bytecode = Bytecode::new(
+            bytecode! {
+                #[start]
+                CALLVALUE
+                STOP
+            }
+            .to_vec(),
+        );
+
+        let call_value = 888999046u64;
+
+        let tx_id = 1;
+        let call_id = 1;
+
+        let call_value_gas_cost = OpcodeId::CALLVALUE.constant_gas_cost().as_u64();
+
+        let randomness = Fr::rand();
+        let block = Block {
+            randomness,
+            txs: vec![Transaction {
+                id: tx_id,
+                // callee_address,
+                steps: vec![
+                    ExecStep {
+                        execution_state: ExecutionState::CALLVALUE,
+                        rw_indices: vec![0, 1],
+                        rw_counter: 1,
+                        program_counter: 0,
+                        stack_pointer: 1024,
+                        gas_left: call_value_gas_cost,
+                        gas_cost: call_value_gas_cost,
+                        opcode: Some(OpcodeId::CALLVALUE),
+                        ..Default::default()
+                    },
+                    ExecStep {
+                        execution_state: ExecutionState::STOP,
+                        rw_counter: 3,
+                        program_counter: 1,
+                        stack_pointer: 1023,
+                        opcode: Some(OpcodeId::STOP),
+                        ..Default::default()
+                    },
+                ],
+                calls: vec![Call {
+                    id: 1,
+                    is_root: true,
+                    is_create: false,
+                    // callee_address,
+                    opcode_source: RandomLinearCombination::random_linear_combine(
+                        bytecode.hash.to_le_bytes(),
+                        randomness,
+                    ),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            rws: vec![
+                Rw::CallContext {
+                    call_id,
+                    rw_counter: 1,
+                    is_write: false,
+                    field_tag: CallContextFieldTag::Value,
+                    value: U256::from(call_value),
+                },
+                // Rw::Account {
+                //     rw_counter: 2,
+                //     is_write: false,
+                //     account_address: callee_address,
+                //     field_tag: AccountFieldTag::Balance,
+                //     value: Word::from(value),
+                //     value_prev: Word::from(value),
+                // },
+                Rw::Stack {
+                    call_id,
+                    rw_counter: 2,
+                    is_write: true,
+                    stack_pointer: 1023,
+                    value: Word::from(call_value),
+                },
+            ],
+            bytecodes: vec![bytecode],
+            ..Default::default()
+        };
+
+        assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
@@ -53,7 +53,7 @@ impl<F: FieldExt> ExecutionGadget<F> for CallvalueGadget<F> {
         offset: usize,
         block: &Block<F>,
         _: &Transaction<F>,
-        _call: &Call<F>,
+        _: &Call<F>,
         step: &ExecStep,
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
@@ -103,7 +103,6 @@ mod test {
             randomness,
             txs: vec![Transaction {
                 id: tx_id,
-                // callee_address,
                 steps: vec![
                     ExecStep {
                         execution_state: ExecutionState::CALLVALUE,
@@ -129,7 +128,6 @@ mod test {
                     id: 1,
                     is_root: true,
                     is_create: false,
-                    // callee_address,
                     opcode_source: RandomLinearCombination::random_linear_combine(
                         bytecode.hash.to_le_bytes(),
                         randomness,
@@ -146,14 +144,6 @@ mod test {
                     field_tag: CallContextFieldTag::Value,
                     value: U256::from(call_value),
                 },
-                // Rw::Account {
-                //     rw_counter: 2,
-                //     is_write: false,
-                //     account_address: callee_address,
-                //     field_tag: AccountFieldTag::Balance,
-                //     value: Word::from(value),
-                //     value_prev: Word::from(value),
-                // },
                 Rw::Stack {
                     call_id,
                     rw_counter: 2,


### PR DESCRIPTION
Specs: already done in https://github.com/appliedzkp/zkevm-specs/pull/96.

Fixes https://github.com/scroll-tech/zkevm-circuits/issues/51 and https://github.com/scroll-tech/zkevm-circuits/issues/54