### PR TITLE
CI: delete previous cached Go folder to fix conflict in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI checks
 
-
 on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI checks
 
+
 on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
@@ -41,12 +42,12 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@v3
         with:
+          cache: false
           go-version: ~1.18
       # https://github.com/actions/cache/issues/133#issuecomment-599102035
       - name: Change cached dir owner
         run: |
-          [ -d ~/.cache/go-build ] && sudo chown -R $(whoami):$(id -ng) ~/.cache/go-build
-          [ -d ~/go/pkg/mod ] && sudo chown -R $(whoami):$(id -ng) ~/go/pkg/mod
+          [ -d ~/go/pkg/mod/ ] && sudo rm -rf ~/go/pkg/mod/*
           [ -d ~/.cargo/ ] && sudo chown -R $(whoami):$(id -ng) ~/.cargo/
       # Go cache for building geth-utils
       - name: Go cache
@@ -101,8 +102,7 @@ jobs:
       # https://github.com/actions/cache/issues/133#issuecomment-599102035
       - name: Change cached dir owner
         run: |
-          [ -d ~/.cache/go-build ] && sudo chown -R $(whoami):$(id -ng) ~/.cache/go-build
-          [ -d ~/go/pkg/mod ] && sudo chown -R $(whoami):$(id -ng) ~/go/pkg/mod
+          [ -d ~/go/pkg/mod/ ] && sudo rm -rf ~/go/pkg/mod/*
           [ -d ~/.cargo/ ] && sudo chown -R $(whoami):$(id -ng) ~/.cargo/
       # Go cache for building geth-utils
       - name: Go cache
@@ -150,8 +150,7 @@ jobs:
       # https://github.com/actions/cache/issues/133#issuecomment-599102035
       - name: Change cached dir owner
         run: |
-          [ -d ~/.cache/go-build ] && sudo chown -R $(whoami):$(id -ng) ~/.cache/go-build
-          [ -d ~/go/pkg/mod ] && sudo chown -R $(whoami):$(id -ng) ~/go/pkg/mod
+          [ -d ~/go/pkg/mod/ ] && sudo rm -rf ~/go/pkg/mod/*
           [ -d ~/.cargo/ ] && sudo chown -R $(whoami):$(id -ng) ~/.cargo/
       # Go cache for building geth-utils
       - name: Go cache
@@ -194,8 +193,7 @@ jobs:
       # https://github.com/actions/cache/issues/133#issuecomment-599102035
       - name: Change cached dir owner
         run: |
-          [ -d ~/.cache/go-build ] && sudo chown -R $(whoami):$(id -ng) ~/.cache/go-build
-          [ -d ~/go/pkg/mod ] && sudo chown -R $(whoami):$(id -ng) ~/go/pkg/mod
+          [ -d ~/go/pkg/mod/ ] && sudo rm -rf ~/go/pkg/mod/*
           [ -d ~/.cargo/ ] && sudo chown -R $(whoami):$(id -ng) ~/.cargo/
       # Go cache for building geth-utils
       - name: Go cache
@@ -244,8 +242,7 @@ jobs:
       # https://github.com/actions/cache/issues/133#issuecomment-599102035
       - name: Change cached dir owner
         run: |
-          [ -d ~/.cache/go-build ] && sudo chown -R $(whoami):$(id -ng) ~/.cache/go-build
-          [ -d ~/go/pkg/mod ] && sudo chown -R $(whoami):$(id -ng) ~/go/pkg/mod
+          [ -d ~/go/pkg/mod/ ] && sudo rm -rf ~/go/pkg/mod/*
           [ -d ~/.cargo/ ] && sudo chown -R $(whoami):$(id -ng) ~/.cargo/
       # Go cache for building geth-utils
       - name: Go cache

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,8 +55,7 @@ jobs:
       # https://github.com/actions/cache/issues/133#issuecomment-599102035
       - name: Change cached dir owner
         run: |
-          [ -d ~/.cache/go-build ] && sudo chown -R $(whoami):$(id -ng) ~/.cache/go-build
-          [ -d ~/go/pkg/mod ] && sudo chown -R $(whoami):$(id -ng) ~/go/pkg/mod
+          [ -d ~/go/pkg/mod/ ] && sudo rm -rf ~/go/pkg/mod/*
           [ -d ~/.cargo/ ] && sudo chown -R $(whoami):$(id -ng) ~/.cargo/
       # Go cache for building geth-utils
       - name: Go cache

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -29,8 +29,7 @@ jobs:
       # https://github.com/actions/cache/issues/133#issuecomment-599102035
       - name: Change cached dir owner
         run: |
-          [ -d ~/.cache/go-build ] && sudo chown -R $(whoami):$(id -ng) ~/.cache/go-build
-          [ -d ~/go/pkg/mod ] && sudo chown -R $(whoami):$(id -ng) ~/go/pkg/mod
+          [ -d ~/go/pkg/mod/ ] && sudo rm -rf ~/go/pkg/mod/*
           [ -d ~/.cargo/ ] && sudo chown -R $(whoami):$(id -ng) ~/.cargo/
       # Go cache for building geth-utils
       - name: Go cache


### PR DESCRIPTION
Delete previous cached Go folder (try to restore from cache) in CI.