### PR TITLE
Feat: Induce dynamic codehash for witness building

### DIFF
--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -13,14 +13,13 @@ lazy_static! {
 }
 
 /// Define any object can encode the code to a 32 bytes hash
-pub trait CodeHash : std::fmt::Debug {
+pub trait CodeHash: std::fmt::Debug {
     /// encode code
     fn hash_code(&self, code: &[u8]) -> Hash;
-
 }
 
 /// Helper trait for clone object in a object-safe way
-pub trait CodeHashCopy : CodeHash {
+pub trait CodeHashCopy: CodeHash {
     /// clone to a boxed obect
     fn clone_box(&self) -> Box<dyn CodeHashCopy>;
 }
@@ -29,11 +28,10 @@ impl<T> CodeHashCopy for T
 where
     T: 'static + CodeHash + Clone,
 {
-    fn clone_box(&self) -> Box<dyn CodeHashCopy>{
+    fn clone_box(&self) -> Box<dyn CodeHashCopy> {
         Box::new(self.clone())
     }
 }
-
 
 /// Memory storage for contract code by code hash.
 #[derive(Debug)]
@@ -69,10 +67,14 @@ impl CodeDB {
     pub fn new() -> Self {
         Self::new_with_code_hasher(Box::new(EthCodeHash))
     }
-    /// Insert code indexed by code hash, and return the code hash. Notice we always
-    /// return Self::empty_code_hash() for empty code
+    /// Insert code indexed by code hash, and return the code hash. Notice we
+    /// always return Self::empty_code_hash() for empty code
     pub fn insert(&mut self, code: Vec<u8>) -> Hash {
-        let hash = if code.is_empty() { Self::empty_code_hash() } else {self.1.hash_code(&code)};
+        let hash = if code.is_empty() {
+            Self::empty_code_hash()
+        } else {
+            self.1.hash_code(&code)
+        };
         self.0.insert(hash, code);
         hash
     }

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -12,9 +12,38 @@ lazy_static! {
     static ref CODE_HASH_ZERO: Hash = H256(keccak256(&[]));
 }
 
+/// Define any object can encode the code to a 32 bytes hash
+pub trait CodeHash : std::fmt::Debug {
+    /// encode code
+    fn hash_code(&self, code: &[u8]) -> Hash;
+
+}
+
+/// Helper trait for clone object in a object-safe way
+pub trait CodeHashCopy : CodeHash {
+    /// clone to a boxed obect
+    fn clone_box(&self) -> Box<dyn CodeHashCopy>;
+}
+
+impl<T> CodeHashCopy for T
+where
+    T: 'static + CodeHash + Clone,
+{
+    fn clone_box(&self) -> Box<dyn CodeHashCopy>{
+        Box::new(self.clone())
+    }
+}
+
+
 /// Memory storage for contract code by code hash.
-#[derive(Debug, Clone)]
-pub struct CodeDB(pub HashMap<Hash, Vec<u8>>);
+#[derive(Debug)]
+pub struct CodeDB(pub HashMap<Hash, Vec<u8>>, Box<dyn CodeHashCopy>);
+
+impl Clone for CodeDB {
+    fn clone(&self) -> Self {
+        CodeDB(self.0.clone(), self.1.clone_box())
+    }
+}
 
 impl Default for CodeDB {
     fn default() -> Self {
@@ -22,16 +51,36 @@ impl Default for CodeDB {
     }
 }
 
+#[derive(Debug, Clone)]
+struct EthCodeHash;
+
+impl CodeHash for EthCodeHash {
+    fn hash_code(&self, code: &[u8]) -> Hash {
+        H256(keccak256(code))
+    }
+}
+
 impl CodeDB {
+    /// Create a new empty Self with specified code hash method
+    pub fn new_with_code_hasher(hasher: Box<dyn CodeHashCopy>) -> Self {
+        Self(HashMap::new(), hasher)
+    }
     /// Create a new empty Self.
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self::new_with_code_hasher(Box::new(EthCodeHash))
     }
-    /// Insert code indexed by code hash, and return the code hash.
+    /// Insert code indexed by code hash, and return the code hash. Notice we always
+    /// return Self::empty_code_hash() for empty code
     pub fn insert(&mut self, code: Vec<u8>) -> Hash {
-        let hash = H256(keccak256(&code));
+        let hash = if code.is_empty() { Self::empty_code_hash() } else {self.1.hash_code(&code)};
         self.0.insert(hash, code);
         hash
+    }
+    /// Specify code hash for empty code (nil), it should be kept consistent
+    /// between different methods because many contract use this magic hash
+    /// for distinguishing accounts without contracts
+    pub fn empty_code_hash() -> Hash {
+        *CODE_HASH_ZERO
     }
 }
 

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -218,9 +218,13 @@ pub fn block_convert(
                     .unique()
                     .into_iter()
                     .map(|code_hash| {
-                        let bytecode =
-                            Bytecode::new(code_db.0.get(&code_hash).cloned().unwrap_or_default());
-                        (bytecode.hash, bytecode)
+                        let bytes = code_db
+                            .0
+                            .get(&code_hash)
+                            .cloned()
+                            .expect("code db should has contain the code");
+                        let hash = Word::from_big_endian(code_hash.as_bytes());
+                        (hash, Bytecode { hash, bytes })
                     })
             })
             .collect(),

--- a/zkevm-circuits/src/witness/bytecode.rs
+++ b/zkevm-circuits/src/witness/bytecode.rs
@@ -1,6 +1,5 @@
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian, Word};
-use sha3::{Digest, Keccak256};
 
 use crate::{evm_circuit::util::RandomLinearCombination, table::BytecodeFieldTag};
 
@@ -14,12 +13,6 @@ pub struct Bytecode {
 }
 
 impl Bytecode {
-    /// Construct from bytecode bytes
-    pub fn new(bytes: Vec<u8>) -> Self {
-        let hash = Word::from_big_endian(Keccak256::digest(&bytes).as_slice());
-        Self { hash, bytes }
-    }
-
     /// Assignments for bytecode table
     pub fn table_assignments<F: Field>(&self, randomness: F) -> Vec<[F; 5]> {
         let n = 1 + self.bytes.len();
@@ -53,11 +46,5 @@ impl Bytecode {
             ])
         }
         rows
-    }
-}
-
-impl From<&eth_types::bytecode::Bytecode> for Bytecode {
-    fn from(b: &eth_types::bytecode::Bytecode) -> Self {
-        Bytecode::new(b.to_vec())
     }
 }


### PR DESCRIPTION
This PR enable user who create block witness to custom the codehash method via a `CodeDB` object.

User now can call `CodeDB::new_with_code_hasher` with a custom hasher object to calculate the hash of codes. The circuit would respect this hasher and its calcultation for codehash.

It enable us inducing poseidon (or other hashing schemes) for codehash externally, without induce too much detail into zkevm's code repo. The evm's codehash scheme (keccak256) would be retained by default so nothing would be broken.