### PR TITLE
chore(github CI): trigger CI for scroll branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+      - scroll-stable
+      - scroll-dev
 
 ## `actions-rs/toolchain@v1` overwrite set to false so that
 ## `rust-toolchain` is always used and the only source of truth.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
       - scroll-stable
       - scroll-dev
 
+env:
+  SCCACHE_REGION: ap-northeast-1
+  SCCACHE_BUCKET: ff-building
+  SCCACHE_S3_USE_SSL: true
+  SCCACHE_S3_KEY_PREFIX: sccache-gh-action
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  CARGO_INCREMENTAL: false
+
 ## `actions-rs/toolchain@v1` overwrite set to false so that
 ## `rust-toolchain` is always used and the only source of truth.
 
@@ -49,6 +58,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup sccache
+        run: |
+          cd $RUNNER_TEMP
+          export NAME="sccache-v0.2.15-x86_64-unknown-linux-musl"
+          curl -fsSOL https://github.com/mozilla/sccache/releases/download/v0.2.15/$NAME.tar.gz
+          tar xzf $NAME.tar.gz
+          mkdir -p ~/.cargo/bin
+          mv ./$NAME/sccache ~/.cargo/bin
+          chmod +x ~/.cargo/bin/sccache
+          printf "[build]\nrustc-wrapper = \"/home/runner/.cargo/bin/sccache\"" >> ~/.cargo/config
+          ~/.cargo/bin/sccache -s
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -93,6 +113,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-%{{ matrix-target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup sccache
+        run: |
+          cd $RUNNER_TEMP
+          export NAME="sccache-v0.2.15-x86_64-unknown-linux-musl"
+          curl -fsSOL https://github.com/mozilla/sccache/releases/download/v0.2.15/$NAME.tar.gz
+          tar xzf $NAME.tar.gz
+          mkdir -p ~/.cargo/bin
+          mv ./$NAME/sccache ~/.cargo/bin
+          chmod +x ~/.cargo/bin/sccache
+          printf "[build]\nrustc-wrapper = \"/home/runner/.cargo/bin/sccache\"" >> ~/.cargo/config
+          ~/.cargo/bin/sccache -s
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:
@@ -136,6 +167,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup sccache
+        run: |
+          cd $RUNNER_TEMP
+          export NAME="sccache-v0.2.15-x86_64-unknown-linux-musl"
+          curl -fsSOL https://github.com/mozilla/sccache/releases/download/v0.2.15/$NAME.tar.gz
+          tar xzf $NAME.tar.gz
+          mkdir -p ~/.cargo/bin
+          mv ./$NAME/sccache ~/.cargo/bin
+          chmod +x ~/.cargo/bin/sccache
+          printf "[build]\nrustc-wrapper = \"/home/runner/.cargo/bin/sccache\"" >> ~/.cargo/config
+          ~/.cargo/bin/sccache -s
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
         uses: actions-rs/cargo@v1
@@ -174,6 +216,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup sccache
+        run: |
+          cd $RUNNER_TEMP
+          export NAME="sccache-v0.2.15-x86_64-unknown-linux-musl"
+          curl -fsSOL https://github.com/mozilla/sccache/releases/download/v0.2.15/$NAME.tar.gz
+          tar xzf $NAME.tar.gz
+          mkdir -p ~/.cargo/bin
+          mv ./$NAME/sccache ~/.cargo/bin
+          chmod +x ~/.cargo/bin/sccache
+          printf "[build]\nrustc-wrapper = \"/home/runner/.cargo/bin/sccache\"" >> ~/.cargo/config
+          ~/.cargo/bin/sccache -s
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:
@@ -218,6 +271,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup sccache
+        run: |
+          cd $RUNNER_TEMP
+          export NAME="sccache-v0.2.15-x86_64-unknown-linux-musl"
+          curl -fsSOL https://github.com/mozilla/sccache/releases/download/v0.2.15/$NAME.tar.gz
+          tar xzf $NAME.tar.gz
+          mkdir -p ~/.cargo/bin
+          mv ./$NAME/sccache ~/.cargo/bin
+          chmod +x ~/.cargo/bin/sccache
+          printf "[build]\nrustc-wrapper = \"/home/runner/.cargo/bin/sccache\"" >> ~/.cargo/config
+          ~/.cargo/bin/sccache -s
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
         with:
           command: test
           args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks
+      - name: Show sccache stats
+        run: ~/.cargo/bin/sccache -s
 
   build:
     if: github.event.pull_request.draft == false
@@ -135,6 +137,8 @@ jobs:
         with:
           command: test
           args: --verbose --release --all-features -p circuit-benchmarks --no-run
+      - name: Show sccache stats
+        run: ~/.cargo/bin/sccache -s
 
   bitrot:
     if: github.event.pull_request.draft == false
@@ -184,6 +188,8 @@ jobs:
         with:
           command: build
           args: --benches --examples --all-features
+      - name: Show sccache stats
+        run: ~/.cargo/bin/sccache -s
 
   doc-links:
     if: github.event.pull_request.draft == false
@@ -239,6 +245,8 @@ jobs:
         with:
           command: doc
           args: --no-deps --all --document-private-items
+      - name: Show sccache stats
+        run: ~/.cargo/bin/sccache -s
 
   fmt:
     if: github.event.pull_request.draft == false
@@ -292,3 +300,5 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+      - name: Show sccache stats
+        run: ~/.cargo/bin/sccache -s

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - scroll-stable
+      - scroll-dev
 
 jobs:
   update_release_draft:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,3 +83,5 @@ jobs:
       # where Greeter.sol is deployed.
       # - run: ./run.sh --steps "tests" --tests "circuits"
       - run: ./run.sh --steps "cleanup"
+      - name: Show sccache stats
+        run: ~/.cargo/bin/sccache -s

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - scroll-stable
+      - scroll-dev
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,15 @@ on:
       - scroll-stable
       - scroll-dev
 
+env:
+  SCCACHE_REGION: ap-northeast-1
+  SCCACHE_BUCKET: ff-building
+  SCCACHE_S3_USE_SSL: true
+  SCCACHE_S3_KEY_PREFIX: sccache-gh-action
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  CARGO_INCREMENTAL: false
+
 jobs:
   integration-tests:
     if: github.event.pull_request.draft == false
@@ -50,6 +59,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup sccache
+        run: |
+          cd $RUNNER_TEMP
+          export NAME="sccache-v0.2.15-x86_64-unknown-linux-musl"
+          curl -fsSOL https://github.com/mozilla/sccache/releases/download/v0.2.15/$NAME.tar.gz
+          tar xzf $NAME.tar.gz
+          mkdir -p ~/.cargo/bin
+          mv ./$NAME/sccache ~/.cargo/bin
+          chmod +x ~/.cargo/bin/sccache
+          printf "[build]\nrustc-wrapper = \"/home/runner/.cargo/bin/sccache\"" >> ~/.cargo/config
+          ~/.cargo/bin/sccache -s
       # Run an initial build in a separate step to split the build time from execution time
       - name: Build bins
         run: cargo build --bin gen_blockchain_data

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+      - scroll-stable
+      - scroll-dev
 
 jobs:
   clippy:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,6 +10,15 @@ on:
       - scroll-stable
       - scroll-dev
 
+env:
+  SCCACHE_REGION: ap-northeast-1
+  SCCACHE_BUCKET: ff-building
+  SCCACHE_S3_USE_SSL: true
+  SCCACHE_S3_KEY_PREFIX: sccache-gh-action
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  CARGO_INCREMENTAL: false
+
 jobs:
   clippy:
     if: github.event.pull_request.draft == false
@@ -44,6 +53,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup sccache
+        run: |
+          cd $RUNNER_TEMP
+          export NAME="sccache-v0.2.15-x86_64-unknown-linux-musl"
+          curl -fsSOL https://github.com/mozilla/sccache/releases/download/v0.2.15/$NAME.tar.gz
+          tar xzf $NAME.tar.gz
+          mkdir -p ~/.cargo/bin
+          mv ./$NAME/sccache ~/.cargo/bin
+          chmod +x ~/.cargo/bin/sccache
+          printf "[build]\nrustc-wrapper = \"/home/runner/.cargo/bin/sccache\"" >> ~/.cargo/config
+          ~/.cargo/bin/sccache -s
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -70,3 +70,5 @@ jobs:
           name: Clippy
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+      - name: Show sccache stats
+        run: ~/.cargo/bin/sccache -s


### PR DESCRIPTION
add CI trigger for `scroll-stable` & `scroll-dev` branches.

also add `sccache`.
taking integration-test as an example:

before
<img width="1337" alt="image" src="https://user-images.githubusercontent.com/37070449/160327171-09686fe3-1a49-4ca8-bea4-395451d82096.png">
after
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/37070449/160327204-a005fd19-b530-45f9-8b95-e83fa10cb7e3.png">
