### PR TITLE
reconstruct memory when set EnableMemory to false in tracing

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -203,10 +203,12 @@ impl<'a> CircuitInputBuilder {
 }
 
 /// Retrieve the init_code from memory for {CREATE, CREATE2}
-pub fn get_create_init_code(step: &GethExecStep) -> Result<&[u8], Error> {
+pub fn get_create_init_code(step: &GethExecStep) -> Result<Vec<u8>, Error> {
     let offset = step.stack.nth_last(1)?;
     let length = step.stack.nth_last(2)?;
-    Ok(&step.memory.0[offset.low_u64() as usize..(offset.low_u64() + length.low_u64()) as usize])
+    Ok(step.memory.borrow().0
+        [offset.low_u64() as usize..(offset.low_u64() + length.low_u64()) as usize]
+        .to_vec())
 }
 
 /// Retrieve the memory offset and length of call.
@@ -336,8 +338,8 @@ impl<P: JsonRpcClient> BuilderClient<P> {
         }
 
         let mut code_db = CodeDB::new();
-        for (_address, code) in codes {
-            code_db.insert(code.clone());
+        for (address, code) in codes {
+            code_db.insert(Some(address), code.clone());
         }
         (sdb, code_db)
     }

--- a/bus-mapping/src/circuit_input_builder/call.rs
+++ b/bus-mapping/src/circuit_input_builder/call.rs
@@ -1,5 +1,6 @@
 use super::CodeSource;
 use crate::{exec_trace::OperationRef, Error};
+use eth_types::evm_types::Memory;
 use eth_types::{evm_types::OpcodeId, Address, Hash, Word};
 
 /// Type of a *CALL*/CREATE* Function.
@@ -108,6 +109,12 @@ pub struct CallContext {
     /// Call data (copy of tx input or caller's
     /// memory[call_data_offset..call_data_offset + call_data_length])
     pub call_data: Vec<u8>,
+    /// memory context of current call
+    pub memory: Memory,
+    /// return data buffer
+    pub return_data: Vec<u8>,
+    /// last call reference
+    pub last_call: Option<Call>,
 }
 
 /// A reversion group is the collection of calls and the operations which are

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -55,7 +55,7 @@ impl ExecStep {
             exec_state: ExecState::Op(step.op),
             pc: step.pc,
             stack_size: step.stack.0.len(),
-            memory_size: step.memory.0.len(),
+            memory_size: step.memory.borrow().len(),
             gas_left: step.gas,
             gas_cost: step.gas_cost,
             gas_refund: Gas(0),

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -532,7 +532,7 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(get_create2_address(
             self.call()?.address,
             salt.to_be_bytes().to_vec(),
-            init_code.to_vec(),
+            init_code,
         ))
     }
 
@@ -576,7 +576,7 @@ impl<'a> CircuitInputStateRef<'a> {
         let (code_source, code_hash) = match kind {
             CallKind::Create | CallKind::Create2 => {
                 let init_code = get_create_init_code(step)?;
-                let code_hash = self.code_db.insert(None, init_code.to_vec());
+                let code_hash = self.code_db.insert(None, init_code);
                 (CodeSource::Memory, code_hash)
             }
             _ => {

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use eth_types::{
     evm_types::{Gas, MemoryAddress, OpcodeId, StackAddress},
-    Address, GethExecStep, ToAddress, ToBigEndian, Word, H256,
+    Address, GethExecStep, Hash, ToAddress, ToBigEndian, Word, H256,
 };
 use ethers_core::utils::{get_contract_address, get_create2_address};
 
@@ -436,10 +436,18 @@ impl<'a> CircuitInputStateRef<'a> {
         self.transfer_with_fee(step, sender, receiver, value, Word::zero())
     }
 
+    pub fn code_hash(&self, address: Address) -> Result<Hash, Error> {
+        self.code_db
+            .address_hash
+            .get(&address)
+            .copied()
+            .ok_or(Error::AccountNotFound(address))
+    }
+
     /// Fetch and return code for the given code hash from the code DB.
     pub fn code(&self, code_hash: H256) -> Result<Vec<u8>, Error> {
         self.code_db
-            .0
+            .hash_code
             .get(&code_hash)
             .cloned()
             .ok_or(Error::CodeNotFound(code_hash))
@@ -481,12 +489,22 @@ impl<'a> CircuitInputStateRef<'a> {
         self.tx_ctx.call_ctx_mut()
     }
 
+    pub fn caller_ctx_mut(&mut self) -> Result<&mut CallContext, Error> {
+        self.tx_ctx
+            .calls
+            .iter_mut()
+            .rev()
+            .nth(1)
+            .ok_or(Error::InternalError("caller id not found in call map"))
+    }
+
     /// Push a new [`Call`] into the [`Transaction`], and add its index and
     /// [`CallContext`] in the `call_stack` of the [`TransactionContext`]
     pub fn push_call(&mut self, call: Call, step: &GethExecStep) {
         let call_data = match call.kind {
             CallKind::Call | CallKind::CallCode | CallKind::DelegateCall | CallKind::StaticCall => {
                 step.memory
+                    .borrow()
                     .read_chunk(call.call_data_offset.into(), call.call_data_length.into())
             }
             CallKind::Create | CallKind::Create2 => Vec::new(),
@@ -566,7 +584,7 @@ impl<'a> CircuitInputStateRef<'a> {
         let (code_source, code_hash) = match kind {
             CallKind::Create | CallKind::Create2 => {
                 let init_code = get_create_init_code(step)?;
-                let code_hash = self.code_db.insert(init_code.to_vec());
+                let code_hash = self.code_db.insert(None, init_code.to_vec());
                 (CodeSource::Memory, code_hash)
             }
             _ => {
@@ -765,8 +783,9 @@ impl<'a> CircuitInputStateRef<'a> {
             let length = step.stack.nth_last(1)?;
             let code = step
                 .memory
+                .borrow()
                 .read_chunk(offset.low_u64().into(), length.low_u64().into());
-            let code_hash = self.code_db.insert(code);
+            let code_hash = self.code_db.insert(None, code);
             let (found, callee_account) = self.sdb.get_account_mut(&call.address);
             if !found {
                 return Err(Error::AccountNotFound(call.address));
@@ -851,8 +870,8 @@ impl<'a> CircuitInputStateRef<'a> {
                     if length > Word::from(0x6000u64) {
                         return Ok(Some(ExecError::MaxCodeSizeExceeded));
                     } else if length > Word::zero()
-                        && !step.memory.0.is_empty()
-                        && step.memory.0.get(offset.low_u64() as usize) == Some(&0xef)
+                        && !step.memory.borrow().is_empty()
+                        && step.memory.borrow().0.get(offset.low_u64() as usize) == Some(&0xef)
                     {
                         return Ok(Some(ExecError::InvalidCreationCode));
                     } else if Word::from(200u64) * length > Word::from(step.gas.0) {

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use eth_types::{
     evm_types::{Gas, MemoryAddress, OpcodeId, StackAddress},
-    Address, GethExecStep, Hash, ToAddress, ToBigEndian, Word, H256,
+    Address, GethExecStep, ToAddress, ToBigEndian, Word, H256,
 };
 use ethers_core::utils::{get_contract_address, get_create2_address};
 
@@ -434,14 +434,6 @@ impl<'a> CircuitInputStateRef<'a> {
         value: Word,
     ) -> Result<(), Error> {
         self.transfer_with_fee(step, sender, receiver, value, Word::zero())
-    }
-
-    pub fn code_hash(&self, address: Address) -> Result<Hash, Error> {
-        self.code_db
-            .address_hash
-            .get(&address)
-            .copied()
-            .ok_or(Error::AccountNotFound(address))
     }
 
     /// Fetch and return code for the given code hash from the code DB.

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -12,7 +12,7 @@ use eth_types::{
     address, bytecode, geth_types::GethData, word, Bytecode, Hash, ToAddress, ToWord, Word,
 };
 use lazy_static::lazy_static;
-use mock::test_ctx::{helpers::*, TestContext};
+use mock::test_ctx::{helpers::*, LoggerConfig, TestContext};
 use mock::MOCK_COINBASE;
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
@@ -135,7 +135,7 @@ fn tracer_err_depth() {
     };
 
     // Create a custom tx setting Gas to
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -153,6 +153,7 @@ fn tracer_err_depth() {
                 .gas(Word::from(10u64.pow(15)));
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -210,7 +211,7 @@ fn tracer_err_insufficient_balance() {
     };
 
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -231,6 +232,7 @@ fn tracer_err_insufficient_balance() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -324,7 +326,7 @@ fn tracer_err_address_collision() {
     };
     code_b.append(&code_b_end);
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -343,6 +345,7 @@ fn tracer_err_address_collision() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -460,7 +463,7 @@ fn tracer_err_code_store_out_of_gas() {
     };
     code_b.append(&code_b_end);
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -479,6 +482,7 @@ fn tracer_err_code_store_out_of_gas() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -511,8 +515,8 @@ fn check_err_invalid_code(step: &GethExecStep, next_step: Option<&GethExecStep>)
         && step.error.is_none()
         && result(next_step).is_zero()
         && length > Word::zero()
-        && !step.memory.0.is_empty()
-        && step.memory.0.get(offset.low_u64() as usize) == Some(&0xef)
+        && !step.memory.borrow().is_empty()
+        && step.memory.borrow().0.get(offset.low_u64() as usize) == Some(&0xef)
 }
 
 #[test]
@@ -566,7 +570,7 @@ fn tracer_err_invalid_code() {
     };
     code_b.append(&code_b_end);
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -585,6 +589,7 @@ fn tracer_err_invalid_code() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -670,7 +675,7 @@ fn tracer_err_max_code_size_exceeded() {
     };
     code_b.append(&code_b_end);
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -689,6 +694,7 @@ fn tracer_err_max_code_size_exceeded() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -764,7 +770,7 @@ fn tracer_create_stop() {
     };
     code_b.append(&code_b_end);
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -785,6 +791,7 @@ fn tracer_create_stop() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -839,7 +846,7 @@ fn tracer_err_invalid_jump() {
         STOP
     };
     let index = 1; // JUMP
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -854,6 +861,7 @@ fn tracer_err_invalid_jump() {
             txs[0].to(accs[0].address).from(accs[1].address);
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -886,7 +894,7 @@ fn tracer_err_invalid_jump() {
     let index = 8; // JUMP
 
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -905,6 +913,7 @@ fn tracer_err_invalid_jump() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -939,7 +948,7 @@ fn tracer_err_execution_reverted() {
         STOP
     };
     let index = 2; // REVERT
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -954,6 +963,7 @@ fn tracer_err_execution_reverted() {
             txs[0].to(accs[0].address).from(accs[1].address);
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -987,7 +997,7 @@ fn tracer_err_execution_reverted() {
     let index = 10; // REVERT
 
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1006,6 +1016,7 @@ fn tracer_err_execution_reverted() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1048,7 +1059,7 @@ fn tracer_stop() {
     let index = 10; // STOP
 
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1067,6 +1078,7 @@ fn tracer_stop() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1122,7 +1134,7 @@ fn tracer_err_return_data_out_of_bounds() {
         RETURN
     };
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1143,6 +1155,7 @@ fn tracer_err_return_data_out_of_bounds() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1179,7 +1192,7 @@ fn tracer_err_gas_uint_overflow() {
         PUSH32(0x100_0000_0000_0000_0000_u128) // offset
         MSTORE
     };
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1194,6 +1207,7 @@ fn tracer_err_gas_uint_overflow() {
             txs[0].to(accs[0].address).from(accs[1].address);
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1217,7 +1231,7 @@ fn tracer_err_invalid_opcode() {
     let mut code = bytecode::Bytecode::default();
     code.write_op(OpcodeId::PC);
     code.write(0x0f);
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1232,6 +1246,7 @@ fn tracer_err_invalid_opcode() {
             txs[0].to(accs[0].address).from(accs[1].address);
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1270,7 +1285,7 @@ fn tracer_err_write_protection() {
         PUSH3(0xbb)
     };
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1289,6 +1304,7 @@ fn tracer_err_write_protection() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1339,7 +1355,7 @@ fn tracer_err_out_of_gas() {
         PUSH1(0x2)
     };
     // Create a custom tx setting Gas to
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         account_0_code_account_1_no_code(code),
         |mut txs, accs| {
@@ -1349,6 +1365,7 @@ fn tracer_err_out_of_gas() {
                 .gas(Word::from(21004u64));
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1364,11 +1381,12 @@ fn tracer_err_stack_overflow() {
     for i in 0u64..1025 {
         code.push(2, Word::from(i));
     }
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         account_0_code_account_1_no_code(code),
         tx_from_1_to_0,
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1394,11 +1412,12 @@ fn tracer_err_stack_underflow() {
     let code = bytecode! {
         SWAP5
     };
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         account_0_code_account_1_no_code(code),
         tx_from_1_to_0,
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1473,7 +1492,7 @@ fn create2_address() {
     };
     code_b.append(&code_b_end);
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1492,6 +1511,7 @@ fn create2_address() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1579,7 +1599,7 @@ fn create_address() {
     };
     code_b.append(&code_b_end);
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1598,6 +1618,7 @@ fn create_address() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1673,7 +1694,7 @@ fn test_gen_access_trace() {
     };
 
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0]
@@ -1690,6 +1711,7 @@ fn test_gen_access_trace() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1768,7 +1790,7 @@ fn test_gen_access_trace_call_EOA_no_new_stack_frame() {
     };
 
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<2, 1>::new(
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
         None,
         |accs| {
             accs[0].address(*MOCK_COINBASE).code(code);
@@ -1776,6 +1798,7 @@ fn test_gen_access_trace_call_EOA_no_new_stack_frame() {
         },
         tx_from_1_to_0,
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();
@@ -1900,7 +1923,7 @@ fn test_gen_access_trace_create_push_call_stack() {
     code_b.append(&code_b_end);
 
     // Get the execution steps from the external tracer
-    let block: GethData = TestContext::<3, 2>::new(
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
         None,
         |accs| {
             accs[0].address(*MOCK_COINBASE).code(code_a);
@@ -1915,6 +1938,7 @@ fn test_gen_access_trace_create_push_call_stack() {
                 .nonce(Word::one());
         },
         |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
     )
     .unwrap()
     .into();

--- a/bus-mapping/src/circuit_input_builder/transaction.rs
+++ b/bus-mapping/src/circuit_input_builder/transaction.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 
+use eth_types::evm_types::Memory;
 use eth_types::{Address, GethExecTrace, Word};
 use ethers_core::utils::get_contract_address;
 
@@ -156,6 +157,9 @@ impl TransactionContext {
             index: call_idx,
             reversible_write_counter: 0,
             call_data,
+            memory: Memory::default(),
+            return_data: vec![],
+            last_call: None,
         });
     }
 
@@ -232,7 +236,7 @@ impl Transaction {
             }
         } else {
             // Contract creation
-            let code_hash = code_db.insert(eth_tx.input.to_vec());
+            let code_hash = code_db.insert(None, eth_tx.input.to_vec());
             Call {
                 call_id,
                 kind: CallKind::Create,

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     AccountNotFound(Address),
     /// Storage key not found in the StateDB
     StorageKeyNotFound(Address, Word),
+    /// Address not found in the CodeDB,
+    AddressNotFound(Address),
     /// Code not found in the CodeDB
     CodeNotFound(H256),
     /// Unable to figure out error at a [`GethExecStep`]
@@ -36,6 +38,8 @@ pub enum Error {
     EthTypeError(eth_types::Error),
     /// EVM Execution error
     ExecutionError(ExecError),
+    /// Internal Code error
+    InternalError(&'static str),
 }
 
 impl From<eth_types::Error> for Error {

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -97,7 +97,7 @@ pub trait Opcode: Debug {
         _state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Memory, Error> {
-        Ok(geth_steps[0].memory.borrow().clone())
+        Ok(geth_steps[0].memory.replace(Memory::default()))
     }
 }
 

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -3,8 +3,7 @@ use crate::{
     circuit_input_builder::{CircuitInputStateRef, ExecStep},
     evm::OpcodeId,
     operation::{
-        AccountField, AccountOp, CallContextField, TxAccessListAccountOp, TxReceiptField,
-        TxRefundOp, RW,
+        AccountField, CallContextField, TxAccessListAccountOp, TxReceiptField, TxRefundOp, RW,
     },
     Error,
 };
@@ -16,6 +15,7 @@ use eth_types::{
 use keccak256::EMPTY_HASH;
 use log::warn;
 use std::collections::HashMap;
+use std::ops::Deref;
 
 mod call;
 mod calldatacopy;
@@ -26,7 +26,9 @@ mod callvalue;
 mod chainid;
 mod codecopy;
 mod codesize;
+mod create;
 mod dup;
+mod extcodecopy;
 mod extcodehash;
 mod gasprice;
 mod logs;
@@ -35,12 +37,17 @@ mod mstore;
 mod number;
 mod origin;
 mod r#return;
+mod returndatacopy;
 mod selfbalance;
+mod sha3;
 mod sload;
 mod sstore;
 mod stackonlyop;
 mod stop;
 mod swap;
+
+#[cfg(test)]
+mod memory_expansion_test;
 
 use call::Call;
 use calldatacopy::Calldatacopy;
@@ -50,7 +57,10 @@ use caller::Caller;
 use callvalue::Callvalue;
 use codecopy::Codecopy;
 use codesize::Codesize;
+use create::DummyCreate;
 use dup::Dup;
+use eth_types::evm_types::Memory;
+use extcodecopy::Extcodecopy;
 use extcodehash::Extcodehash;
 use gasprice::GasPrice;
 use logs::Log;
@@ -58,7 +68,9 @@ use mload::Mload;
 use mstore::Mstore;
 use origin::Origin;
 use r#return::Return;
+use returndatacopy::Returndatacopy;
 use selfbalance::Selfbalance;
+use sha3::Sha3;
 use sload::Sload;
 use sstore::Sstore;
 use stackonlyop::StackOnlyOpcode;
@@ -75,161 +87,169 @@ pub trait Opcode: Debug {
     /// [`StorageOp`](crate::operation::StorageOp)s associated to the Opcode
     /// is implemented for.
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error>;
+
+    fn reconstruct_memory(
+        &self,
+        _state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        Ok(geth_steps[0].memory.borrow().clone())
+    }
 }
 
-fn dummy_gen_associated_ops(
-    state: &mut CircuitInputStateRef,
-    geth_steps: &[GethExecStep],
-) -> Result<Vec<ExecStep>, Error> {
-    Ok(vec![state.new_step(&geth_steps[0])?])
+#[derive(Debug, Copy, Clone)]
+struct Dummy;
+
+impl Opcode for Dummy {
+    fn gen_associated_ops(
+        &self,
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        Ok(vec![state.new_step(&geth_steps[0])?])
+    }
 }
 
-type FnGenAssociatedOps = fn(
-    state: &mut CircuitInputStateRef,
-    geth_steps: &[GethExecStep],
-) -> Result<Vec<ExecStep>, Error>;
-
-fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
+fn down_cast_to_opcode(opcode_id: &OpcodeId) -> &dyn Opcode {
     if opcode_id.is_push() {
-        return StackOnlyOpcode::<0, 1>::gen_associated_ops;
+        return &StackOnlyOpcode::<0, 1>;
     }
 
     match opcode_id {
-        OpcodeId::STOP => Stop::gen_associated_ops,
-        OpcodeId::ADD => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::MUL => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SUB => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::DIV => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SDIV => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::MOD => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SMOD => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::ADDMOD => StackOnlyOpcode::<3, 1>::gen_associated_ops,
-        OpcodeId::MULMOD => StackOnlyOpcode::<3, 1>::gen_associated_ops,
-        OpcodeId::EXP => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SIGNEXTEND => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::LT => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::GT => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SLT => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SGT => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::EQ => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::ISZERO => StackOnlyOpcode::<1, 1>::gen_associated_ops,
-        OpcodeId::AND => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::OR => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::XOR => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::NOT => StackOnlyOpcode::<1, 1>::gen_associated_ops,
-        OpcodeId::BYTE => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SHL => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SHR => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SAR => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::SHA3 => StackOnlyOpcode::<2, 1>::gen_associated_ops,
-        OpcodeId::ADDRESS => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::BALANCE => StackOnlyOpcode::<1, 1>::gen_associated_ops,
-        OpcodeId::ORIGIN => Origin::gen_associated_ops,
-        OpcodeId::CALLER => Caller::gen_associated_ops,
-        OpcodeId::CALLVALUE => Callvalue::gen_associated_ops,
-        OpcodeId::CALLDATASIZE => Calldatasize::gen_associated_ops,
-        OpcodeId::CALLDATALOAD => Calldataload::gen_associated_ops,
-        OpcodeId::CALLDATACOPY => Calldatacopy::gen_associated_ops,
-        OpcodeId::GASPRICE => GasPrice::gen_associated_ops,
-        OpcodeId::CODECOPY => Codecopy::gen_associated_ops,
-        OpcodeId::CODESIZE => Codesize::gen_associated_ops,
-        OpcodeId::EXTCODESIZE => StackOnlyOpcode::<1, 1>::gen_associated_ops,
-        OpcodeId::EXTCODECOPY => StackOnlyOpcode::<4, 0>::gen_associated_ops,
-        OpcodeId::RETURNDATASIZE => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::RETURNDATACOPY => StackOnlyOpcode::<3, 0>::gen_associated_ops,
-        OpcodeId::EXTCODEHASH => Extcodehash::gen_associated_ops,
-        OpcodeId::BLOCKHASH => StackOnlyOpcode::<1, 1>::gen_associated_ops,
-        OpcodeId::COINBASE => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::TIMESTAMP => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::NUMBER => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::DIFFICULTY => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::GASLIMIT => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::CHAINID => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::SELFBALANCE => Selfbalance::gen_associated_ops,
-        OpcodeId::BASEFEE => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::POP => StackOnlyOpcode::<1, 0>::gen_associated_ops,
-        OpcodeId::MLOAD => Mload::gen_associated_ops,
-        OpcodeId::MSTORE => Mstore::<false>::gen_associated_ops,
-        OpcodeId::MSTORE8 => Mstore::<true>::gen_associated_ops,
-        OpcodeId::SLOAD => Sload::gen_associated_ops,
-        OpcodeId::SSTORE => Sstore::gen_associated_ops,
-        OpcodeId::JUMP => StackOnlyOpcode::<1, 0>::gen_associated_ops,
-        OpcodeId::JUMPI => StackOnlyOpcode::<2, 0>::gen_associated_ops,
-        OpcodeId::PC => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::MSIZE => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::GAS => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::JUMPDEST => dummy_gen_associated_ops,
-        OpcodeId::DUP1 => Dup::<1>::gen_associated_ops,
-        OpcodeId::DUP2 => Dup::<2>::gen_associated_ops,
-        OpcodeId::DUP3 => Dup::<3>::gen_associated_ops,
-        OpcodeId::DUP4 => Dup::<4>::gen_associated_ops,
-        OpcodeId::DUP5 => Dup::<5>::gen_associated_ops,
-        OpcodeId::DUP6 => Dup::<6>::gen_associated_ops,
-        OpcodeId::DUP7 => Dup::<7>::gen_associated_ops,
-        OpcodeId::DUP8 => Dup::<8>::gen_associated_ops,
-        OpcodeId::DUP9 => Dup::<9>::gen_associated_ops,
-        OpcodeId::DUP10 => Dup::<10>::gen_associated_ops,
-        OpcodeId::DUP11 => Dup::<11>::gen_associated_ops,
-        OpcodeId::DUP12 => Dup::<12>::gen_associated_ops,
-        OpcodeId::DUP13 => Dup::<13>::gen_associated_ops,
-        OpcodeId::DUP14 => Dup::<14>::gen_associated_ops,
-        OpcodeId::DUP15 => Dup::<15>::gen_associated_ops,
-        OpcodeId::DUP16 => Dup::<16>::gen_associated_ops,
-        OpcodeId::SWAP1 => Swap::<1>::gen_associated_ops,
-        OpcodeId::SWAP2 => Swap::<2>::gen_associated_ops,
-        OpcodeId::SWAP3 => Swap::<3>::gen_associated_ops,
-        OpcodeId::SWAP4 => Swap::<4>::gen_associated_ops,
-        OpcodeId::SWAP5 => Swap::<5>::gen_associated_ops,
-        OpcodeId::SWAP6 => Swap::<6>::gen_associated_ops,
-        OpcodeId::SWAP7 => Swap::<7>::gen_associated_ops,
-        OpcodeId::SWAP8 => Swap::<8>::gen_associated_ops,
-        OpcodeId::SWAP9 => Swap::<9>::gen_associated_ops,
-        OpcodeId::SWAP10 => Swap::<10>::gen_associated_ops,
-        OpcodeId::SWAP11 => Swap::<11>::gen_associated_ops,
-        OpcodeId::SWAP12 => Swap::<12>::gen_associated_ops,
-        OpcodeId::SWAP13 => Swap::<13>::gen_associated_ops,
-        OpcodeId::SWAP14 => Swap::<14>::gen_associated_ops,
-        OpcodeId::SWAP15 => Swap::<15>::gen_associated_ops,
-        OpcodeId::SWAP16 => Swap::<16>::gen_associated_ops,
-        OpcodeId::LOG0 => Log::gen_associated_ops,
-        OpcodeId::LOG1 => Log::gen_associated_ops,
-        OpcodeId::LOG2 => Log::gen_associated_ops,
-        OpcodeId::LOG3 => Log::gen_associated_ops,
-        OpcodeId::LOG4 => Log::gen_associated_ops,
+        OpcodeId::STOP => &Stop,
+        OpcodeId::ADD => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::MUL => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SUB => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::DIV => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SDIV => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::MOD => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SMOD => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::ADDMOD => &StackOnlyOpcode::<3, 1>,
+        OpcodeId::MULMOD => &StackOnlyOpcode::<3, 1>,
+        OpcodeId::EXP => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SIGNEXTEND => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::LT => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::GT => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SLT => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SGT => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::EQ => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::ISZERO => &StackOnlyOpcode::<1, 1>,
+        OpcodeId::AND => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::OR => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::XOR => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::NOT => &StackOnlyOpcode::<1, 1>,
+        OpcodeId::BYTE => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SHL => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SHR => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SAR => &StackOnlyOpcode::<2, 1>,
+        OpcodeId::SHA3 => &Sha3,
+        OpcodeId::ADDRESS => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::BALANCE => &StackOnlyOpcode::<1, 1>,
+        OpcodeId::ORIGIN => &Origin,
+        OpcodeId::CALLER => &Caller,
+        OpcodeId::CALLVALUE => &Callvalue,
+        OpcodeId::CALLDATASIZE => &Calldatasize,
+        OpcodeId::CALLDATALOAD => &Calldataload,
+        OpcodeId::CALLDATACOPY => &Calldatacopy,
+        OpcodeId::GASPRICE => &GasPrice,
+        OpcodeId::CODECOPY => &Codecopy,
+        OpcodeId::CODESIZE => &Codesize,
+        OpcodeId::EXTCODESIZE => &StackOnlyOpcode::<1, 1>,
+        OpcodeId::EXTCODECOPY => &Extcodecopy,
+        OpcodeId::RETURNDATASIZE => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::RETURNDATACOPY => &Returndatacopy,
+        OpcodeId::EXTCODEHASH => &Extcodehash,
+        OpcodeId::BLOCKHASH => &StackOnlyOpcode::<1, 1>,
+        OpcodeId::COINBASE => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::TIMESTAMP => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::NUMBER => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::DIFFICULTY => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::GASLIMIT => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::CHAINID => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::SELFBALANCE => &Selfbalance,
+        OpcodeId::BASEFEE => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::POP => &StackOnlyOpcode::<1, 0>,
+        OpcodeId::MLOAD => &Mload,
+        OpcodeId::MSTORE => &Mstore::<false>,
+        OpcodeId::MSTORE8 => &Mstore::<true>,
+        OpcodeId::SLOAD => &Sload,
+        OpcodeId::SSTORE => &Sstore,
+        OpcodeId::JUMP => &StackOnlyOpcode::<1, 0>,
+        OpcodeId::JUMPI => &StackOnlyOpcode::<2, 0>,
+        OpcodeId::PC => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::MSIZE => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::GAS => &StackOnlyOpcode::<0, 1>,
+        OpcodeId::JUMPDEST => &Dummy,
+        OpcodeId::DUP1 => &Dup::<1>,
+        OpcodeId::DUP2 => &Dup::<2>,
+        OpcodeId::DUP3 => &Dup::<3>,
+        OpcodeId::DUP4 => &Dup::<4>,
+        OpcodeId::DUP5 => &Dup::<5>,
+        OpcodeId::DUP6 => &Dup::<6>,
+        OpcodeId::DUP7 => &Dup::<7>,
+        OpcodeId::DUP8 => &Dup::<8>,
+        OpcodeId::DUP9 => &Dup::<9>,
+        OpcodeId::DUP10 => &Dup::<10>,
+        OpcodeId::DUP11 => &Dup::<11>,
+        OpcodeId::DUP12 => &Dup::<12>,
+        OpcodeId::DUP13 => &Dup::<13>,
+        OpcodeId::DUP14 => &Dup::<14>,
+        OpcodeId::DUP15 => &Dup::<15>,
+        OpcodeId::DUP16 => &Dup::<16>,
+        OpcodeId::SWAP1 => &Swap::<1>,
+        OpcodeId::SWAP2 => &Swap::<2>,
+        OpcodeId::SWAP3 => &Swap::<3>,
+        OpcodeId::SWAP4 => &Swap::<4>,
+        OpcodeId::SWAP5 => &Swap::<5>,
+        OpcodeId::SWAP6 => &Swap::<6>,
+        OpcodeId::SWAP7 => &Swap::<7>,
+        OpcodeId::SWAP8 => &Swap::<8>,
+        OpcodeId::SWAP9 => &Swap::<9>,
+        OpcodeId::SWAP10 => &Swap::<10>,
+        OpcodeId::SWAP11 => &Swap::<11>,
+        OpcodeId::SWAP12 => &Swap::<12>,
+        OpcodeId::SWAP13 => &Swap::<13>,
+        OpcodeId::SWAP14 => &Swap::<14>,
+        OpcodeId::SWAP15 => &Swap::<15>,
+        OpcodeId::SWAP16 => &Swap::<16>,
+        OpcodeId::LOG0 => &Log,
+        OpcodeId::LOG1 => &Log,
+        OpcodeId::LOG2 => &Log,
+        OpcodeId::LOG3 => &Log,
+        OpcodeId::LOG4 => &Log,
         // OpcodeId::CREATE => {},
-        OpcodeId::CALL => Call::gen_associated_ops,
+        OpcodeId::CALL => &Call,
         // OpcodeId::CALLCODE => {},
-        // OpcodeId::RETURN => {},
+        OpcodeId::RETURN => &Return,
         // OpcodeId::DELEGATECALL => {},
         // OpcodeId::CREATE2 => {},
         // OpcodeId::STATICCALL => {},
-        // OpcodeId::REVERT => {},
-        OpcodeId::REVERT | OpcodeId::RETURN => {
-            warn!("Using dummy gen_associated_ops for opcode {:?}", opcode_id);
-            Return::gen_associated_ops
-        }
+        // REVERT is almost the same as RETURN
+        OpcodeId::REVERT => &Return,
         OpcodeId::SELFDESTRUCT => {
             warn!("Using dummy gen_selfdestruct_ops for opcode SELFDESTRUCT");
-            dummy_gen_selfdestruct_ops
+            &DummySelfDestruct
         }
         OpcodeId::CALLCODE | OpcodeId::DELEGATECALL | OpcodeId::STATICCALL => {
             warn!("Using dummy gen_call_ops for opcode {:?}", opcode_id);
-            dummy_gen_call_ops
+            &DummyCall
         }
         OpcodeId::CREATE | OpcodeId::CREATE2 => {
             warn!("Using dummy gen_create_ops for opcode {:?}", opcode_id);
-            dummy_gen_create_ops
+            &DummyCreate
         }
         _ => {
             warn!("Using dummy gen_associated_ops for opcode {:?}", opcode_id);
-            dummy_gen_associated_ops
+            &Dummy
         }
     }
 }
 
+#[allow(clippy::collapsible_else_if)]
 /// Generate the associated operations according to the particular
 /// [`OpcodeId`].
 pub fn gen_associated_ops(
@@ -237,8 +257,31 @@ pub fn gen_associated_ops(
     state: &mut CircuitInputStateRef,
     geth_steps: &[GethExecStep],
 ) -> Result<Vec<ExecStep>, Error> {
-    let fn_gen_associated_ops = fn_gen_associated_ops(opcode_id);
-    fn_gen_associated_ops(state, geth_steps)
+    let opcode = down_cast_to_opcode(opcode_id);
+
+    let memory = opcode.reconstruct_memory(state, geth_steps)?;
+
+    if geth_steps.len() > 1 {
+        if !geth_steps[1].memory.borrow().is_empty() {
+            // memory trace is enabled or it is a call
+            assert_eq!(geth_steps[1].memory.borrow().deref(), &memory);
+        } else {
+            if opcode_id.is_call() {
+                if geth_steps[0].depth == geth_steps[1].depth {
+                    geth_steps[1].memory.replace(memory.clone());
+                } else {
+                    geth_steps[1].memory.replace(Memory::default());
+                }
+            } else {
+                // debug: enable trace = true
+                // TODO: comment this when mem trace = false(auto) .. heihei...
+                //assert_eq!(geth_steps[1].memory.borrow().deref(), &memory);
+                geth_steps[1].memory.replace(memory.clone());
+            }
+        }
+        state.call_ctx_mut()?.memory = memory;
+    }
+    opcode.gen_associated_ops(state, geth_steps)
 }
 
 pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Error> {
@@ -487,6 +530,19 @@ pub fn gen_end_tx_ops(
     Ok(exec_step)
 }
 
+#[derive(Debug, Copy, Clone)]
+struct DummyCall;
+
+impl Opcode for DummyCall {
+    fn gen_associated_ops(
+        &self,
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        dummy_gen_call_ops(state, geth_steps)
+    }
+}
+
 fn dummy_gen_call_ops(
     state: &mut CircuitInputStateRef,
     geth_steps: &[GethExecStep],
@@ -530,75 +586,18 @@ fn dummy_gen_call_ops(
     }
 }
 
-fn dummy_gen_create_ops(
-    state: &mut CircuitInputStateRef,
-    geth_steps: &[GethExecStep],
-) -> Result<Vec<ExecStep>, Error> {
-    let geth_step = &geth_steps[0];
-    let mut exec_step = state.new_step(geth_step)?;
+#[derive(Debug, Copy, Clone)]
+struct DummySelfDestruct;
 
-    let tx_id = state.tx_ctx.id();
-    let call = state.parse_call(geth_step)?;
-
-    // Increase caller's nonce
-    let nonce_prev = state.sdb.get_nonce(&call.caller_address);
-    state.push_op_reversible(
-        &mut exec_step,
-        RW::WRITE,
-        AccountOp {
-            address: call.caller_address,
-            field: AccountField::Nonce,
-            value: (nonce_prev + 1).into(),
-            value_prev: nonce_prev.into(),
-        },
-    )?;
-
-    // Add callee into access list
-    let is_warm = state.sdb.check_account_in_access_list(&call.address);
-    state.push_op_reversible(
-        &mut exec_step,
-        RW::WRITE,
-        TxAccessListAccountOp {
-            tx_id,
-            address: call.address,
-            is_warm: true,
-            is_warm_prev: is_warm,
-        },
-    )?;
-
-    state.push_call(call.clone(), geth_step);
-
-    // Increase callee's nonce
-    let nonce_prev = state.sdb.get_nonce(&call.address);
-    debug_assert!(nonce_prev == 0);
-    state.push_op_reversible(
-        &mut exec_step,
-        RW::WRITE,
-        AccountOp {
-            address: call.address,
-            field: AccountField::Nonce,
-            value: 1.into(),
-            value_prev: 0.into(),
-        },
-    )?;
-
-    state.transfer(
-        &mut exec_step,
-        call.caller_address,
-        call.address,
-        call.value,
-    )?;
-
-    if call.code_hash.to_fixed_bytes() == *EMPTY_HASH {
-        // 1. Create with empty initcode.
-        state.handle_return(geth_step)?;
-        Ok(vec![exec_step])
-    } else {
-        // 2. Create with non-empty initcode.
-        Ok(vec![exec_step])
+impl Opcode for DummySelfDestruct {
+    fn gen_associated_ops(
+        &self,
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        dummy_gen_selfdestruct_ops(state, geth_steps)
     }
 }
-
 fn dummy_gen_selfdestruct_ops(
     state: &mut CircuitInputStateRef,
     geth_steps: &[GethExecStep],

--- a/bus-mapping/src/evm/opcodes/call.rs
+++ b/bus-mapping/src/evm/opcodes/call.rs
@@ -4,6 +4,7 @@ use crate::{
     operation::{AccountField, CallContextField, TxAccessListAccountOp, RW},
     Error,
 };
+use eth_types::evm_types::Memory;
 use eth_types::{
     evm_types::{
         gas_utils::{eip150_gas, memory_expansion_gas_cost},
@@ -13,6 +14,7 @@ use eth_types::{
 };
 use keccak256::EMPTY_HASH;
 use log::warn;
+use std::cmp::max;
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the `OpcodeId::CALL` `OpcodeId`.
@@ -21,6 +23,7 @@ pub(crate) struct Call;
 
 impl Opcode for Call {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
@@ -114,7 +117,7 @@ impl Opcode for Call {
         // Calculate next_memory_word_size and callee_gas_left manually in case
         // there isn't next geth_step (e.g. callee doesn't have code).
         let next_memory_word_size = [
-            geth_step.memory.word_size() as u64,
+            geth_step.memory.borrow().word_size() as u64,
             (call.call_data_offset + call.call_data_length + 31) / 32,
             (call.return_data_offset + call.return_data_length + 31) / 32,
         ]
@@ -136,7 +139,7 @@ impl Opcode for Call {
         } else {
             0
         } + memory_expansion_gas_cost(
-            geth_step.memory.word_size() as u64,
+            geth_step.memory.borrow().word_size() as u64,
             next_memory_word_size,
         );
         let callee_gas_left = eip150_gas(geth_step.gas.0 - gas_cost, geth_step.stack.last()?);
@@ -228,5 +231,34 @@ impl Opcode for Call {
                 Ok(vec![exec_step])
             }
         }
+    }
+
+    fn reconstruct_memory(
+        &self,
+        _state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        let geth_step = &geth_steps[0];
+        let args_offset = geth_step.stack.nth_last(3)?.as_usize();
+        let args_length = geth_step.stack.nth_last(4)?.as_usize();
+        let ret_offset = geth_step.stack.nth_last(5)?.as_usize();
+        let ret_length = geth_step.stack.nth_last(6)?.as_usize();
+
+        let mut memory = geth_steps[0].memory.borrow().clone();
+        let args_minimal = if args_length != 0 {
+            args_offset + args_length
+        } else {
+            0
+        };
+        let ret_minimal = if ret_length != 0 {
+            ret_offset + ret_length
+        } else {
+            0
+        };
+        if args_minimal != 0 || ret_minimal != 0 {
+            let minimal_length = max(args_minimal, ret_minimal);
+            memory.extend_at_least(minimal_length);
+        }
+        Ok(memory)
     }
 }

--- a/bus-mapping/src/evm/opcodes/call.rs
+++ b/bus-mapping/src/evm/opcodes/call.rs
@@ -244,7 +244,7 @@ impl Opcode for Call {
         let ret_offset = geth_step.stack.nth_last(5)?.as_usize();
         let ret_length = geth_step.stack.nth_last(6)?.as_usize();
 
-        let mut memory = geth_steps[0].memory.borrow().clone();
+        let mut memory = geth_steps[0].memory.replace(Memory::default());
         let args_minimal = if args_length != 0 {
             args_offset + args_length
         } else {

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -34,7 +34,7 @@ impl Opcode for Calldatacopy {
         let memory_offset = geth_steps[0].stack.nth_last(0)?.as_u64();
         let data_offset = geth_steps[0].stack.nth_last(1)?.as_u64();
         let length = geth_steps[0].stack.nth_last(2)?.as_usize();
-        let mut memory = geth_steps[0].memory.borrow().clone();
+        let mut memory = geth_steps[0].memory.replace(Memory::default());
         if length != 0 {
             let minimal_length = memory_offset as usize + length;
             memory.extend_at_least(minimal_length);

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     constants::MAX_COPY_BYTES,
 };
+use eth_types::evm_types::Memory;
 use eth_types::GethExecStep;
 
 #[derive(Clone, Copy, Debug)]
@@ -14,6 +15,7 @@ pub(crate) struct Calldatacopy;
 
 impl Opcode for Calldatacopy {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
@@ -22,6 +24,37 @@ impl Opcode for Calldatacopy {
         let memory_copy_steps = gen_memory_copy_steps(state, geth_steps)?;
         exec_steps.extend(memory_copy_steps);
         Ok(exec_steps)
+    }
+
+    fn reconstruct_memory(
+        &self,
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        let memory_offset = geth_steps[0].stack.nth_last(0)?.as_u64();
+        let data_offset = geth_steps[0].stack.nth_last(1)?.as_u64();
+        let length = geth_steps[0].stack.nth_last(2)?.as_usize();
+        let mut memory = geth_steps[0].memory.borrow().clone();
+        if length != 0 {
+            let minimal_length = memory_offset as usize + length;
+            memory.extend_at_least(minimal_length);
+
+            let mem_starts = memory_offset as usize;
+            let mem_ends = mem_starts + length as usize;
+            let data_starts = data_offset as usize;
+            let data_ends = data_starts + length as usize;
+            let call_data = &state.call_ctx()?.call_data;
+            if data_ends <= call_data.len() {
+                memory.0[mem_starts..mem_ends].copy_from_slice(&call_data[data_starts..data_ends]);
+            } else if let Some(actual_length) = call_data.len().checked_sub(data_starts) {
+                let mem_code_ends = mem_starts + actual_length;
+                memory.0[mem_starts..mem_code_ends].copy_from_slice(&call_data[data_starts..]);
+                // since we already resize the memory, no need to copy 0s for
+                // out of bound bytes
+            }
+        }
+        state.call_ctx_mut()?.memory = memory.clone();
+        Ok(memory)
     }
 }
 
@@ -235,6 +268,8 @@ mod calldatacopy_tests {
         .unwrap()
         .into();
 
+        println!("{}", serde_json::to_string(&block.geth_traces).unwrap());
+
         let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
         builder
             .handle_block(&block.eth_block, &block.geth_traces)
@@ -345,6 +380,71 @@ mod calldatacopy_tests {
                 memory_ops
             },
         );
+    }
+
+    #[test]
+    fn calldatacopy_opcode_internal_overflow() {
+        let (addr_a, addr_b) = (mock::MOCK_ACCOUNTS[0], mock::MOCK_ACCOUNTS[1]);
+
+        // code B gets called by code A, so the call is an internal call.
+        let dst_offset = 0x00usize;
+        let offset = 0x00usize;
+        let copy_size = 0x50usize;
+        let code_b = bytecode! {
+            PUSH32(copy_size)  // size
+            PUSH32(offset)     // offset
+            PUSH32(dst_offset) // dst_offset
+            CALLDATACOPY
+            STOP
+        };
+
+        // code A calls code B.
+        let pushdata = hex::decode("1234567890abcdef").unwrap();
+        let _memory_a = std::iter::repeat(0)
+            .take(24)
+            .chain(pushdata.clone())
+            .collect::<Vec<u8>>();
+        let call_data_length = 0x20usize;
+        let call_data_offset = 0x10usize;
+        let code_a = bytecode! {
+            // populate memory in A's context.
+            PUSH8(Word::from_big_endian(&pushdata))
+            PUSH1(0x00) // offset
+            MSTORE
+            // call addr_b.
+            PUSH1(0x00) // retLength
+            PUSH1(0x00) // retOffset
+            PUSH1(call_data_length) // argsLength
+            PUSH1(call_data_offset) // argsOffset
+            PUSH1(0x00) // value
+            PUSH32(addr_b.to_word()) // addr
+            PUSH32(0x1_0000) // gas
+            CALL
+            STOP
+        };
+
+        // Get the execution steps from the external tracer
+        let block: GethData = TestContext::<3, 1>::new(
+            None,
+            |accs| {
+                accs[0].address(addr_b).code(code_b);
+                accs[1].address(addr_a).code(code_a);
+                accs[2]
+                    .address(mock::MOCK_ACCOUNTS[2])
+                    .balance(Word::from(1u64 << 30));
+            },
+            |mut txs, accs| {
+                txs[0].to(accs[1].address).from(accs[2].address);
+            },
+            |block, _tx| block,
+        )
+        .unwrap()
+        .into();
+
+        let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
+        builder
+            .handle_block(&block.eth_block, &block.geth_traces)
+            .unwrap();
     }
 
     #[test]

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -268,8 +268,6 @@ mod calldatacopy_tests {
         .unwrap()
         .into();
 
-        println!("{}", serde_json::to_string(&block.geth_traces).unwrap());
-
         let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
         builder
             .handle_block(&block.eth_block, &block.geth_traces)

--- a/bus-mapping/src/evm/opcodes/calldataload.rs
+++ b/bus-mapping/src/evm/opcodes/calldataload.rs
@@ -12,6 +12,7 @@ pub(crate) struct Calldataload;
 
 impl Opcode for Calldataload {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/calldatasize.rs
+++ b/bus-mapping/src/evm/opcodes/calldatasize.rs
@@ -13,6 +13,7 @@ pub(crate) struct Calldatasize;
 
 impl Opcode for Calldatasize {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/caller.rs
+++ b/bus-mapping/src/evm/opcodes/caller.rs
@@ -11,6 +11,7 @@ pub(crate) struct Caller;
 
 impl Opcode for Caller {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/callvalue.rs
+++ b/bus-mapping/src/evm/opcodes/callvalue.rs
@@ -11,6 +11,7 @@ pub(crate) struct Callvalue;
 
 impl Opcode for Callvalue {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -38,7 +38,7 @@ impl Opcode for Codecopy {
         let code_hash = state.call()?.code_hash;
         let code = state.code(code_hash)?;
 
-        let mut memory = geth_steps[0].memory.borrow().clone();
+        let mut memory = geth_steps[0].memory.replace(Memory::default());
         if length != 0 {
             let minimal_length = (dest_offset + length) as usize;
             memory.extend_at_least(minimal_length);

--- a/bus-mapping/src/evm/opcodes/codesize.rs
+++ b/bus-mapping/src/evm/opcodes/codesize.rs
@@ -12,6 +12,7 @@ pub(crate) struct Codesize;
 
 impl Opcode for Codesize {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -15,6 +15,7 @@ impl Opcode for DummyCreate {
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
+        // TODO: replace dummy create here
         dummy_gen_create_ops(state, geth_steps)
     }
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -1,0 +1,104 @@
+use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
+use crate::evm::Opcode;
+use crate::operation::{AccountField, AccountOp, TxAccessListAccountOp, RW};
+use crate::Error;
+use eth_types::evm_types::Memory;
+use eth_types::GethExecStep;
+use keccak256::EMPTY_HASH;
+
+#[derive(Debug, Copy, Clone)]
+pub struct DummyCreate;
+
+impl Opcode for DummyCreate {
+    fn gen_associated_ops(
+        &self,
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        dummy_gen_create_ops(state, geth_steps)
+    }
+
+    fn reconstruct_memory(
+        &self,
+        _state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        let geth_step = &geth_steps[0];
+        let offset = geth_step.stack.nth_last(1)?.as_usize();
+        let length = geth_step.stack.nth_last(2)?.as_usize();
+
+        let mut memory = geth_step.memory.borrow().clone();
+        memory.extend_at_least(offset + length);
+
+        Ok(memory)
+    }
+}
+
+fn dummy_gen_create_ops(
+    state: &mut CircuitInputStateRef,
+    geth_steps: &[GethExecStep],
+) -> Result<Vec<ExecStep>, Error> {
+    let geth_step = &geth_steps[0];
+    let mut exec_step = state.new_step(geth_step)?;
+
+    let tx_id = state.tx_ctx.id();
+    let call = state.parse_call(geth_step)?;
+
+    // Increase caller's nonce
+    let nonce_prev = state.sdb.get_nonce(&call.caller_address);
+    state.push_op_reversible(
+        &mut exec_step,
+        RW::WRITE,
+        AccountOp {
+            address: call.caller_address,
+            field: AccountField::Nonce,
+            value: (nonce_prev + 1).into(),
+            value_prev: nonce_prev.into(),
+        },
+    )?;
+
+    // Add callee into access list
+    let is_warm = state.sdb.check_account_in_access_list(&call.address);
+    state.push_op_reversible(
+        &mut exec_step,
+        RW::WRITE,
+        TxAccessListAccountOp {
+            tx_id,
+            address: call.address,
+            is_warm: true,
+            is_warm_prev: is_warm,
+        },
+    )?;
+
+    state.push_call(call.clone(), geth_step);
+
+    // Increase callee's nonce
+    let nonce_prev = state.sdb.get_nonce(&call.address);
+    debug_assert!(nonce_prev == 0);
+    state.push_op_reversible(
+        &mut exec_step,
+        RW::WRITE,
+        AccountOp {
+            address: call.address,
+            field: AccountField::Nonce,
+            value: 1.into(),
+            value_prev: 0.into(),
+        },
+    )?;
+
+    state.transfer(
+        &mut exec_step,
+        call.caller_address,
+        call.address,
+        call.value,
+    )?;
+
+    if call.code_hash.to_fixed_bytes() == *EMPTY_HASH {
+        // 1. Create with empty initcode.
+        state.handle_return(geth_step)?;
+        Ok(vec![exec_step])
+    } else {
+        // 2. Create with non-empty initcode.
+        Ok(vec![exec_step])
+    }
+}

--- a/bus-mapping/src/evm/opcodes/dup.rs
+++ b/bus-mapping/src/evm/opcodes/dup.rs
@@ -10,6 +10,7 @@ pub(crate) struct Dup<const N: usize>;
 
 impl<const N: usize> Opcode for Dup<N> {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -33,8 +33,9 @@ impl Opcode for Extcodecopy {
         let code_offset = geth_steps[0].stack.nth_last(2)?.as_u64();
         let length = geth_steps[0].stack.nth_last(3)?.as_u64();
 
-        let code_hash = state.code_hash(address)?;
-        let code = state.code(code_hash)?;
+        let (exist, account) = state.sdb.get_account(&address);
+        assert!(exist, "target account does not exist");
+        let code = state.code(account.code_hash)?;
 
         let mut memory = geth_steps[0].memory.replace(Memory::default());
         if length != 0 {
@@ -111,11 +112,12 @@ fn gen_memory_copy_steps(
     let code_offset = geth_steps[0].stack.nth_last(2)?.as_u64();
     let length = geth_steps[0].stack.nth_last(3)?.as_u64();
 
-    let code_hash = state.code_hash(address)?;
-    let code = state.code(code_hash)?;
+    let (exist, account) = state.sdb.get_account(&address);
+    assert!(exist, "target account does not exist");
+    let code = state.code(account.code_hash)?;
     let src_addr_end = code.len() as u64;
 
-    let code_source = code_hash.to_word();
+    let code_source = account.code_hash.to_word();
     let mut copied = 0;
     let mut steps = vec![];
     while copied < length {

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -36,7 +36,7 @@ impl Opcode for Extcodecopy {
         let code_hash = state.code_hash(address)?;
         let code = state.code(code_hash)?;
 
-        let mut memory = geth_steps[0].memory.borrow().clone();
+        let mut memory = geth_steps[0].memory.replace(Memory::default());
         if length != 0 {
             let minimal_length = (dest_offset + length) as usize;
             memory.extend_at_least(minimal_length);

--- a/bus-mapping/src/evm/opcodes/extcodehash.rs
+++ b/bus-mapping/src/evm/opcodes/extcodehash.rs
@@ -13,6 +13,7 @@ pub(crate) struct Extcodehash;
 
 impl Opcode for Extcodehash {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/gasprice.rs
+++ b/bus-mapping/src/evm/opcodes/gasprice.rs
@@ -11,6 +11,7 @@ pub(crate) struct GasPrice;
 
 impl Opcode for GasPrice {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     constants::MAX_COPY_BYTES,
 };
-use eth_types::evm_types::{MemoryAddress, OpcodeId};
+use eth_types::evm_types::{Memory, MemoryAddress, OpcodeId};
 use eth_types::Word;
 use eth_types::{GethExecStep, ToBigEndian, ToWord};
 
@@ -16,6 +16,7 @@ pub(crate) struct Log;
 
 impl Opcode for Log {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
@@ -25,6 +26,21 @@ impl Opcode for Log {
         let log_copy_steps = gen_log_copy_steps(state, geth_steps)?;
         exec_steps.extend(log_copy_steps);
         Ok(exec_steps)
+    }
+
+    fn reconstruct_memory(
+        &self,
+        _state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        let geth_step = &geth_steps[0];
+        let offset = geth_step.stack.nth_last(0)?.as_usize();
+        let length = geth_step.stack.nth_last(1)?.as_usize();
+
+        let mut memory = geth_step.memory.borrow().clone();
+        memory.extend_at_least(offset + length);
+
+        Ok(memory)
     }
 }
 
@@ -130,7 +146,11 @@ fn gen_log_copy_step(
 ) -> Result<(), Error> {
     // Get memory data
     let memory_address: MemoryAddress = Word::from(src_addr).try_into()?;
-    let mem_read_value = geth_steps[0].memory.read_word(memory_address).to_be_bytes();
+    let mem_read_value = geth_steps[0]
+        .memory
+        .borrow()
+        .read_word(memory_address)
+        .to_be_bytes();
 
     let data_end_index = std::cmp::min(bytes_left, MAX_COPY_BYTES);
     for (idx, _) in mem_read_value.iter().enumerate().take(data_end_index) {

--- a/bus-mapping/src/evm/opcodes/memory_expansion_test.rs
+++ b/bus-mapping/src/evm/opcodes/memory_expansion_test.rs
@@ -1,0 +1,129 @@
+use eth_types::geth_types::GethData;
+use eth_types::{bytecode, word, Bytecode, GethExecStep};
+use mock::test_ctx::helpers::{account_0_code_account_1_no_code, tx_from_1_to_0};
+use mock::test_ctx::LoggerConfig;
+use mock::TestContext;
+
+fn might_neg_index(index: isize, len: usize) -> usize {
+    if index < 0 {
+        (len as isize + index) as usize
+    } else {
+        index as usize
+    }
+}
+
+fn assert_expanded(traces: &[GethExecStep], before: isize, after: isize) {
+    let traces_len = traces.len();
+    let before = might_neg_index(before, traces_len);
+    let after = might_neg_index(after, traces_len);
+    let size_before = traces[before].memory.borrow().len();
+    let size_after = traces[after].memory.borrow().len();
+    assert_ne!(size_before, size_after);
+}
+
+fn trace_and_assert<FN>(code: Bytecode, before: isize, after: isize, assert_fn: FN)
+where
+    FN: Fn(&[GethExecStep], isize, isize),
+{
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
+        None,
+        account_0_code_account_1_no_code(code),
+        tx_from_1_to_0,
+        |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
+    )
+    .unwrap()
+    .into();
+
+    assert_fn(&block.geth_traces[0].struct_logs, before, after);
+}
+
+#[test]
+fn sha3_test() {
+    let code = bytecode! {
+        PUSH1(0xffu64)
+        PUSH1(0x40u64)
+        SHA3
+        STOP
+    };
+    trace_and_assert(code, -2, -1, assert_expanded);
+}
+
+#[test]
+fn mload_test() {
+    let code = bytecode! {
+        PUSH1(0xffu64)
+        MLOAD
+        STOP
+    };
+    trace_and_assert(code, -2, -1, assert_expanded);
+}
+
+#[test]
+fn log0_test() {
+    let code = bytecode! {
+        PUSH1(0xffu64)
+        PUSH1(0x40u64)
+        LOG0
+        STOP
+    };
+    trace_and_assert(code, -2, -1, assert_expanded);
+}
+
+#[test]
+fn create_test() {
+    let code = bytecode! {
+        PUSH21(word!("0x6B6020600060003760006000F3600052600C6014F3"))
+        PUSH1(0)
+        MSTORE
+        PUSH1 (0xff)
+        PUSH1 (0xB)
+        PUSH1 (0)
+        CREATE
+        STOP
+    };
+    trace_and_assert(code, -2, -1, assert_expanded);
+}
+
+#[test]
+fn call_test() {
+    // // deployed contract
+    // PUSH1 0x20
+    // PUSH1 0
+    // PUSH1 0
+    // CALLDATACOPY
+    // PUSH1 0
+    // PUSH1 0
+    // RETURN
+    //
+    // bytecode: 0x6020600060003760006000F3
+    //
+    // // constructor
+    // PUSH12 0x6020600060003760006000F3
+    // PUSH1 0
+    // MSTORE
+    // PUSH1 0xC
+    // PUSH1 0x14
+    // RETURN
+    //
+    // bytecode: 0x6B6020600060003760006000F3600052600C6014F3
+    let code = bytecode! {
+        PUSH21(word!("0x6B6020600060003760006000F3600052600C6014F3"))
+        PUSH1(0)
+        MSTORE
+        PUSH1 (0x15)
+        PUSH1 (0xB)
+        PUSH1 (0)
+        CREATE
+        PUSH1 (0x0)
+        PUSH1 (0x0)
+        PUSH1 (0x20)
+        PUSH1 (0xff)
+        PUSH1 (0)
+        DUP6
+        PUSH2 (0xFFFF)
+        CALL
+        STOP
+    };
+    trace_and_assert(code, -2, -1, assert_expanded);
+}

--- a/bus-mapping/src/evm/opcodes/mstore.rs
+++ b/bus-mapping/src/evm/opcodes/mstore.rs
@@ -2,7 +2,7 @@ use super::Opcode;
 use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::Error;
 use core::convert::TryInto;
-use eth_types::evm_types::MemoryAddress;
+use eth_types::evm_types::{Memory, MemoryAddress};
 use eth_types::{GethExecStep, ToBigEndian, ToLittleEndian};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
@@ -13,6 +13,7 @@ pub(crate) struct Mstore<const IS_MSTORE8: bool>;
 
 impl<const IS_MSTORE8: bool> Opcode for Mstore<IS_MSTORE8> {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
@@ -50,6 +51,35 @@ impl<const IS_MSTORE8: bool> Opcode for Mstore<IS_MSTORE8> {
         }
 
         Ok(vec![exec_step])
+    }
+
+    fn reconstruct_memory(
+        &self,
+        _state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        let geth_step = &geth_steps[0];
+        let offset = geth_step.stack.nth_last(0)?;
+        let value = geth_step.stack.nth_last(1)?;
+        let offset_addr: MemoryAddress = offset.try_into()?;
+
+        let mut memory = geth_step.memory.borrow().clone();
+        let minimal_length = offset_addr.0 + if IS_MSTORE8 { 1 } else { 32 };
+        memory.extend_at_least(minimal_length);
+
+        let mem_starts = offset_addr.0;
+
+        match IS_MSTORE8 {
+            true => {
+                let val = *value.to_le_bytes().first().unwrap();
+                memory.0[mem_starts] = val;
+            }
+            false => {
+                let bytes = value.to_be_bytes();
+                memory[mem_starts..mem_starts + 32].copy_from_slice(&bytes);
+            }
+        }
+        Ok(memory)
     }
 }
 

--- a/bus-mapping/src/evm/opcodes/origin.rs
+++ b/bus-mapping/src/evm/opcodes/origin.rs
@@ -9,6 +9,7 @@ pub(crate) struct Origin;
 
 impl Opcode for Origin {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -13,6 +13,7 @@ impl Opcode for Returndatacopy {
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
+        // TODO: complete `ExecStep` and circuit implementation
         let exec_step = state.new_step(&geth_steps[0])?;
         Ok(vec![exec_step])
     }

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -1,21 +1,19 @@
 use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::evm::Opcode;
 use crate::Error;
-use core::borrow::Borrow;
 use eth_types::evm_types::Memory;
-use eth_types::{GethExecStep, ToAddress};
+use eth_types::GethExecStep;
 
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct Return;
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Returndatacopy;
 
-impl Opcode for Return {
+impl Opcode for Returndatacopy {
     fn gen_associated_ops(
         &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
         let exec_step = state.new_step(&geth_steps[0])?;
-        state.handle_return(&geth_steps[0])?;
         Ok(vec![exec_step])
     }
 
@@ -24,44 +22,35 @@ impl Opcode for Return {
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Memory, Error> {
-        let current_call = state.call()?.clone();
-
         let geth_step = &geth_steps[0];
-        let offset = geth_step.stack.nth_last(0)?.as_usize();
-        let length = geth_step.stack.nth_last(1)?.as_usize();
+        let dest_offset = geth_step.stack.nth_last(0)?;
+        let offset = geth_step.stack.nth_last(1)?;
+        let size = geth_step.stack.nth_last(2)?;
 
-        // skip reconstruction for root-level return/revert
-        if !current_call.is_root {
-            if !current_call.is_create() {
-                // handle normal return/revert
-                // copy return data
-                // update to the caller memory
-                let caller_ctx = state.caller_ctx_mut()?;
-                let return_offset = current_call.return_data_offset as usize;
-                caller_ctx.memory.extend_at_least(return_offset + length);
-                caller_ctx.memory.0[return_offset..return_offset + length]
-                    .copy_from_slice(&geth_step.memory.borrow().0[offset..offset + length]);
-                caller_ctx.return_data.resize(length as usize, 0);
-                caller_ctx
-                    .return_data
-                    .copy_from_slice(&geth_step.memory.borrow().0[offset..offset + length]);
-                caller_ctx.last_call = Some(current_call);
+        let call = state.call_ctx()?;
+        let return_data = &call.return_data;
+
+        let mut memory = geth_step.memory.borrow().clone();
+        let length = size.as_usize();
+        if length != 0 {
+            let mem_starts = dest_offset.as_usize();
+            let mem_ends = mem_starts + length;
+            let data_starts = offset.as_usize();
+            let data_ends = data_starts + length;
+            let minimal_length = dest_offset.as_usize() + length;
+            if data_ends <= return_data.len() {
+                memory.extend_at_least(minimal_length);
+                memory[mem_starts..mem_ends].copy_from_slice(&return_data[data_starts..data_ends]);
             } else {
-                // dealing with contract creation
-                assert!(offset + length <= geth_step.memory.borrow().0.len());
-                let code = geth_step.memory.borrow().0[offset..offset + length].to_vec();
-                let contract_addr = geth_steps[1].stack.nth_last(0)?.to_address();
-                state.code_db.insert(Some(contract_addr), code);
+                assert_eq!(geth_steps.len(), 1);
+                // if overflows this opcode would fails current context, so
+                // there is no more steps.
             }
-            let caller_ctx = state.caller_ctx()?;
-            Ok(caller_ctx.memory.borrow().clone())
-        } else {
-            Ok(geth_steps[0].memory.borrow().clone())
         }
+
+        Ok(memory)
     }
 }
-
-// TODO: circuit implement
 
 #[cfg(test)]
 mod return_tests {
@@ -111,6 +100,12 @@ mod return_tests {
             DUP6
             PUSH2 (0xFFFF)
             CALL
+
+            PUSH1 (0x20)
+            PUSH1 (0)
+            PUSH1 (0x40)
+            RETURNDATACOPY
+
             STOP
         };
         // Get the execution steps from the external tracer
@@ -138,21 +133,21 @@ mod return_tests {
         // CALLDATACOPY
         // PUSH1 0x20
         // PUSH1 0
-        // REVERT
+        // RETURN
         //
-        // bytecode: 0x6020600060003760206000FD
+        // bytecode: 0x6020600060003760206000F3
         //
         // // constructor
-        // PUSH12 0x6020600060003760206000FD
+        // PUSH12 0x6020600060003760206000F3
         // PUSH1 0
         // MSTORE
         // PUSH1 0xC
         // PUSH1 0x14
         // RETURN
         //
-        // bytecode: 0x6B6020600060003760206000FD600052600C6014F3
+        // bytecode: 0x6B6020600060003760206000F3600052600C6014F3
         let code = bytecode! {
-            PUSH21(word!("6B6020600060003760206000FD600052600C6014F3"))
+            PUSH21(word!("6B6020600060003760206000F3600052600C6014F3"))
             PUSH1(0)
             MSTORE
 
@@ -169,6 +164,12 @@ mod return_tests {
             DUP6
             PUSH2 (0xFFFF)
             CALL
+
+            PUSH1 (0x40)
+            PUSH1 (0)
+            PUSH1 (0x40)
+            RETURNDATACOPY
+
             STOP
         };
         // Get the execution steps from the external tracer

--- a/bus-mapping/src/evm/opcodes/selfbalance.rs
+++ b/bus-mapping/src/evm/opcodes/selfbalance.rs
@@ -9,6 +9,7 @@ pub(crate) struct Selfbalance;
 
 impl Opcode for Selfbalance {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -1,0 +1,34 @@
+use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
+use crate::evm::opcodes::stackonlyop::StackOnlyOpcode;
+use crate::evm::Opcode;
+use crate::Error;
+use eth_types::evm_types::Memory;
+use eth_types::GethExecStep;
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Sha3;
+
+impl Opcode for Sha3 {
+    fn gen_associated_ops(
+        &self,
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        StackOnlyOpcode::<2, 1>.gen_associated_ops(state, geth_steps)
+    }
+
+    fn reconstruct_memory(
+        &self,
+        _state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        let geth_step = &geth_steps[0];
+        let offset = geth_step.stack.nth_last(0)?.as_usize();
+        let length = geth_step.stack.nth_last(1)?.as_usize();
+
+        let mut memory = geth_step.memory.borrow().clone();
+        memory.extend_at_least(offset + length);
+
+        Ok(memory)
+    }
+}

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -14,6 +14,8 @@ impl Opcode for Sha3 {
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
+        // TODO: memory reads
+        log::warn!("incomplete SHA3 implementation");
         StackOnlyOpcode::<2, 1>.gen_associated_ops(state, geth_steps)
     }
 

--- a/bus-mapping/src/evm/opcodes/sload.rs
+++ b/bus-mapping/src/evm/opcodes/sload.rs
@@ -15,6 +15,7 @@ pub(crate) struct Sload;
 
 impl Opcode for Sload {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/sstore.rs
+++ b/bus-mapping/src/evm/opcodes/sstore.rs
@@ -16,6 +16,7 @@ pub(crate) struct Sstore;
 
 impl Opcode for Sstore {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/stackonlyop.rs
+++ b/bus-mapping/src/evm/opcodes/stackonlyop.rs
@@ -14,6 +14,7 @@ pub(crate) struct StackOnlyOpcode<const N_POP: usize, const N_PUSH: usize>;
 
 impl<const N_POP: usize, const N_PUSH: usize> Opcode for StackOnlyOpcode<N_POP, N_PUSH> {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/evm/opcodes/stop.rs
+++ b/bus-mapping/src/evm/opcodes/stop.rs
@@ -4,7 +4,7 @@ use crate::{
     operation::CallContextField,
     Error,
 };
-use eth_types::{GethExecStep, ToWord};
+use eth_types::{evm_types::Memory, GethExecStep, ToWord};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the [`OpcodeId::STOP`](crate::evm::OpcodeId::STOP)
@@ -17,6 +17,7 @@ pub(crate) struct Stop;
 
 impl Opcode for Stop {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
@@ -69,7 +70,7 @@ impl Opcode for Stop {
                 (CallContextField::GasLeft, caller_gas_left.into()),
                 (
                     CallContextField::MemorySize,
-                    geth_step_next.memory.word_size().into(),
+                    geth_step_next.memory.borrow().word_size().into(),
                 ),
                 (
                     CallContextField::ReversibleWriteCounter,
@@ -91,5 +92,21 @@ impl Opcode for Stop {
         state.handle_return(geth_step)?;
 
         Ok(vec![exec_step])
+    }
+
+    fn reconstruct_memory(
+        &self,
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Memory, Error> {
+        let current_call = state.call()?.clone();
+        if !current_call.is_root {
+            let caller_ctx = state.caller_ctx_mut()?;
+            let length = current_call.return_data_offset + current_call.return_data_length;
+            caller_ctx.memory.extend_at_least(length as usize);
+            Ok(caller_ctx.memory.clone())
+        } else {
+            Ok(geth_steps[0].memory.borrow().clone())
+        }
     }
 }

--- a/bus-mapping/src/evm/opcodes/stop.rs
+++ b/bus-mapping/src/evm/opcodes/stop.rs
@@ -106,7 +106,7 @@ impl Opcode for Stop {
             caller_ctx.memory.extend_at_least(length as usize);
             Ok(caller_ctx.memory.clone())
         } else {
-            Ok(geth_steps[0].memory.borrow().clone())
+            Ok(geth_steps[0].memory.replace(Memory::default()))
         }
     }
 }

--- a/bus-mapping/src/evm/opcodes/swap.rs
+++ b/bus-mapping/src/evm/opcodes/swap.rs
@@ -10,6 +10,7 @@ pub(crate) struct Swap<const N: usize>;
 
 impl<const N: usize> Opcode for Swap<N> {
     fn gen_associated_ops(
+        &self,
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -219,12 +219,14 @@
 #![allow(non_snake_case)]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 //#![deny(unsafe_code)] Allowed now until we find a
 // better way to handle downcasting from Operation into it's variants.
 #![allow(clippy::upper_case_acronyms)] // Too pedantic
 
 extern crate alloc;
+extern crate core;
+
 pub mod circuit_input_builder;
 pub mod constants;
 pub mod error;

--- a/bus-mapping/src/mock.rs
+++ b/bus-mapping/src/mock.rs
@@ -50,7 +50,7 @@ impl BlockData {
         }
 
         for account in geth_data.accounts {
-            let code_hash = code_db.insert(account.code.to_vec());
+            let code_hash = code_db.insert(None, account.code.to_vec());
             sdb.set_account(
                 &account.address,
                 state_db::Account {

--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -39,7 +39,7 @@ pub(crate) struct GethLoggerConfig {
 impl Default for GethLoggerConfig {
     fn default() -> Self {
         Self {
-            enable_memory: true,
+            enable_memory: false,
             disable_stack: false,
             disable_storage: false,
             enable_return_data: true,

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -14,7 +14,10 @@ lazy_static! {
 
 /// Memory storage for contract code by code hash.
 #[derive(Debug, Clone)]
-pub struct CodeDB(pub HashMap<Hash, Vec<u8>>);
+pub struct CodeDB {
+    pub address_hash: HashMap<Address, Hash>,
+    pub hash_code: HashMap<Hash, Vec<u8>>,
+}
 
 impl Default for CodeDB {
     fn default() -> Self {
@@ -25,12 +28,18 @@ impl Default for CodeDB {
 impl CodeDB {
     /// Create a new empty Self.
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self {
+            address_hash: HashMap::new(),
+            hash_code: HashMap::new(),
+        }
     }
     /// Insert code indexed by code hash, and return the code hash.
-    pub fn insert(&mut self, code: Vec<u8>) -> Hash {
+    pub fn insert(&mut self, address: Option<Address>, code: Vec<u8>) -> Hash {
         let hash = H256(keccak256(&code));
-        self.0.insert(hash, code);
+        self.hash_code.insert(hash, code);
+        if let Some(address) = address {
+            self.address_hash.insert(address, hash);
+        }
         hash
     }
 }

--- a/eth-types/src/evm_types/opcode_ids.rs
+++ b/eth-types/src/evm_types/opcode_ids.rs
@@ -329,9 +329,22 @@ impl OpcodeId {
     pub fn is_swap(&self) -> bool {
         self.as_u8() >= Self::SWAP1.as_u8() && self.as_u8() <= Self::SWAP16.as_u8()
     }
+
     /// Returns `true` if the `OpcodeId` is a `LOGn`.
     pub fn is_log(&self) -> bool {
         self.as_u8() >= Self::LOG0.as_u8() && self.as_u8() <= Self::LOG4.as_u8()
+    }
+
+    /// Returns `true` if the `OpcodeId` is a CALL-like.
+    pub fn is_call(&self) -> bool {
+        matches!(
+            self,
+            OpcodeId::CREATE
+                | OpcodeId::CALL
+                | OpcodeId::CALLCODE
+                | OpcodeId::DELEGATECALL
+                | OpcodeId::STATICCALL
+        )
     }
 }
 
@@ -637,6 +650,20 @@ impl OpcodeId {
             OpcodeId::INVALID(_) => GasCost::ZERO,
             OpcodeId::SELFDESTRUCT => GasCost::SELFDESTRUCT,
         }
+    }
+
+    /// Returns if the `OpcodeId` has memory access
+    pub const fn has_memory_access(&self) -> bool {
+        matches!(
+            self,
+            OpcodeId::MLOAD
+                | OpcodeId::MSTORE
+                | OpcodeId::MSTORE8
+                | OpcodeId::CALLDATACOPY
+                | OpcodeId::RETURNDATACOPY
+                | OpcodeId::CODECOPY
+                | OpcodeId::EXTCODECOPY
+        )
     }
 }
 

--- a/eth-types/src/evm_types/opcode_ids.rs
+++ b/eth-types/src/evm_types/opcode_ids.rs
@@ -652,7 +652,7 @@ impl OpcodeId {
         }
     }
 
-    /// Returns if the `OpcodeId` has memory access
+    /// Returns `true` if the `OpcodeId` has memory access
     pub const fn has_memory_access(&self) -> bool {
         matches!(
             self,

--- a/eth-types/src/evm_types/storage.rs
+++ b/eth-types/src/evm_types/storage.rs
@@ -1,6 +1,8 @@
 //! Doc this
-use crate::Error;
 use crate::{DebugWord, Word};
+use crate::{Error, ToBigEndian};
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -20,6 +22,19 @@ impl fmt::Debug for Storage {
         f.debug_map()
             .entries(self.0.iter().map(|(k, v)| (DebugWord(k), DebugWord(v))))
             .finish()
+    }
+}
+
+impl Serialize for Storage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut ser = serializer.serialize_map(Some(self.0.len()))?;
+        for (k, v) in self.0.iter() {
+            ser.serialize_entry(&hex::encode(k.to_be_bytes()), &hex::encode(v.to_be_bytes()))?;
+        }
+        ser.end()
     }
 }
 

--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -30,6 +30,7 @@ use halo2_proofs::{
         group::ff::PrimeField,
     },
 };
+use std::cell::RefCell;
 
 use crate::evm_types::{memory::Memory, stack::Stack, storage::Storage};
 use crate::evm_types::{Gas, GasCost, OpcodeId, ProgramCounter};
@@ -40,7 +41,7 @@ pub use ethers_core::types::{
     Address, Block, Bytes, H160, H256, U256, U64,
 };
 
-use serde::{de, Deserialize};
+use serde::{de, Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
@@ -248,7 +249,7 @@ struct GethExecStepInternal {
 
 /// The execution step type returned by geth RPC debug_trace* methods.
 /// Corresponds to `StructLogRes` in `go-ethereum/internal/ethapi/api.go`.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Serialize)]
 #[doc(hidden)]
 pub struct GethExecStep {
     pub pc: ProgramCounter,
@@ -261,7 +262,7 @@ pub struct GethExecStep {
     // stack is in hex 0x prefixed
     pub stack: Stack,
     // memory is in chunks of 32 bytes, in hex
-    pub memory: Memory,
+    pub memory: RefCell<Memory>,
     // storage is hex -> hex
     pub storage: Storage,
 }
@@ -316,12 +317,12 @@ impl<'de> Deserialize<'de> for GethExecStep {
             depth: s.depth,
             error: s.error,
             stack: Stack(s.stack.iter().map(|dw| dw.to_word()).collect::<Vec<Word>>()),
-            memory: Memory::from(
+            memory: RefCell::new(Memory::from(
                 s.memory
                     .iter()
                     .map(|dw| dw.to_word())
                     .collect::<Vec<Word>>(),
-            ),
+            )),
             storage: Storage(
                 s.storage
                     .iter()
@@ -353,7 +354,7 @@ pub struct ResultGethExecTrace {
 /// The deserialization truncates the memory of each step in `struct_logs` to
 /// the memory size before the expansion, so that it corresponds to the memory
 /// before the step is executed.
-#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 pub struct GethExecTrace {
     /// Used gas
     pub gas: Gas,
@@ -488,7 +489,7 @@ mod tests {
                         error: None,
                         stack: Stack::new(),
                         storage: Storage(word_map!()),
-                        memory: Memory::new(),
+                        memory: RefCell::new(Memory::new()),
                     },
                     GethExecStep {
                         pc: ProgramCounter(163),
@@ -500,7 +501,11 @@ mod tests {
                         error: None,
                         stack: Stack(vec![word!("0x1003e2d2"), word!("0x2a"), word!("0x0")]),
                         storage: Storage(word_map!("0x0" => "0x6f")),
-                        memory: Memory::from(vec![word!("0x0"), word!("0x0"), word!("0x080")]),
+                        memory: RefCell::new(Memory::from(vec![
+                            word!("0x0"),
+                            word!("0x0"),
+                            word!("0x080")
+                        ])),
                     },
                     GethExecStep {
                         pc: ProgramCounter(189),
@@ -516,7 +521,7 @@ mod tests {
                             word!("0x0")
                         ]),
                         storage: Storage(word_map!()),
-                        memory: Memory::from(vec![
+                        memory: RefCell::new(Memory::from(vec![
                             word!(
                                 "000000000000000000000000b8f67472dcc25589672a61905f7fd63f09e5d470"
                             ),
@@ -535,7 +540,7 @@ mod tests {
                             word!(
                                 "00000000000000000000000000000000000000000000003635c9adc5dea00000"
                             ),
-                        ]),
+                        ])),
                     }
                 ],
             }

--- a/external-tracer/src/lib.rs
+++ b/external-tracer/src/lib.rs
@@ -21,6 +21,45 @@ pub struct TraceConfig {
     pub accounts: HashMap<Address, Account>,
     /// transaction
     pub transactions: Vec<Transaction>,
+    /// logger
+    pub logger_config: LoggerConfig,
+}
+
+/// Configuration structure for `logger.Config`
+#[derive(Debug, Clone, Serialize)]
+pub struct LoggerConfig {
+    /// enable memory capture
+    #[serde(rename = "EnableMemory")]
+    pub enable_memory: bool,
+    /// disable stack capture
+    #[serde(rename = "DisableStack")]
+    pub disable_stack: bool,
+    /// disable storage capture
+    #[serde(rename = "DisableStorage")]
+    pub disable_storage: bool,
+    /// enable return data capture
+    #[serde(rename = "EnableReturnData")]
+    pub enable_return_data: bool,
+}
+
+impl Default for LoggerConfig {
+    fn default() -> Self {
+        Self {
+            enable_memory: false,
+            disable_stack: false,
+            disable_storage: false,
+            enable_return_data: true,
+        }
+    }
+}
+
+impl LoggerConfig {
+    pub fn enable_memory() -> Self {
+        Self {
+            enable_memory: true,
+            ..Self::default()
+        }
+    }
 }
 
 /// Creates a trace for the specified config

--- a/geth-utils/gethutil/trace.go
+++ b/geth-utils/gethutil/trace.go
@@ -121,6 +121,7 @@ type TraceConfig struct {
 	Block         Block                      `json:"block_constants"`
 	Accounts      map[common.Address]Account `json:"accounts"`
 	Transactions  []Transaction              `json:"transactions"`
+	LoggerConfig  *logger.Config             `json:"logger_config"`
 }
 
 func Trace(config TraceConfig) ([]*ExecutionResult, error) {
@@ -213,7 +214,7 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 	// Run the transactions with tracing enabled.
 	executionResults := make([]*ExecutionResult, len(config.Transactions))
 	for i, message := range messages {
-		tracer := logger.NewStructLogger(&logger.Config{EnableMemory: true})
+		tracer := logger.NewStructLogger(config.LoggerConfig)
 		evm := vm.NewEVM(blockCtx, core.NewEVMTxContext(message), stateDB, &chainConfig, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 
 		result, err := core.ApplyMessage(evm, message, new(core.GasPool).AddGas(message.Gas()))

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -379,6 +379,8 @@ mod test {
         let from = MOCK_ACCOUNTS[1];
 
         let code = bytecode! {
+            PUSH1(0)
+            PUSH1(0)
             RETURN
         };
 

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -1422,7 +1422,8 @@ pub fn block_convert(
                     .unique()
                     .into_iter()
                     .map(|code_hash| {
-                        let bytecode = Bytecode::new(code_db.0.get(&code_hash).unwrap().to_vec());
+                        let bytecode =
+                            Bytecode::new(code_db.hash_code.get(&code_hash).unwrap().to_vec());
                         (bytecode.hash, bytecode)
                     })
             })


### PR DESCRIPTION



## Checklist

### OpCodes Impl
- [x] CALLDATACOPY
- [x] RETURNDATACOPY
- [x] CODECOPY
- [x] EXTCODECOPY
- [x] MSTORE
- [x] MSTORE8
- [x] RETURN

### Test

### Unit Tests
- [x] CALLDATACOPY
- [x] RETURNDATACOPY
- [x] CODECOPY
- [x] EXTCODECOPY
- [x] MSTORE
- [x] MSTORE8
- [x] RETURN

### Integration Test
- [x] Test with tracer config: `EnableMemory: false`

### Note
this pr is related to scroll-tech/go-ethereum/issues/94 and privacy-scaling-explorations/zkevm-circuits/issues/502.
