### PR TITLE
soundness problem of rw table

### DIFF
--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -998,7 +998,8 @@ fn prover(rows: Vec<Rw>, overrides: HashMap<(AdviceColumn, isize), Fr>) -> MockP
 fn verify(rows: Vec<Rw>) -> Result<(), Vec<VerifyFailure>> {
     let used_rows = rows.len();
     prover(rows, HashMap::new())
-        .verify_at_rows(N_ROWS - used_rows..N_ROWS, N_ROWS - used_rows..N_ROWS)
+        .verify_par()
+        //.verify_at_rows(N_ROWS - used_rows..N_ROWS, N_ROWS - used_rows..N_ROWS)
 }
 
 fn verify_with_overrides(

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -9,6 +9,7 @@ use crate::witness::{
     Block, BlockContext, Bytecode, MptUpdateRow, MptUpdates, Rw, RwMap, RwRow, Transaction,
 };
 use bus_mapping::circuit_input_builder::{CopyDataType, CopyEvent, CopyStep};
+use rand::rngs::OsRng;
 use core::iter::once;
 use eth_types::{Field, ToLittleEndian, ToScalar, Word};
 use gadgets::binary_number::{BinaryNumberChip, BinaryNumberConfig};
@@ -437,6 +438,19 @@ impl RwTable {
         for (offset, row) in rows.iter().enumerate() {
             self.assign(region, offset, &row.table_assignment(randomness))?;
         }
+        self.assign(region, rows.len() + 3, &RwRow {
+            rw_counter: F::random(OsRng),
+            is_write:  F::random(OsRng),
+            tag: F::random(OsRng),
+            id: F::random(OsRng),
+            address: F::random(OsRng),
+            field_tag: F::random(OsRng),
+            storage_key: F::random(OsRng),
+            value: F::random(OsRng),
+            value_prev: F::random(OsRng),
+            aux1: F::random(OsRng),
+            aux2: F::random(OsRng),
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
just run

```
cargo test -p zkevm-circuits --all-features --release state -- --nocapture
```