### PR TITLE
optim/next-step-queries: remove unnecessary queries

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -288,7 +288,7 @@ impl<F: Field> ExecutionConfig<F> {
         let q_step_last = meta.complex_selector();
         let advices = [(); STEP_WIDTH].map(|_| meta.advice_column());
 
-        let step_curr = Step::new(meta, advices, 0);
+        let step_curr = Step::new(meta, advices, 0, false);
         let mut height_map = HashMap::new();
 
         meta.create_gate("Constrain execution state", |meta| {
@@ -362,7 +362,7 @@ impl<F: Field> ExecutionConfig<F> {
         });
 
         let mut stored_expressions_map = HashMap::new();
-        let step_next = Step::new(meta, advices, MAX_STEP_HEIGHT);
+        let step_next = Step::new(meta, advices, MAX_STEP_HEIGHT, true);
         macro_rules! configure_gadget {
             () => {
                 Self::configure_gadget(
@@ -548,7 +548,7 @@ impl<F: Field> ExecutionConfig<F> {
         };
 
         // Now actually configure the gadget with the correct minimal height
-        let step_next = &Step::new(meta, advices, height);
+        let step_next = &Step::new(meta, advices, height, true);
         let mut cb = ConstraintBuilder::new(
             step_curr.clone(),
             step_next.clone(),

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -4,6 +4,7 @@ use super::table::Table;
 pub(crate) const STEP_WIDTH: usize = 128;
 /// Step height
 pub const MAX_STEP_HEIGHT: usize = 21;
+pub(crate) const STEP_STATE_HEIGHT: usize = 1;
 pub(crate) const N_CELLS_STEP_STATE: usize = 11;
 
 /// Lookups done per row.

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -4,6 +4,8 @@ use super::table::Table;
 pub(crate) const STEP_WIDTH: usize = 128;
 /// Step height
 pub const MAX_STEP_HEIGHT: usize = 21;
+/// The height of the state of a step, used by gates that connect two consecutive steps.
+/// We target 1, which is also convenient for padding with EndBlock steps.
 pub(crate) const STEP_STATE_HEIGHT: usize = 1;
 pub(crate) const N_CELLS_STEP_STATE: usize = 11;
 

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -1,7 +1,7 @@
 use super::util::{CachedRegion, CellManager, CellType};
 use crate::{
     evm_circuit::{
-        param::{MAX_STEP_HEIGHT, STEP_WIDTH},
+        param::{MAX_STEP_HEIGHT, STEP_STATE_HEIGHT, STEP_WIDTH},
         util::{Cell, RandomLinearCombination},
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -466,8 +466,14 @@ impl<F: FieldExt> Step<F> {
         meta: &mut ConstraintSystem<F>,
         advices: [Column<Advice>; STEP_WIDTH],
         offset: usize,
+        is_next: bool,
     ) -> Self {
-        let mut cell_manager = CellManager::new(meta, MAX_STEP_HEIGHT, &advices, offset);
+        let height = if is_next {
+            STEP_STATE_HEIGHT // Query only the state of the next step.
+        } else {
+            MAX_STEP_HEIGHT // Query the entire current step.
+        };
+        let mut cell_manager = CellManager::new(meta, height, &advices, offset);
         let state = {
             StepState {
                 execution_state: DynamicSelectorHalf::new(

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -100,7 +100,7 @@ pub struct SuperCircuitConfig<F: Field, const MAX_TXS: usize, const MAX_CALLDATA
 }
 
 /// The Super Circuit contains all the zkEVM circuits
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct SuperCircuit<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> {
     // EVM Circuit
     /// Block witness. Usually derived via
@@ -343,9 +343,16 @@ impl<const MAX_TXS: usize, const MAX_CALLDATA: usize> SuperCircuit<Fr, MAX_TXS, 
             bytecode_size: bytecodes_len + 64,
         };
 
+        let instance = circuit.instance();
+        Ok((k, circuit, instance))
+    }
+
+    /// Returns suitable inputs for the SuperCircuit.
+    pub fn instance(&self) -> Vec<Vec<Fr>> {
         // SignVerifyChip -> ECDSAChip -> MainGate instance column
-        let instances = vec![vec![]];
-        Ok((k, circuit, instances))
+        let instance = vec![vec![]];
+
+        instance
     }
 }
 


### PR DESCRIPTION
Currently, CellManager::new queries all rows of the next step. However, only the first row with state registers is necessary for step transition. This PR removes the unused queries.

This cuts the number of polynomial evaluations in almost half; proof size by 42%; verification time 3X. (with `make evm_bench`)