### PR TITLE
[don't-merge] fix: ignore CI actions when target is `main` branch (source is `scroll-stable`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI checks
 on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    # Ignore when target branch is `main` and source branch is scroll-stable.
+    # It could avoid running twice. Since scroll-stable is set as `push` below.
+    branches-ignore:
+      - main
   push:
     branches:
       - scroll-stable

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,10 @@ name: Integration Tests
 on:
   pull_request:
     types: [synchronize, labeled]
+    # Ignore when target branch is `main` and source branch is scroll-stable.
+    # It could avoid running twice. Since scroll-stable is set as `push` below.
+    branches-ignore:
+      - main
   push:
     branches:
       - scroll-stable

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -4,6 +4,10 @@ name: Lints
 on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    # Ignore when target branch is `main` and source branch is scroll-stable.
+    # It could avoid running twice. Since scroll-stable is set as `push` below.
+    branches-ignore:
+      - main
   push:
     branches:
       - scroll-stable


### PR DESCRIPTION
Ignore CI when target branch is `main` and source branch is `scroll-stable`. It could avoid running CI twice. Since `scroll-stable` is set as `push` to activate CI.