### PR TITLE
[WIP] Induce zktrie circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 [[package]]
 name = "halo2-mpt-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0111#723309fb71ef83b87aa1a908bc8e50cb14c4a64e"
+source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0111#222cd0e73acdd0c339f686fc59e5427cbca1b1c8"
 dependencies = [
  "halo2_proofs",
  "hex",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0111#f1cc833b70841b43a7914cb0ec3b7dceed1c8ef6"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0111#a9ec2633504ac48460b5a72d6d889ae18d55c393"
 dependencies = [
  "bitvec 0.22.3",
  "halo2_proofs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,9 +3285,12 @@ dependencies = [
  "eth-types",
  "halo2-mpt-circuits",
  "halo2_proofs",
+ "hex",
  "lazy_static",
  "log",
  "num-bigint",
+ "serde",
+ "serde_json",
  "zktrie",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,14 +302,26 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+dependencies = [
+ "funty 1.2.0",
+ "radium 0.6.2",
+ "tap",
+ "wyz 0.4.0",
+]
+
+[[package]]
+name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty",
+ "funty 2.0.0",
  "radium 0.7.0",
  "tap",
- "wyz",
+ "wyz 0.5.1",
 ]
 
 [[package]]
@@ -2165,6 +2177,11 @@ dependencies = [
 
 [[package]]
 name = "funty"
+version = "1.2.0"
+source = "git+https://github.com/ferrilab/funty/?rev=7ef0d890fbcd8b3def1635ac1a877fc298488446#7ef0d890fbcd8b3def1635ac1a877fc298488446"
+
+[[package]]
+name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
@@ -2435,6 +2452,22 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "halo2-mpt-circuits"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0111#723309fb71ef83b87aa1a908bc8e50cb14c4a64e"
+dependencies = [
+ "halo2_proofs",
+ "hex",
+ "lazy_static",
+ "num-bigint",
+ "poseidon-circuit",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "halo2_proofs"
@@ -3244,6 +3277,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpt-zktrie"
+version = "0.1.0"
+dependencies = [
+ "bus-mapping",
+ "env_logger",
+ "eth-types",
+ "halo2-mpt-circuits",
+ "halo2_proofs",
+ "lazy_static",
+ "log",
+ "num-bigint",
+ "zktrie",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3834,6 +3882,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poseidon-circuit"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0111#f1cc833b70841b43a7914cb0ec3b7dceed1c8ef6"
+dependencies = [
+ "bitvec 0.22.3",
+ "halo2_proofs",
+ "lazy_static",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,6 +4045,12 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -6323,6 +6388,15 @@ dependencies = [
 
 [[package]]
 name = "wyz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
@@ -6394,6 +6468,7 @@ dependencies = [
  "log",
  "maingate",
  "mock",
+ "mpt-zktrie",
  "num",
  "num-bigint",
  "pretty_assertions",
@@ -6406,4 +6481,12 @@ dependencies = [
  "strum",
  "strum_macros",
  "subtle",
+]
+
+[[package]]
+name = "zktrie"
+version = "0.1.1"
+source = "git+https://github.com/scroll-tech/zktrie.git?branch=dev-1102#f7ba2ca825f087ecba2240daacc63e2ee166e1e4"
+dependencies = [
+ "gobuild",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "bus-mapping",
     "geth-utils",
     "keccak256",
+    "zktrie",
     "gadgets",
     "integration-tests",
     "circuit-benchmarks",
@@ -12,8 +13,13 @@ members = [
     "mock",
 ]
 
+[patch.crates-io]
+# temporary solution to funty@1.2.0 being yanked, tracking issue: https://github.com/ferrilab/funty/issues/7
+funty = { git = "https://github.com/ferrilab/funty/", rev = "7ef0d890fbcd8b3def1635ac1a877fc298488446" }
+
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-1220" }
+
 
 # Definition of benchmarks profile to use.
 [profile.bench]

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -24,6 +24,7 @@ rand_xorshift = "0.3"
 rand = "0.8"
 itertools = "0.10.3"
 lazy_static = "1.4"
+mpt-zktrie = { path = "../zktrie" }
 keccak256 = { path = "../keccak256"}
 log = "0.4"
 env_logger = "0.9"

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -22,6 +22,7 @@ pub mod copy_circuit;
 pub mod evm_circuit;
 pub mod exp_circuit;
 pub mod keccak_circuit;
+pub mod mpt_circuit;
 pub mod pi_circuit;
 pub mod rlp_circuit;
 pub mod state_circuit;

--- a/zkevm-circuits/src/mpt_circuit.rs
+++ b/zkevm-circuits/src/mpt_circuit.rs
@@ -1,0 +1,109 @@
+//! wrapping of mpt-circuit
+use crate::{
+    table::{PoseidonTable, MptTable},
+    util::{Challenges, Expr, SubCircuit, SubCircuitConfig},
+    witness::{self, MptUpdates, Rw, RwMap},
+};
+use mpt_zktrie::{EthTrie, EthTrieConfig, EthTrieCircuit, operation::AccountOp};
+use mpt_zktrie::hash::Hashable;
+use eth_types::{Address, Field};
+use halo2_proofs::{
+    circuit::{Layouter, Region, SimpleFloorPlanner, Value},
+    plonk::{ConstraintSystem, Error, Expression},
+};
+
+/// re-wrapping for mpt circuit
+#[derive(Default, Clone)]
+pub struct MptCircuit<F: Field> (EthTrieCircuit<F, false>);
+
+/// Circuit configuration argumen ts
+pub struct MptCircuitConfigArgs<F: Field> {
+    /// PoseidonTable
+    pub poseidon_table: PoseidonTable,
+    /// MptTable
+    pub mpt_table: MptTable,
+    /// Challenges
+    pub challenges: Challenges<Expression<F>>,     
+}
+
+/// re-wrapping for mpt config
+pub struct MptCircuitConfig (EthTrieConfig);
+
+impl<F: Field> SubCircuitConfig<F> for MptCircuitConfig {
+    type ConfigArgs = MptCircuitConfigArgs<F>;
+
+    fn new(
+        meta: &mut ConstraintSystem<F>,
+        Self::ConfigArgs {
+            poseidon_table,
+            mpt_table,
+            challenges,
+        }: Self::ConfigArgs,
+    ) -> Self {
+
+        let conf = EthTrieConfig::configure_sub(
+            meta, 
+            mpt_table.0, 
+            poseidon_table.0,
+            challenges.evm_word(),
+        );
+        Self(conf)
+    }
+}
+
+#[cfg(any(feature = "test", test))]
+impl<F: Field + Hashable> SubCircuit<F> for MptCircuit<F> {
+    type Config = MptCircuitConfig;
+
+    fn new_from_block(block: &witness::Block<F>) -> Self {
+
+        let rows = block.rws.table_assignments();
+        let (_, traces, tips) = MptUpdates::construct(
+            rows.as_slice(), 
+            block.mpt_state.as_ref().expect("need block with trie state"),
+        );
+        let mut eth_trie : EthTrie<F> = Default::default();
+        eth_trie.add_ops(traces.iter().map(|tr|AccountOp::try_from(tr).unwrap()));
+        let (circuit, _) = eth_trie.to_circuits((block.circuits_params.max_rws, None), tips.as_slice());
+        MptCircuit(circuit)
+    }
+
+    fn min_num_rows_block(block: &witness::Block<F>) -> usize {
+        let rows = block.rws.table_assignments();
+        let (_, traces, _) = MptUpdates::construct(
+            rows.as_slice(), 
+            block.mpt_state.as_ref().expect("need block with trie state"),
+        );
+        let mut eth_trie : EthTrie<F> = Default::default();
+        eth_trie.add_ops(traces.iter().map(|tr|AccountOp::try_from(tr).unwrap()));
+        let (mpt_rows, _) = eth_trie.use_rows();
+        mpt_rows
+    }
+
+    /// Make the assignments to the MptCircuit
+    fn synthesize_sub(
+        &self,
+        config: &Self::Config,
+        challenges: &Challenges<Value<F>>,
+        layouter: &mut impl Layouter<F>,
+    ) -> Result<(), Error> {
+
+        config.0.load_mpt_table(
+            layouter, 
+            challenges.evm_word().inner, 
+            self.0.ops.as_slice(), 
+            self.0.mpt_table.iter().copied(), 
+            self.0.calcs)?;
+        config.0.synthesize_core(
+            layouter, 
+            self.0.ops.as_slice(), 
+            self.0.calcs
+        )
+
+    }
+    
+    /// powers of randomness for instance columns
+    fn instance(&self) -> Vec<Vec<F>> {
+        vec![]
+    }    
+}

--- a/zkevm-circuits/src/mpt_circuit.rs
+++ b/zkevm-circuits/src/mpt_circuit.rs
@@ -69,7 +69,7 @@ impl<F: Field + Hashable> SubCircuit<F> for MptCircuit<F> {
         MptCircuit(circuit)
     }
 
-    fn min_num_rows_block(block: &witness::Block<F>) -> usize {
+    fn min_num_rows_block(block: &witness::Block<F>) -> (usize, usize) {
         let rows = block.rws.table_assignments();
         let (_, traces, _) = MptUpdates::construct(
             rows.as_slice(), 
@@ -78,7 +78,7 @@ impl<F: Field + Hashable> SubCircuit<F> for MptCircuit<F> {
         let mut eth_trie : EthTrie<F> = Default::default();
         eth_trie.add_ops(traces.iter().map(|tr|AccountOp::try_from(tr).unwrap()));
         let (mpt_rows, _) = eth_trie.use_rows();
-        mpt_rows
+        (mpt_rows, block.circuits_params.max_rws.max(mpt_rows))
     }
 
     /// Make the assignments to the MptCircuit, notice it fill mpt table

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -365,6 +365,8 @@ impl<
             &challenges,
         )?;
 
+        // TODO: if we have mpt circuit, mpt table should be assigned within it
+        // rather than being loaded externally
         config.mpt_table.load(
             &mut layouter,
             &MptUpdates::mock_from(rws),

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -553,7 +553,7 @@ impl From<AccountFieldTag> for ProofType {
 
 /// The MptTable shared between MPT Circuit and State Circuit
 #[derive(Clone, Copy, Debug)]
-pub struct MptTable([Column<Advice>; 7]);
+pub struct MptTable(pub [Column<Advice>; 7]);
 
 impl DynamicTableColumns for MptTable {
     fn columns(&self) -> Vec<Column<Advice>> {
@@ -604,6 +604,60 @@ impl MptTable {
         Ok(())
     }
 }
+
+
+/// The Poseidon hash table shared between Hash Circuit, Mpt Circuit and Bytecode Circuit
+#[derive(Clone, Copy, Debug)]
+pub struct PoseidonTable(pub [Column<Advice>; 4]);
+
+impl DynamicTableColumns for PoseidonTable {
+    fn columns(&self) -> Vec<Column<Advice>> {
+        self.0.to_vec()
+    }
+}
+
+impl PoseidonTable {
+    /// Construct a new PoseidonTable
+    pub(crate) fn construct<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+        Self([0; 4].map(|_| meta.advice_column()))
+    }
+
+    pub(crate) fn assign<F: Field>(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        row: &[Value<F>],
+    ) -> Result<(), Error> {
+        for (column, value) in self.0.iter().zip_eq(row) {
+            region.assign_advice(|| "assign mpt table row value", *column, offset, || *value)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn load<'d, F: Field>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        hashes: impl Iterator<Item=&'d [Value<F>]> + Clone,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "mpt table",
+            |mut region| self.load_with_region(&mut region, hashes.clone()),
+        )
+    }
+
+    pub(crate) fn load_with_region<'d, F: Field>(
+        &self,
+        region: &mut Region<'_, F>,
+        hashes: impl Iterator<Item=&'d [Value<F>]>,
+    ) -> Result<(), Error> {
+        self.assign(region, 0, [Value::known(F::zero()); 7].as_slice())?;
+        for (offset, row) in hashes.enumerate() {
+            self.assign(region, offset + 1, row)?;
+        }
+        Ok(())
+    }
+}
+
 
 /// Tag to identify the field in a Bytecode Table row
 #[derive(Clone, Copy, Debug)]

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -11,7 +11,7 @@ use eth_types::{Address, Field, ToLittleEndian, ToScalar, Word};
 
 use halo2_proofs::circuit::Value;
 
-use super::{step::step_convert, tx::tx_convert, Bytecode, ExecStep, RwMap, Transaction};
+use super::{step::step_convert, tx::tx_convert, Bytecode, ExecStep, RwMap, Transaction, mpt::ZktrieState as MptState};
 use crate::util::{Challenges, DEFAULT_RAND};
 
 // TODO: Remove fields that are duplicated in`eth_block`
@@ -36,6 +36,8 @@ pub struct Block<F> {
     pub bytecodes: HashMap<Word, Bytecode>,
     /// The block context
     pub context: BlockContexts,
+    /// The init state of mpt
+    pub mpt_state: Option<MptState>,
     /// Copy events for the copy circuit's table.
     pub copy_events: Vec<CopyEvent>,
     /// Exponentiation traces for the exponentiation circuit's table.
@@ -109,6 +111,7 @@ pub struct BlockContext {
 }
 
 impl BlockContext {
+
     /// Assignments for block table
     pub fn table_assignments<F: Field>(
         &self,
@@ -256,6 +259,7 @@ pub fn block_convert<F: Field>(
     Ok(Block {
         randomness: F::from_u128(DEFAULT_RAND),
         context: block.into(),
+        mpt_state: None,
         rws: RwMap::from(&block.container),
         txs: block
             .txs()
@@ -297,4 +301,11 @@ pub fn block_convert<F: Field>(
         prev_state_root: block.prev_state_root,
         keccak_inputs: circuit_input_builder::keccak_inputs(block, code_db)?,
     })
+}
+
+/// Attach witness block with mpt states
+pub fn block_attach_mpt_state<F: Field>(mut block: Block<F>, mpt_state: MptState) -> Block<F> {
+
+    block.mpt_state.replace(mpt_state);
+    block
 }

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -1,9 +1,12 @@
 use crate::evm_circuit::{util::RandomLinearCombination, witness::Rw};
 use crate::table::{AccountFieldTag, ProofType};
-use eth_types::{Address, Field, ToLittleEndian, ToScalar, Word};
+use eth_types::{Address, Field, ToLittleEndian, ToScalar, Word, U256};
 use halo2_proofs::circuit::Value;
 use itertools::Itertools;
 use std::collections::BTreeMap;
+use mpt_zktrie::{state, serde::SMTTrace, MPTProofType};
+
+pub use state::ZktrieState;
 
 /// An MPT update whose validility is proved by the MptCircuit
 #[derive(Debug, Clone, Copy)]
@@ -42,6 +45,52 @@ pub struct MptUpdateRow<F>(pub(crate) [F; 7]);
 impl MptUpdates {
     pub(crate) fn get(&self, row: &Rw) -> Option<MptUpdate> {
         key(row).map(|key| *self.0.get(&key).expect("missing key in mpt updates"))
+    }
+
+    pub(crate) fn construct(rows: &[Rw], init_trie: &ZktrieState) -> (Self, Vec<SMTTrace>, Vec<MPTProofType>) {
+
+        use state::witness::WitnessGenerator;
+
+        let mut update_without_root = Self::mock_from(rows);
+
+        let mut wit_gen = WitnessGenerator::from(init_trie);
+        let mut smt_traces = Vec::new();
+        let mut tips = Vec::new();
+
+        for (key, update) in &mut update_without_root.0 {
+            let proof_tip = state::as_proof_type(
+                match key {
+                    Key::AccountStorage { .. } => {
+                        if update.old_value.is_zero() && update.new_value.is_zero() {
+                            ProofType::StorageDoesNotExist as i32
+                        } else {
+                            ProofType::StorageChanged as i32
+                        } 
+                    }
+                    Key::Account { field_tag, .. } => *field_tag as i32,
+                }
+            );
+            let smt_trace = wit_gen.handle_new_state(
+                proof_tip,
+                match key {
+                    Key::Account { address, .. } | Key::AccountStorage { address, .. } => *address,
+                },
+                update.new_value,
+                update.old_value,
+                match key {
+                    Key::Account { .. } => None,
+                    Key::AccountStorage { storage_key, .. } => Some(*storage_key),
+                }
+            );
+            update.old_root = U256::from_little_endian(smt_trace.account_path[0].root.as_ref());
+            update.new_root = U256::from_little_endian(smt_trace.account_path[1].root.as_ref());
+            smt_traces.push(smt_trace);
+            tips.push(proof_tip);
+            
+        }
+
+        let updates = update_without_root;
+        (updates, smt_traces, tips)
     }
 
     pub(crate) fn mock_from(rows: &[Rw]) -> Self {
@@ -137,6 +186,7 @@ enum Key {
 }
 
 impl Key {
+    
     fn address<F: Field>(&self) -> F {
         match self {
             Self::Account { address, .. } | Self::AccountStorage { address, .. } => {

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -15,7 +15,12 @@ eth-types = { path = "../eth-types" }
 lazy_static = "1.4"
 num-bigint = { version = "0.4" }
 log = "0.4"
+
+[dev-dependencies]
 env_logger = "0.9"
+serde = {version = "1", features = ["derive"] }
+serde_json = "1"
+hex = "0.4"
 
 [features]
 default = []

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mpt-zktrie"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0111" }
+zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "dev-1102" }
+bus-mapping = { path = "../bus-mapping" }
+eth-types = { path = "../eth-types" }
+lazy_static = "1.4"
+num-bigint = { version = "0.4" }
+log = "0.4"
+env_logger = "0.9"
+
+[features]
+default = []

--- a/zktrie/src/lib.rs
+++ b/zktrie/src/lib.rs
@@ -1,0 +1,22 @@
+//! mpt-zktrie circuits and utils
+//
+#![deny(missing_docs)]
+
+pub use mpt_circuits::MPTProofType;
+pub use mpt_circuits::EthTrie;
+pub use mpt_circuits::EthTrieConfig;
+pub use mpt_circuits::EthTrieCircuit;
+pub use mpt_circuits::operation;
+pub use mpt_circuits::serde;
+
+/// the hash scheme (poseidon) used by mpt-zktrie 
+pub mod hash {
+    pub use mpt_circuits::HashCircuit;
+    pub use mpt_circuits::hash::Hashable;
+}
+
+//pub use mpt_circuits::hash;
+//use mpt_circuits::{hash::Hashable, operation::AccountOp, EthTrie, EthTrieCircuit, HashCircuit, MPTProofType};
+
+/// the state modules include structures represent zktrie and witness generator
+pub mod state;

--- a/zktrie/src/lib.rs
+++ b/zktrie/src/lib.rs
@@ -2,21 +2,22 @@
 //
 #![deny(missing_docs)]
 
-pub use mpt_circuits::MPTProofType;
-pub use mpt_circuits::EthTrie;
-pub use mpt_circuits::EthTrieConfig;
-pub use mpt_circuits::EthTrieCircuit;
 pub use mpt_circuits::operation;
 pub use mpt_circuits::serde;
+pub use mpt_circuits::EthTrie;
+pub use mpt_circuits::EthTrieCircuit;
+pub use mpt_circuits::EthTrieConfig;
+pub use mpt_circuits::MPTProofType;
 
-/// the hash scheme (poseidon) used by mpt-zktrie 
+/// the hash scheme (poseidon) used by mpt-zktrie
 pub mod hash {
-    pub use mpt_circuits::HashCircuit;
     pub use mpt_circuits::hash::Hashable;
+    pub use mpt_circuits::HashCircuit;
 }
 
 //pub use mpt_circuits::hash;
-//use mpt_circuits::{hash::Hashable, operation::AccountOp, EthTrie, EthTrieCircuit, HashCircuit, MPTProofType};
+//use mpt_circuits::{hash::Hashable, operation::AccountOp, EthTrie,
+// EthTrieCircuit, HashCircuit, MPTProofType};
 
 /// the state modules include structures represent zktrie and witness generator
 pub mod state;

--- a/zktrie/src/state.rs
+++ b/zktrie/src/state.rs
@@ -1,22 +1,21 @@
 //! Represent the storage state under zktrie as implement
 
-use bus_mapping::state_db::StateDB;
-//use eth_types::Word;
-use eth_types::{Address, Bytes, Hash};
+use bus_mapping::state_db::{Account, StateDB};
+use eth_types::{Address, Hash, Word, H256, U256};
 use mpt_circuits::MPTProofType;
 
-pub use zktrie::{ZkMemoryDb, ZkTrie, ZkTrieNode, Hash as ZkTrieHash};
 use std::collections::HashMap;
+use std::io::Error;
+pub use zktrie::{Hash as ZkTrieHash, ZkMemoryDb, ZkTrie, ZkTrieNode};
 
-pub mod witness;
 pub mod builder;
+pub mod witness;
 
-use std::{rc::Rc, cell::RefCell};
 use std::fmt;
+use std::{cell::RefCell, rc::Rc};
 
 /// turn a integer (expressed by field) into MPTProofType
 pub fn as_proof_type(v: i32) -> MPTProofType {
-
     match v {
         1 => MPTProofType::NonceChanged,
         2 => MPTProofType::BalanceChanged,
@@ -29,7 +28,6 @@ pub fn as_proof_type(v: i32) -> MPTProofType {
     }
 }
 
-
 /// represent a storage state being applied in specified block
 #[derive(Clone, Default)]
 pub struct ZktrieState {
@@ -41,37 +39,111 @@ pub struct ZktrieState {
 
 impl fmt::Debug for ZktrieState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ZktrieState: {{sdb: {:?}, trie: {:x?}, accounts: {:?}}}", self.sdb, self.trie_root, self.accounts.keys())
+        write!(
+            f,
+            "ZktrieState: {{sdb: {:?}, trie: {:x?}, accounts: {:?}}}",
+            self.sdb,
+            self.trie_root,
+            self.accounts.keys()
+        )
     }
 }
 
 impl ZktrieState {
+    /// help to query account data
+    pub fn state(&self) -> &StateDB {
+        &self.sdb
+    }
+
     /// construct from external data
     pub fn construct<'d>(
         sdb: StateDB,
         state_root: Hash,
-        proofs: impl IntoIterator<Item=&'d Bytes>,
-        acc_storage_roots: impl IntoIterator<Item=(&'d Address, &'d Hash)>,
+        proofs: impl IntoIterator<Item = &'d [u8]>,
+        acc_storage_roots: impl IntoIterator<Item = (Address, Hash)>,
     ) -> Self {
+        assert!(
+            *builder::HASH_SCHEME_DONE,
+            "must set hash scheme into zktrie"
+        );
 
         let mut zk_db = ZkMemoryDb::default();
         for bytes in proofs {
-            zk_db.add_node_bytes(bytes.as_ref()).unwrap();
+            zk_db.add_node_bytes(bytes).unwrap();
         }
 
-        let accounts = acc_storage_roots.into_iter()
-            .map(|(addr_r, hash_r)|(*addr_r, hash_r.0))
+        let accounts = acc_storage_roots
+            .into_iter()
+            .map(|(addr_r, hash_r)| (addr_r, hash_r.0))
             .collect();
-        
+
         Self {
             sdb,
             zk_db: Rc::new(RefCell::new(zk_db)),
             trie_root: state_root.0,
             accounts,
         }
-
     }
 
+    /// construct from external data
+    pub fn from_trace<'d, BYTES>(
+        state_root: Hash,
+        account_proofs: impl Iterator<Item = (&'d Address, BYTES)> + Clone,
+        storage_proofs: impl Iterator<Item = (&'d Address, &'d Word, BYTES)> + Clone,
+    ) -> Result<Self, Error>
+    where
+        BYTES: IntoIterator<Item = &'d [u8]>,
+    {
+        use builder::{AccountProof, BytesArray, StorageProof};
 
+        let mut sdb = StateDB::new();
+        let mut acc_storage_roots: HashMap<Address, Hash> = Default::default();
 
+        let proofs = account_proofs
+            .clone()
+            .flat_map(|(_, bytes)| bytes)
+            .chain(storage_proofs.clone().flat_map(|(_, _, bytes)| bytes));
+
+        for (addr, bytes) in account_proofs {
+            let acc_proof = builder::verify_proof_leaf(
+                AccountProof::try_from(BytesArray(bytes.into_iter()))?,
+                &builder::extend_address_to_h256(addr),
+            );
+            if acc_proof.key.is_some() {
+                let acc_data = acc_proof.data;
+                sdb.set_account(
+                    addr,
+                    Account {
+                        nonce: U256::from(acc_data.nonce),
+                        balance: acc_data.balance,
+                        code_hash: acc_data.code_hash,
+                        storage: Default::default(),
+                    },
+                );
+
+                acc_storage_roots.insert(*addr, acc_data.storage_root);
+            } else {
+                sdb.set_account(addr, Account::zero());
+                acc_storage_roots.insert(*addr, H256::zero());
+            }
+        }
+
+        for (addr, key, bytes) in storage_proofs {
+            let (_, acc) = sdb.get_account_mut(addr);
+            let mut key_buf = [0u8; 32];
+            key.to_big_endian(key_buf.as_mut_slice());
+            let store_proof = builder::verify_proof_leaf(
+                StorageProof::try_from(BytesArray(bytes.into_iter()))?,
+                &key_buf,
+            );
+            if store_proof.key.is_some() {
+                acc.storage.insert(*key, *store_proof.data.as_ref());
+            }
+        }
+
+        Ok(Self::construct(sdb, state_root, proofs, acc_storage_roots))
+    }
 }
+
+#[cfg(any(feature = "test", test))]
+mod test;

--- a/zktrie/src/state.rs
+++ b/zktrie/src/state.rs
@@ -1,0 +1,77 @@
+//! Represent the storage state under zktrie as implement
+
+use bus_mapping::state_db::StateDB;
+//use eth_types::Word;
+use eth_types::{Address, Bytes, Hash};
+use mpt_circuits::MPTProofType;
+
+pub use zktrie::{ZkMemoryDb, ZkTrie, ZkTrieNode, Hash as ZkTrieHash};
+use std::collections::HashMap;
+
+pub mod witness;
+pub mod builder;
+
+use std::{rc::Rc, cell::RefCell};
+use std::fmt;
+
+/// turn a integer (expressed by field) into MPTProofType
+pub fn as_proof_type(v: i32) -> MPTProofType {
+
+    match v {
+        1 => MPTProofType::NonceChanged,
+        2 => MPTProofType::BalanceChanged,
+        3 => MPTProofType::CodeHashExists,
+        4 => MPTProofType::AccountDoesNotExist,
+        5 => MPTProofType::AccountDestructed,
+        6 => MPTProofType::StorageChanged,
+        7 => MPTProofType::StorageDoesNotExist,
+        _ => unreachable!("unexpected proof type number {:?}", v),
+    }
+}
+
+
+/// represent a storage state being applied in specified block
+#[derive(Clone, Default)]
+pub struct ZktrieState {
+    sdb: StateDB,
+    zk_db: Rc<RefCell<ZkMemoryDb>>,
+    trie_root: ZkTrieHash,
+    accounts: HashMap<Address, ZkTrieHash>,
+}
+
+impl fmt::Debug for ZktrieState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ZktrieState: {{sdb: {:?}, trie: {:x?}, accounts: {:?}}}", self.sdb, self.trie_root, self.accounts.keys())
+    }
+}
+
+impl ZktrieState {
+    /// construct from external data
+    pub fn construct<'d>(
+        sdb: StateDB,
+        state_root: Hash,
+        proofs: impl IntoIterator<Item=&'d Bytes>,
+        acc_storage_roots: impl IntoIterator<Item=(&'d Address, &'d Hash)>,
+    ) -> Self {
+
+        let mut zk_db = ZkMemoryDb::default();
+        for bytes in proofs {
+            zk_db.add_node_bytes(bytes.as_ref()).unwrap();
+        }
+
+        let accounts = acc_storage_roots.into_iter()
+            .map(|(addr_r, hash_r)|(*addr_r, hash_r.0))
+            .collect();
+        
+        Self {
+            sdb,
+            zk_db: Rc::new(RefCell::new(zk_db)),
+            trie_root: state_root.0,
+            accounts,
+        }
+
+    }
+
+
+
+}

--- a/zktrie/src/state/builder.rs
+++ b/zktrie/src/state/builder.rs
@@ -1,0 +1,311 @@
+//! utils for build state trie
+
+use eth_types::{Word, Address, Bytes, H256, U256, U64};
+use num_bigint::BigUint;
+use std::{
+    convert::TryFrom,
+    io::{Error, ErrorKind, Read},
+};
+
+
+const NODE_TYPE_MIDDLE: u8 = 0;
+const NODE_TYPE_LEAF: u8 = 1;
+const NODE_TYPE_EMPTY: u8 = 2;
+
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) struct AccountData {
+    pub nonce: u64,
+    pub balance: U256,
+    pub code_hash: H256,
+    pub storage_root: H256,
+}
+
+pub(crate) fn extend_address_to_h256(src: &Address) -> [u8; 32] {
+    let mut bts: Vec<u8> = src.as_bytes().into();
+    bts.resize(32, 0);
+    bts.as_slice().try_into().expect("32 bytes")
+}
+
+pub(crate) trait CanRead: Sized {
+    fn try_parse(rd: impl Read) -> Result<Self, Error>;
+    fn parse_leaf(data: &[u8]) -> Result<Self, Error> {
+        // notice the first 33 bytes has been read external
+        Self::try_parse(&data[33..])
+    }
+}
+
+impl CanRead for AccountData {
+    fn try_parse(mut rd: impl Read) -> Result<Self, Error> {
+        let mut uint_buf = [0; 4];
+        rd.read_exact(&mut uint_buf)?;
+        // check it is 0x04040000
+        if uint_buf != [4, 4, 0, 0] {
+            return Err(Error::new(ErrorKind::Other, "unexpected flags"));
+        }
+
+        let mut byte32_buf = [0; 32];
+        rd.read_exact(&mut byte32_buf)?; //nonce
+        let nonce = U64::from_big_endian(&byte32_buf[24..]);
+        rd.read_exact(&mut byte32_buf)?; //balance
+        let balance = U256::from_big_endian(&byte32_buf);
+        rd.read_exact(&mut byte32_buf)?; //codehash
+        let code_hash = H256::from(&byte32_buf);
+        rd.read_exact(&mut byte32_buf)?; //storage root, not need yet
+        let storage_root = H256::from(&byte32_buf);
+
+        Ok(AccountData {
+            nonce: nonce.as_u64(),
+            balance,
+            code_hash,
+            storage_root,
+        })
+    }
+}
+
+
+#[derive(Debug, Default, Clone)]
+struct StorageData(Word);
+
+impl AsRef<Word> for StorageData {
+    fn as_ref(&self) -> &Word {
+        &self.0
+    }
+}
+
+impl CanRead for StorageData {
+    fn try_parse(mut rd: impl Read) -> Result<Self, Error> {
+        let mut uint_buf = [0; 4];
+        rd.read_exact(&mut uint_buf)?;
+        // check it is 0x01010000
+        if uint_buf != [1, 1, 0, 0] {
+            return Err(Error::new(ErrorKind::Other, "unexpected flags"));
+        }
+        let mut byte32_buf = [0; 32];
+        rd.read_exact(&mut byte32_buf)?;
+        Ok(StorageData(Word::from(byte32_buf)))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TrieProof<T> {
+    pub data: T,
+    pub key: Option<H256>,
+    // the path from top to bottom, in (left child, right child) form
+    pub path: Vec<(U256, U256)>,
+}
+
+type AccountProof = TrieProof<AccountData>;
+type StorageProof = TrieProof<StorageData>;
+
+pub(crate) struct BytesArray<T> (pub T);
+
+impl<'d, T, BYTES> TryFrom<BytesArray<BYTES>> for TrieProof<T> 
+where
+    T : CanRead + Default,
+    BYTES: Iterator<Item= &'d [u8]>,
+{
+    type Error = Error;
+
+    fn try_from(src: BytesArray<BYTES>) -> Result<Self, Self::Error> {
+        let mut path: Vec<(U256, U256)> = Vec::new();
+        for data in src.0 {
+            let mut rd = data;
+            let mut prefix = [0; 1];
+            rd.read_exact(&mut prefix)?;
+            match prefix[0] {
+                NODE_TYPE_LEAF => {
+                    let mut byte32_buf = [0; 32];
+                    rd.read_exact(&mut byte32_buf)?;
+                    let key = H256::from(byte32_buf);
+                    let data = T::parse_leaf(data)?;
+                    return Ok(Self {
+                        key: Some(key),
+                        data,
+                        path,
+                    });
+                }
+                NODE_TYPE_EMPTY => {
+                    return Ok(Self {
+                        path,
+                        ..Default::default()
+                    });
+                }
+                NODE_TYPE_MIDDLE => {
+                    let mut buf: [u8; 32] = [0; 32];
+                    rd.read_exact(&mut buf)?;
+                    let left = U256::from_big_endian(&buf);
+                    rd.read_exact(&mut buf)?;
+                    let right = U256::from_big_endian(&buf);
+                    path.push((left, right));
+                }
+                _ => (),
+            }
+        }
+
+        Err(Error::new(ErrorKind::UnexpectedEof, "no leaf key found"))
+    }
+}
+
+
+impl<T : CanRead + Default> TryFrom<&[Bytes]> for TrieProof<T> 
+{
+    type Error = Error;
+    fn try_from(src: &[Bytes]) -> Result<Self, Self::Error> {
+        Self::try_from(BytesArray(src.iter().map(Bytes::as_ref)))
+    }
+}
+
+pub(crate) fn verify_proof_leaf<T: Default>(
+    inp: TrieProof<T>,
+    key_buf: &[u8; 32],
+) -> TrieProof<T> {
+    use halo2_proofs::halo2curves::bn256::Fr;
+    use halo2_proofs::arithmetic::FieldExt;
+    use mpt_circuits::hash::Hashable;
+
+    let first_16bytes: [u8; 16] = key_buf[..16].try_into().expect("expect first 16 bytes");
+    let last_16bytes: [u8; 16] = key_buf[16..].try_into().expect("expect last 16 bytes");
+
+    let bt_high = Fr::from_u128(u128::from_be_bytes(first_16bytes));
+    let bt_low = Fr::from_u128(u128::from_be_bytes(last_16bytes));
+
+    if let Some(key) = inp.key {
+        let rev_key_bytes: Vec<u8> = key.to_fixed_bytes().into_iter().rev().collect();
+        let key_fr = Fr::from_bytes(&rev_key_bytes.try_into().unwrap()).unwrap();
+
+        let secure_hash = Fr::hash([bt_high, bt_low]);
+
+        if key_fr == secure_hash {
+            inp
+        } else {
+            Default::default()
+        }
+    } else {
+        inp
+    }
+}
+
+
+/*
+pub fn build_statedb_and_codedb(blocks: &[BlockTrace]) -> Result<(StateDB, CodeDB), anyhow::Error> {
+    let mut sdb = StateDB::new();
+    let mut cdb =
+        CodeDB::new_with_code_hasher(Box::new(PoseidonCodeHash::new(POSEIDONHASH_BYTES_IN_FIELD)));
+
+    // step1: insert proof into statedb
+    for block in blocks.iter().rev() {
+        let storage_trace = &block.storage_trace;
+        if let Some(acc_proofs) = &storage_trace.proofs {
+            for (addr, acc) in acc_proofs.iter() {
+                let acc_proof: mpt::AccountProof = acc.as_slice().try_into()?;
+                let acc = verify_proof_leaf(acc_proof, &mpt::extend_address_to_h256(addr));
+                if acc.key.is_some() {
+                    // a valid leaf
+                    let (_, acc_mut) = sdb.get_account_mut(addr);
+                    acc_mut.nonce = acc.data.nonce.into();
+                    acc_mut.code_hash = acc.data.code_hash;
+                    acc_mut.balance = acc.data.balance;
+                } else {
+                    // it is essential to set it as default (i.e. not existed account data)
+                    sdb.set_account(
+                        addr,
+                        Account {
+                            nonce: Default::default(),
+                            balance: Default::default(),
+                            storage: HashMap::new(),
+                            code_hash: Default::default(),
+                        },
+                    );
+                }
+            }
+        }
+
+        for (addr, s_map) in storage_trace.storage_proofs.iter() {
+            let (found, acc) = sdb.get_account_mut(addr);
+            if !found {
+                log::error!("missed address in proof field show in storage: {:?}", addr);
+                continue;
+            }
+
+            for (k, val) in s_map {
+                let mut k_buf: [u8; 32] = [0; 32];
+                k.to_big_endian(&mut k_buf[..]);
+                let val_proof: mpt::StorageProof = val.as_slice().try_into()?;
+                let val = verify_proof_leaf(val_proof, &k_buf);
+
+                if val.key.is_some() {
+                    // a valid leaf
+                    acc.storage.insert(*k, *val.data.as_ref());
+                //                log::info!("set storage {:?} {:?} {:?}", addr, k, val.data);
+                } else {
+                    // add 0
+                    acc.storage.insert(*k, Default::default());
+                    //                log::info!("set empty storage {:?} {:?}", addr, k);
+                }
+            }
+        }
+
+        // step2: insert code into codedb
+        // notice empty codehash always kept as keccak256(nil)
+        cdb.insert(Vec::new());
+
+        for execution_result in &block.execution_results {
+            if let Some(bytecode) = &execution_result.byte_code {
+                if execution_result.account_created.is_none() {
+                    cdb.0.insert(
+                        execution_result
+                            .code_hash
+                            .ok_or_else(|| anyhow!("empty code hash in result"))?,
+                        decode_bytecode(bytecode)?.to_vec(),
+                    );
+                }
+            }
+
+            for step in execution_result.exec_steps.iter().rev() {
+                if let Some(data) = &step.extra_data {
+                    match step.op {
+                        OpcodeId::CALL
+                        | OpcodeId::CALLCODE
+                        | OpcodeId::DELEGATECALL
+                        | OpcodeId::STATICCALL => {
+                            let callee_code = data.get_code_at(1);
+                            trace_code(&mut cdb, step, &sdb, callee_code, 1);
+                        }
+                        OpcodeId::CREATE | OpcodeId::CREATE2 => {
+                            // notice we do not need to insert code for CREATE,
+                            // bustmapping do this job
+                        }
+                        OpcodeId::EXTCODESIZE | OpcodeId::EXTCODECOPY => {
+                            let code = data.get_code_at(0);
+                            trace_code(&mut cdb, step, &sdb, code, 0);
+                        }
+
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    // A temporary fix: zkgeth do not trace 0 address if it is only refered as coinbase
+    // (For it is not the "real" coinbase address in PoA) but would still refer it for
+    // other reasons (like being transferred or called), in the other way, busmapping
+    // seems always refer it as coinbase (?)
+    // here we just add it as unexisted account and consider fix it in zkgeth later (always
+    // record 0 addr inside storageTrace field)
+    let (zero_coinbase_exist, _) = sdb.get_account(&Default::default());
+    if !zero_coinbase_exist {
+        sdb.set_account(
+            &Default::default(),
+            Account {
+                nonce: Default::default(),
+                balance: Default::default(),
+                storage: HashMap::new(),
+                code_hash: Default::default(),
+            },
+        );
+    }
+
+    Ok((sdb, cdb))
+}
+ */

--- a/zktrie/src/state/test.rs
+++ b/zktrie/src/state/test.rs
@@ -1,0 +1,281 @@
+use super::*;
+use eth_types::{Bytes, Word};
+use log::{info, warn};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+type AccountTrieProofs = HashMap<Address, Vec<Bytes>>;
+type StorageTrieProofs = HashMap<Address, HashMap<Word, Vec<Bytes>>>;
+
+#[derive(Deserialize, Default, Debug, Clone)]
+struct StorageTrace {
+    #[serde(rename = "rootBefore")]
+    pub root_before: Hash,
+    #[serde(rename = "rootAfter")]
+    pub root_after: Hash,
+    pub proofs: Option<AccountTrieProofs>,
+    #[serde(rename = "storageProofs", default)]
+    pub storage_proofs: StorageTrieProofs,
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+struct BlockTrace {
+    #[serde(rename = "storageTrace")]
+    pub storage_trace: StorageTrace,
+}
+
+fn build_state_from_sample(sample_file: &str) -> (ZktrieState, Hash) {
+    let trace = serde_json::from_reader::<_, BlockTrace>(std::fs::File::open(sample_file).unwrap())
+        .unwrap()
+        .storage_trace;
+
+    (
+        ZktrieState::from_trace(
+            trace.root_before,
+            trace
+                .proofs
+                .unwrap()
+                .iter()
+                .map(|(k, bts)| (k, bts.iter().map(Bytes::as_ref))),
+            trace.storage_proofs.iter().flat_map(|(k, kv_map)| {
+                kv_map
+                    .iter()
+                    .map(move |(sk, bts)| (k, sk, bts.iter().map(Bytes::as_ref)))
+            }),
+        )
+        .unwrap(),
+        trace.root_after,
+    )
+}
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub(crate) static ref TEST_SAMPLE_STR: String =
+        { std::env::var("ZKTRIE_TEST_SAMPLE").unwrap_or_default() };
+}
+
+fn init() {
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
+#[test]
+fn deserialize_example1() {
+    let example = r#"
+    {
+        "rootBefore": "0x138e9434a520607da9e07013cdb82c3f832191d3bc2cd1b271b2ed9fa7a6a554",
+        "rootAfter": "0x24244ef5c8a7829b8c80d7c2dc7f32ef9b087541444ab5ea2b4f6f00557361a7",
+        "proofs": {
+            "0x0000000000000000000000000000000000000000": [
+                "0x00b50fa7ebcfbf879d2c87c30fa8da23205fec4876c05200c0211e27a330e9ca16444758a273fc0cfb23366a7a377630f0427fe495c9f78efbed9dc47a1e3f9e0e",
+                "0x009f673aa1dbc844b4d6ec60b57e617ede40d603158e71c02b94fed4127bfa5c02c913cad65a874081a2f409ab839f7bf87ac50ba44e76c7d99a538806fb379e04",
+                "0x008b4c8f5f6840f4a1366d6700d8f4ea9c4f331afd0232cca6f4c9437832269027166f08f09d830e962a2675968f7e75f95dd4953c750800ae11fc646e73e64722",
+                "0x013c6eff766107f2db0c4bf0ead086d4befa5d8675dcf54c50073efc389830fb060404000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000cc0a77f6e063b4b62eb7d9ed6f427cf687d8d0071d751850cfe5d136bc60d3ab12b6a6aca3814be9efdc6b17540f6e7bb06457e9102149aba975e2210fd3617a00",
+                "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+            ],
+            "0x4cb1aB63aF5D8931Ce09673EbD8ae2ce16fD6571": [
+                "0x00b50fa7ebcfbf879d2c87c30fa8da23205fec4876c05200c0211e27a330e9ca16444758a273fc0cfb23366a7a377630f0427fe495c9f78efbed9dc47a1e3f9e0e",
+                "0x0076a4691e1917894350a3b6b4d10c44aa94316e09692a37c678764b415de1021a537a6fac1254f68629734e6263e4d41e8d6ba08e0eba4e2317bad3b469159907",
+                "0x00ae72888fea2b0ee021bee3ae2e80f0a50b87a5a7966e98b29aa8770b7f485605a3d8fb602901f3cd49e1260c12d40e98607bd279b30164c708d668126345c829",
+                "0x00fbbed4358df764ff3a263c66df07b445abeaaf4ab50bddc2fd643f3512e02a1b6d8a9b9874fbccdb5b7890a8e46e5c5b987819a86cc4b9a642786181f62dda1f",
+                "0x000000000000000000000000000000000000000000000000000000000000000000e2591e8c149131c6df1ac04f9c0f54ff8db991eb80dff52b4b218cac31c1430b",
+                "0x0078c7b59d789c294f21339f0a872b81a418d6b24273fe959dc00126520917970dc63dba5cdc4a7aa1f0e97f4355d9caac51821d67463fa58cb89ffc53c1fe9f27",
+                "0x000000000000000000000000000000000000000000000000000000000000000000e6c0fdae5b43dd0b7edfd21803e8816e191138071fd2e1f7e42d92c5c19a592b",
+                "0x008ebbbd4b7d5ddd66149c1b9feeeaec862e8e489cb8c50409aaaf00de33310721a72c67edca1db779b38140aaee9baf382c96315f0884909da4a4a7480f3ab82d",
+                "0x017581e431a68d0fa641e14a7d29a6c2b150db6da1d13f59dee6f7f492a0bebd2904040000000000000000000000000000000000000000000000000000000000000000001b0056bc75e2d630fffffffffffffffffffffffffffffffffffff7a8e726dd7f67c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470000000000000000000000000000000000000000000000000000000000000000000",
+                "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+            ],
+            "0xe8D466681784504A8458d4EF34F141adaDA678Fe": [
+                "0x00b50fa7ebcfbf879d2c87c30fa8da23205fec4876c05200c0211e27a330e9ca16444758a273fc0cfb23366a7a377630f0427fe495c9f78efbed9dc47a1e3f9e0e",
+                "0x0076a4691e1917894350a3b6b4d10c44aa94316e09692a37c678764b415de1021a537a6fac1254f68629734e6263e4d41e8d6ba08e0eba4e2317bad3b469159907",
+                "0x00ae72888fea2b0ee021bee3ae2e80f0a50b87a5a7966e98b29aa8770b7f485605a3d8fb602901f3cd49e1260c12d40e98607bd279b30164c708d668126345c829",
+                "0x00fbbed4358df764ff3a263c66df07b445abeaaf4ab50bddc2fd643f3512e02a1b6d8a9b9874fbccdb5b7890a8e46e5c5b987819a86cc4b9a642786181f62dda1f",
+                "0x016d3e389f7dd8c147fe168ec3dfa575f588d5caee7bd4da9fd99c7ecf9cc5df000404000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000178763dea206ad5ecfbf211ddeb69d930d18811bc617cb4bbb0c0e7f0d28a3aa2739429413c40c987071b484a92400ccce811ec9e5202885b87d6ed24f27e3ca00",
+                "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+            ]
+        },
+        "storageProofs": {
+            "0xe8D466681784504A8458d4EF34F141adaDA678Fe": {
+                "0x5a158573daab1c353835da34297290f5f813859e4bb52de641691b875502523f": [
+                    "0x00be85171617341aa3277ff987f889ac613465f94f1ce1f88c1cade46090fbd411fd876ccea893e2a915742ccb261abedf8ccc01079f341586b724c103dd1adb17",
+                    "0x015bcfa567f724b471f0711c5b1b5295f4babeca2d70ed85e33abf5f8086e7721a0101000000000000000000000000000000000000000000007f228daac38a51833dbbf83000",
+                    "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+                ],
+                "0x977b86d8b2c12cb1b0cf5c34210e07337f1ed424f3f38ee3bddb639468b3095f": [
+                    "0x00be85171617341aa3277ff987f889ac613465f94f1ce1f88c1cade46090fbd411fd876ccea893e2a915742ccb261abedf8ccc01079f341586b724c103dd1adb17",
+                    "0x00f7f26bfedc1c3c30c68d11e0cb3f7d434e6235eb8c88637f9dc7ffa68aa9280bf855e9ec031301edaf7f84f64a9dc5798916c8678a1f907597da2c3bf8b63a0e",
+                    "0x0057a298c09fb1f9609b74ff09c68470bf41a983d24995a2e05a1fb9546ce3050df3311fe9cdd331d512ec3a45956f00ff6f2bfde8fffbbadf9b8500c230b7b705",
+                    "0x008f2fa3897bc04514e3935443ef67a70c0ebe0dd85364f0202ebb79bd910c5a250000000000000000000000000000000000000000000000000000000000000000",
+                    "0x0052fb41bda5330046b2f736cfd86106e5b0aadc56e770f870958d7c15334f96090266f9b3b99373c76aabe6fd12667ea462892cac46ef50e325de902b437a7a20",
+                    "0x0134aedb4be7574a842f0fde19fc74dcf1a0369b31b42311b841f80bbc74556d230101000000000000000000000000000000000000000000000000000000000000000007d000",
+                    "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+                ]
+            }
+        }
+    }
+    "#;
+
+    init();
+    let s_trace: StorageTrace = serde_json::from_str(example).unwrap();
+    let proofs = s_trace.proofs.as_ref().unwrap();
+    for (_, proof) in proofs.iter() {
+        let proof: builder::AccountProof = proof.as_slice().try_into().unwrap();
+        info!("proof: {:?}", proof);
+    }
+
+    for (_, s_map) in s_trace.storage_proofs.iter() {
+        for (k, val) in s_map {
+            let val_proof: builder::StorageProof = val.as_slice().try_into().unwrap();
+            info!("k: {}, v: {:?}", k, val_proof);
+        }
+    }
+}
+
+#[test]
+fn deserialize_example2() {
+    let example = r#"
+    {
+        "rootBefore": "0x21d23ec063cd5e5049ce308c85579851b3fc00fa16288c74e03154a759b060be",
+        "rootAfter": "0x01298a670d2df71e85631288e106bbfc1cd75a24293c23b052350058a18745ad",
+        "proofs": {
+            "0x05fDbDfaE180345C6Cff5316c286727CF1a43327": [
+                "0x001e2f9f788fddbe60528860cd94401896e598ff7ec689129b64b38c6f6e5d7cd00e831da32eb5166892a00be68f2ac1fe7ed65e19e0d5e4fc9220c5525af57b47",
+                "0x002ee00d41c4efcec95739e672b3c2c054103f03bf6b376a51ff27c66fd1600c972e8d75732548f8a07026d2dbb807f7844caac67aa88a9c4be518f26779d3eee0",
+                "0x002ab9b4cbc77f170bac3dbc2c9324063d4baa50f57c15819edaad95a16e8166af13d8fd8ebedae18d8dcf924c604b6771e9bbcb08c0ddb2e22473ef9541c41ba2",
+                "0x012512bcd4ae09e58018baa6cdfddc75ac00133901daabcdb14de10e2d25286cfb04040000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002adda4f0d2f9538b1c95d876e5ecb0bb0bcd847efab535259dff10a6f58aa8db2a76acf8180ab9c36b231ae111a8ac21cd34c5133fcd1c403fa893f1f31471c300",
+                "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+            ],
+            "0x4cb1aB63aF5D8931Ce09673EbD8ae2ce16fD6571": [
+                "0x001e2f9f788fddbe60528860cd94401896e598ff7ec689129b64b38c6f6e5d7cd00e831da32eb5166892a00be68f2ac1fe7ed65e19e0d5e4fc9220c5525af57b47",
+                "0x002ee00d41c4efcec95739e672b3c2c054103f03bf6b376a51ff27c66fd1600c972e8d75732548f8a07026d2dbb807f7844caac67aa88a9c4be518f26779d3eee0",
+                "0x002289e22abe96b0811a18c472ed2151193155e06dcb894f1cc0e415a22070e1f60511178241b5d9745ede181272654009625d78f4888c06633049bcbab1108578",
+                "0x000186c8ed5ea22968ac76644a1d293ff710a5a760206aad0af0d55b73e89f31452007487a1885185444169e80b08beb9a0e7875498d711f7e17d08bda1175f20c",
+                "0x000000000000000000000000000000000000000000000000000000000000000000050d40d784982a6c8c4f032301c362969c25ae9c7b1c27f072f4a943f7798d15",
+                "0x002248f47a53d7e981b187961b71a36033d9ef59273228ec127666f43c5d0fd2c503371eca2ecb6391c55284c1347145909bfcf00264117c6964ad841e6e946357",
+                "0x0000000000000000000000000000000000000000000000000000000000000000000cebb486e4008593f2a1d6aa5c7f50e0b2b64359f10a572fd24344ccfd30ffa0",
+                "0x0025a325f40c2da66b692f124296a6d273aa1e3afc6cde947abbb912960c1ba3382fe8b70043185278f8f6c75d7057d75ebc62e82052f480dfc207de3b0e89700e",
+                "0x0129bdbea092f4f7e6de593fd1a16ddb50b1c2a6297d4ae141a60f8da631e481750404000000000000000000000000000000000000000000000000000000000000000000330056bc75e2d630ffffffffffffffffffffffffffffffffffff4b6f9404062776c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470000000000000000000000000000000000000000000000000000000000000000000",
+                "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+            ],
+            "0xAC3DecAa2009EB6b384531B43A57Fa5C10f8ec33": [
+                "0x001e2f9f788fddbe60528860cd94401896e598ff7ec689129b64b38c6f6e5d7cd00e831da32eb5166892a00be68f2ac1fe7ed65e19e0d5e4fc9220c5525af57b47",
+                "0x002ee00d41c4efcec95739e672b3c2c054103f03bf6b376a51ff27c66fd1600c972e8d75732548f8a07026d2dbb807f7844caac67aa88a9c4be518f26779d3eee0",
+                "0x002289e22abe96b0811a18c472ed2151193155e06dcb894f1cc0e415a22070e1f60511178241b5d9745ede181272654009625d78f4888c06633049bcbab1108578",
+                "0x001e70ad06df66e7e2878877adc54b4f4b3ffd6d490ac216dba8caafa16031872817a8517bc379e6f45beda1173adfd50de5cdef7035ee67f60199b82695d0e160",
+                "0x0126d5d7ba8c158e8d4a20ff7dd5315879c206cffc2d41deb795f042ea0550f709040400000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000029b74e075daad9f17eb39cd893c2dd32f52ecd99084d63964842defd00ebcbe223c319641375b3a4b50a6f9fbcd6954072add60cae4e507863924d76aef900ca00",
+                "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+            ]
+        },
+        "storageProofs": {
+            "0x05fDbDfaE180345C6Cff5316c286727CF1a43327": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000": [
+                    "0x012098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b6486401010000000000000000000000000000f34a8c7a8b3230be235cd3550f9a15fe5bee3aba00",
+                    "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+                ]
+            },
+            "0xAC3DecAa2009EB6b384531B43A57Fa5C10f8ec33": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000": [
+                    "0x02",
+                    "0x5448495320495320534f4d45204d4147494320425954455320464f5220534d54206d3172525867503278704449"
+                ]
+            }
+        }
+    }
+    "#;
+
+    init();
+    let s_trace: StorageTrace = serde_json::from_str(example).unwrap();
+    let proofs = s_trace.proofs.as_ref().unwrap();
+    for (_, proof) in proofs.iter() {
+        let proof: builder::AccountProof = proof.as_slice().try_into().unwrap();
+        info!("proof: {:?}", proof);
+    }
+
+    for (_, s_map) in s_trace.storage_proofs.iter() {
+        for (k, val) in s_map {
+            let val_proof: builder::StorageProof = val.as_slice().try_into().unwrap();
+            info!("k: {}, v: {:?}", k, val_proof);
+        }
+    }
+}
+
+#[test]
+fn witgen_init_writer() {
+    use witness::WitnessGenerator;
+    init();
+    if TEST_SAMPLE_STR.is_empty() {
+        warn!("skip test for path of sample file not specified");
+        return;
+    }
+    let (state, _) = build_state_from_sample(TEST_SAMPLE_STR.as_str());
+    let w = WitnessGenerator::from(&state);
+
+    let root_init = w.root();
+
+    info!("root: {:?}", root_init);
+
+    assert_eq!(
+        format!("{:?}", root_init),
+        "0x2cf68fe79d67e26d05cf401118293952d507eaea98ab69bd9f3381bded8e2220"
+    );
+}
+
+fn smt_bytes_to_hash(bt: &[u8]) -> [u8; 32] {
+    let mut out: Vec<_> = bt.iter().copied().rev().collect();
+    out.resize(32, 0);
+    out.try_into().expect("extract size has been set")
+}
+
+#[test]
+fn witgen_update_one() {
+    use witness::WitnessGenerator;
+    init();
+    if TEST_SAMPLE_STR.is_empty() {
+        warn!("skip test for path of sample file not specified");
+        return;
+    }
+    let (state, _) = build_state_from_sample(TEST_SAMPLE_STR.as_str());
+    let mut w = WitnessGenerator::from(&state);
+
+    let target_addr = Address::from_slice(
+        hex::decode("b4d98243a206feab61d19413f60c06154137e2c2")
+            .unwrap()
+            .as_slice(),
+    );
+    let (existed, start_state) = state.state().get_account(&target_addr);
+    assert!(existed, "we picked an existed account");
+
+    let trace = w.handle_new_state(
+        MPTProofType::BalanceChanged,
+        target_addr,
+        start_state.balance + U256::from(1 as u64),
+        start_state.balance,
+        None,
+    );
+
+    let new_root = w.root();
+
+    let new_acc_root = smt_bytes_to_hash(trace.account_path[1].root.as_ref());
+    assert_eq!(new_root.0, new_acc_root);
+
+    info!("ret {:?}", trace);
+
+    let trace = w.handle_new_state(
+        MPTProofType::StorageChanged,
+        target_addr,
+        U256::from(1u32),
+        if let Some(v) = start_state.storage.get(&U256::zero()) {
+            *v
+        } else {
+            U256::default()
+        },
+        Some(U256::zero()),
+    );
+
+    let new_root = w.root();
+
+    let new_acc_root = smt_bytes_to_hash(trace.account_path[1].root.as_ref());
+    assert_eq!(new_root.0, new_acc_root);
+
+    info!("ret {:?}", trace);
+}

--- a/zktrie/src/state/witness.rs
+++ b/zktrie/src/state/witness.rs
@@ -1,0 +1,481 @@
+//! witness generator
+use bus_mapping::state_db::{StateDB, Account};
+use eth_types::{Address, Bytes, Word, Hash, H256, U256};
+use halo2_proofs::arithmetic::FieldExt;
+use mpt_circuits::MPTProofType;
+use mpt_circuits::serde::{Hash as SMTHash, HexBytes, SMTNode, SMTPath, SMTTrace, StateData, AccountData as SMTAccount};
+use std::collections::{HashMap, HashSet};
+use zktrie::{ZkMemoryDb, ZkTrie, ZkTrieNode};
+use super::builder::{CanRead, TrieProof, BytesArray, AccountData, extend_address_to_h256};
+use super::ZktrieState;
+
+use num_bigint::BigUint;
+use std::io::{Error as IoError, Read};
+
+
+impl From<AccountData> for SMTAccount {
+    fn from(acc: AccountData) -> Self {
+        let mut balance: [u8; 32] = [0; 32];
+        acc.balance.to_big_endian(balance.as_mut_slice());
+        let balance = BigUint::from_bytes_be(balance.as_slice());
+        let code_hash = BigUint::from_bytes_be(acc.code_hash.as_bytes());
+
+        Self {
+            nonce: acc.nonce,
+            balance,
+            code_hash,
+        }
+    }
+}
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref HASH_SCHEME_DONE: bool = {
+        zktrie::init_hash_scheme(hash_scheme);
+        true
+    };
+}
+
+/// witness generator for producing SMTTrace
+pub struct WitnessGenerator {
+    trie: ZkTrie,
+    accounts: HashMap<Address, Option<AccountData>>,
+    storages: HashMap<Address, ZkTrie>,
+}
+
+impl From<&ZktrieState> for WitnessGenerator {
+    fn from(state: &ZktrieState) -> Self {
+        let sdb = &state.sdb;
+
+        let trie = state.zk_db.borrow_mut().new_trie(&state.trie_root).unwrap();
+
+        let accounts : HashMap<_, _> = state.accounts
+            .iter()
+            .map(|(addr, storage_root)|{
+                let (existed, acc_data) = sdb.get_account(addr);
+                (*addr,
+                 if existed {
+                    Some(AccountData{
+                        nonce: acc_data.nonce.as_u64(),
+                        balance: acc_data.balance,
+                        code_hash: acc_data.code_hash,
+                        storage_root: H256::from(storage_root),
+                    })
+                } else {
+                    None
+                })
+            })
+            .collect();
+        
+        let storages : HashMap<_, _> = state.accounts
+            .iter()
+            .map(|(addr, storage_root)|{
+                (*addr, state.zk_db.borrow_mut().new_trie(storage_root))
+            })
+            .filter(|(_, storage_root)|storage_root.is_some())
+            .map(|(addr, storage_root)|(addr, storage_root.expect("None has been filtered")))
+            .collect();
+
+        Self {trie, accounts, storages}
+    }
+}
+
+static FILED_ERROR_READ: &str = "invalid input field";
+static FILED_ERROR_OUT: &str = "output field fail";
+
+use halo2_proofs::halo2curves::bn256::Fr;
+use halo2_proofs::halo2curves::group::ff::{Field, PrimeField};
+use mpt_circuits::hash::Hashable;
+
+extern "C" fn hash_scheme(a: *const u8, b: *const u8, out: *mut u8) -> *const i8 {
+    use std::slice;
+    let a: [u8; 32] =
+        TryFrom::try_from(unsafe { slice::from_raw_parts(a, 32) }).expect("length specified");
+    let b: [u8; 32] =
+        TryFrom::try_from(unsafe { slice::from_raw_parts(b, 32) }).expect("length specified");
+    let out = unsafe { slice::from_raw_parts_mut(out, 32) };
+
+    let fa = Fr::from_bytes(&a);
+    let fa = if fa.is_some().into() {
+        fa.unwrap()
+    } else {
+        return FILED_ERROR_READ.as_ptr().cast();
+    };
+    let fb = Fr::from_bytes(&b);
+    let fb = if fb.is_some().into() {
+        fb.unwrap()
+    } else {
+        return FILED_ERROR_READ.as_ptr().cast();
+    };
+
+    let h = Fr::hash([fa, fb]);
+    let repr_h = h.to_repr();
+    if repr_h.len() == 32 {
+        out.copy_from_slice(repr_h.as_ref());
+        std::ptr::null()
+    } else {
+        FILED_ERROR_OUT.as_ptr().cast()
+    }
+}
+
+impl WitnessGenerator {
+
+/*     fn set_data_from_block(db: &mut ZkMemoryDb, block: &BlockTrace) {
+        block
+            .storage_trace
+            .proofs
+            .iter()
+            .flatten()
+            .flat_map(|(_, proofs)| proofs.iter())
+            .for_each(|bytes| {
+                db.add_node_bytes(bytes.as_ref()).unwrap();
+            });
+
+        block
+            .storage_trace
+            .storage_proofs
+            .iter()
+            .flat_map(|(_, v_proofs)| v_proofs.iter())
+            .flat_map(|(_, proofs)| proofs.iter())
+            .for_each(|bytes| {
+                db.add_node_bytes(bytes.as_ref()).unwrap();
+            });
+    }
+
+    fn set_accounts_from_block(&mut self, block: &BlockTrace) {
+        let filter_map: HashSet<_> = self.accounts.keys().copied().collect();
+
+        let new_accs = block
+            .storage_trace
+            .proofs
+            .iter()
+            .flatten()
+            .filter(|(account, _)| !filter_map.contains(account))
+            .map(|(account, proofs)| {
+                let proof: AccountProof = verify_proof_leaf(
+                    proofs.as_slice().try_into().unwrap(),
+                    &extend_address_to_h256(account),
+                );
+                (*account, proof.key.as_ref().map(|_| proof.data))
+            });
+
+        self.accounts.extend(new_accs);
+    }
+
+    fn set_storages_from_block(&mut self, block: &BlockTrace) {
+        for (account, _) in block.storage_trace.storage_proofs.iter() {
+            if !self.storages.contains_key(account) {
+                let acc_data = self.accounts.get(account).unwrap();
+                let s_trie = self
+                    .db
+                    .new_trie(
+                        &acc_data
+                            .map(|d| d.storage_root)
+                            .unwrap_or_else(Hash::zero)
+                            .0,
+                    )
+                    .unwrap();
+                self.storages.insert(*account, s_trie);
+            }
+        }
+    }
+
+    pub fn add_block(&mut self, block: &BlockTrace) {
+        Self::set_data_from_block(&mut self.db, block);
+        self.set_accounts_from_block(block);
+        self.set_storages_from_block(block);
+    }
+
+    pub fn new(block: &BlockTrace) -> Self {
+        let mut db = ZkMemoryDb::new();
+        Self::set_data_from_block(&mut db, block);
+        let trie = db.new_trie(&block.storage_trace.root_before.0).unwrap();
+
+        let mut out = Self {
+            db,
+            trie,
+            accounts: HashMap::new(),
+            storages: HashMap::new(),
+        };
+
+        out.set_accounts_from_block(block);
+        out.set_storages_from_block(block);
+
+        out
+    }*/
+
+    fn trace_storage_update(
+        &mut self,
+        address: Address,
+        key: Word,
+        new_value: Word,
+        old_value: Word,
+    ) -> SMTTrace {
+
+        let (storage_key, key) = {
+            let mut word_buf = [0u8; 32];
+            key.to_big_endian(word_buf.as_mut_slice());
+            (hash_zktrie_key(&word_buf), HexBytes(word_buf))
+        };
+        let trie = self.storages.get_mut(&address).unwrap();
+
+        let store_before = {
+            let mut word_buf = [0u8; 32];
+            old_value.to_big_endian(word_buf.as_mut_slice());
+            // sanity check
+            assert_eq!(word_buf, trie.get_store(key.as_ref()).unwrap_or_default());
+            StateData { 
+                key, 
+                value: HexBytes(word_buf), 
+            }
+        };
+        let store_after = {
+            let mut word_buf = [0u8; 32];
+            new_value.to_big_endian(word_buf.as_mut_slice());
+            StateData {
+                key,
+                value: HexBytes(word_buf),
+            }
+        };        
+        let storage_before_proofs = trie.prove(key.as_ref());
+        let storage_before_path = decode_proof_for_mpt_path(storage_key, storage_before_proofs);
+        if !new_value.is_zero() {
+            trie.update_store(key.as_ref(), &store_after.value.0).unwrap();
+        } else if !old_value.is_zero() {
+            trie.delete(key.as_ref());
+        } // notice if the value is both zero we never touch the trie layer
+
+        let storage_root_after = H256(trie.root());
+        let storage_after_proofs = trie.prove(key.as_ref());
+        let storage_after_path = decode_proof_for_mpt_path(storage_key, storage_after_proofs);
+
+        // sanity check
+        assert_eq!(
+            smt_hash_from_bytes(storage_root_after.as_bytes()),
+            storage_after_path
+                .as_ref()
+                .map(|p| p.root)
+                .unwrap_or(HexBytes([0; 32]))
+        );
+
+        let mut out = self.trace_account_update(address, |acc| {
+            // sanity check
+            assert_eq!(
+                smt_hash_from_bytes(acc.storage_root.as_bytes()),
+                storage_before_path
+                    .as_ref()
+                    .map(|p| p.root)
+                    .unwrap_or(HexBytes([0; 32]))
+            );
+            let mut acc = *acc;
+            acc.storage_root = storage_root_after;
+            Some(acc)
+        });
+
+        out.common_state_root = None; // clear common state root
+        out.state_key = {
+            let high = Fr::from_u128(u128::from_be_bytes((&key.0[..16]).try_into().unwrap()));
+            let low = Fr::from_u128(u128::from_be_bytes((&key.0[16..]).try_into().unwrap()));
+            let hash = Fr::hash([high, low]);
+            let mut buf = [0u8; 32];
+            buf.as_mut_slice().copy_from_slice(hash.to_repr().as_ref());
+            Some(HexBytes(buf))
+        };
+
+        out.state_path = [storage_before_path.ok(), storage_after_path.ok()];
+        out.state_update = Some([Some(store_before), Some(store_after)]);
+        out
+    }
+
+    fn trace_account_update<U>(&mut self, address: Address, update_account_data: U) -> SMTTrace
+    where
+        U: FnOnce(&AccountData) -> Option<AccountData>,
+    {
+        let account_data_before = *self.accounts.get(&address).expect("todo: handle this");
+
+        let proofs = self.trie.prove(address.as_bytes());
+        let address_key = hash_zktrie_key(&extend_address_to_h256(&address));
+
+        let account_path_before = decode_proof_for_mpt_path(address_key, proofs).unwrap();
+
+        let account_data_after = update_account_data(&account_data_before.unwrap_or_default());
+
+        if let Some(account_data_after) = account_data_after {
+            let mut nonce = [0u8; 32];
+            U256::from(account_data_after.nonce).to_big_endian(nonce.as_mut_slice());
+            let mut balance = [0u8; 32];
+            account_data_after
+                .balance
+                .to_big_endian(balance.as_mut_slice());
+            let mut code_hash = [0u8; 32];
+            U256::from(account_data_after.code_hash.0).to_big_endian(code_hash.as_mut_slice());
+
+            let acc_data = [nonce, balance, code_hash, account_data_after.storage_root.0];
+            self.trie
+                .update_account(address.as_bytes(), &acc_data)
+                .expect("todo: handle this");
+            self.accounts.insert(address, Some(account_data_after));
+        } else {
+            self.trie.delete(address.as_bytes());
+            self.accounts.remove(&address);
+        }
+
+        let proofs = self.trie.prove(address.as_bytes());
+        let account_path_after = decode_proof_for_mpt_path(address_key, proofs).unwrap();
+
+        SMTTrace {
+            address: HexBytes(address.0),
+            account_path: [account_path_before, account_path_after],
+            account_update: [
+                account_data_before.map(Into::into),
+                account_data_after.map(Into::into),
+            ],
+            account_key: HexBytes(address_key.to_repr().as_ref().try_into().unwrap()),
+            state_path: [None, None],
+            common_state_root: account_data_before
+                .map(|data| smt_hash_from_bytes(data.storage_root.as_bytes()))
+                .or(Some(HexBytes([0; 32]))),
+            state_key: None,
+            state_update: None,
+        }
+    }
+
+    /// use one entry in mpt table to build the corresponding mpt operation (via SMTTrace)
+    pub fn handle_new_state(
+        &mut self, 
+        proof_type: MPTProofType,
+        address: Address,
+        new_val: Word,
+        old_val: Word,
+        key: Option<Word>,
+        ) -> SMTTrace {
+        if let Some(key) = key {
+            self.trace_storage_update(address, key, new_val, old_val)       
+
+        } else {
+            self.trace_account_update(address, |acc_before| {
+                let mut acc_data = acc_before.clone();
+                match proof_type {
+                    MPTProofType::NonceChanged => {
+                        assert_eq!(old_val.as_u64(), acc_data.nonce);
+                        acc_data.nonce = new_val.as_u64();
+                    },
+                    MPTProofType::BalanceChanged => {
+                        assert_eq!(old_val, acc_data.balance);
+                        acc_data.balance = new_val;
+                    },
+                    MPTProofType::CodeHashExists => {
+                        let mut code_hash = [0u8; 32];
+                        old_val.to_big_endian(code_hash.as_mut_slice());
+                        assert_eq!(H256::from(code_hash), acc_data.code_hash);
+                        new_val.to_big_endian(code_hash.as_mut_slice());
+                        acc_data.code_hash = H256::from(code_hash);
+                    },
+                    MPTProofType::AccountDoesNotExist => (),
+                    _ => unreachable!("invalid proof type: {:?}", proof_type),
+                }
+                Some(acc_data)
+            })            
+        }
+    }
+}
+
+fn smt_hash_from_u256(i: &U256) -> SMTHash {
+    let mut out: [u8; 32] = [0; 32];
+    i.to_little_endian(&mut out);
+    HexBytes(out)
+}
+
+fn smt_hash_from_bytes(bt: &[u8]) -> SMTHash {
+    let mut out: Vec<_> = bt.iter().copied().rev().collect();
+    out.resize(32, 0);
+    HexBytes(out.try_into().expect("extract size has been set"))
+}
+
+fn hash_zktrie_key(key_buf: &[u8; 32]) -> Fr {
+    let first_16bytes: [u8; 16] = key_buf[..16].try_into().expect("expect first 16 bytes");
+    let last_16bytes: [u8; 16] = key_buf[16..].try_into().expect("expect last 16 bytes");
+
+    let bt_high = Fr::from_u128(u128::from_be_bytes(first_16bytes));
+    let bt_low = Fr::from_u128(u128::from_be_bytes(last_16bytes));
+
+    Fr::hash([bt_high, bt_low])
+}
+
+#[derive(Debug, Default, Clone)]
+struct LeafNodeHash(H256);
+
+impl CanRead for LeafNodeHash {
+    fn try_parse(mut _rd: impl Read) -> Result<Self, IoError> {
+        panic!("this entry is not used")
+    }
+    fn parse_leaf(data: &[u8]) -> Result<Self, IoError> {
+        let node = ZkTrieNode::parse(data);
+        Ok(Self(
+            node.value_hash()
+                .expect("leaf should has value hash")
+                .into(),
+        ))
+    }
+}
+
+impl AsRef<[u8]> for LeafNodeHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+fn decode_proof_for_mpt_path(mut key_fr: Fr, proofs: Vec<Vec<u8>>) -> Result<SMTPath, IoError> {
+    let root = if let Some(arr) = proofs.first() {
+        let n = ZkTrieNode::parse(arr.as_slice());
+        smt_hash_from_bytes(n.key().as_slice())
+    } else {
+        HexBytes::<32>([0; 32])
+    };
+
+    let proof_bytes = proofs.iter().map(Vec::as_slice);
+    let trie_proof = TrieProof::<LeafNodeHash>::try_from(BytesArray(proof_bytes))?;
+
+    // convert path part
+    let invert_2 = Fr::one().double().invert().unwrap();
+    let mut path_bit_now = BigUint::from(1_u32);
+    let mut path_part: BigUint = Default::default();
+    let mut path = Vec::new();
+
+    for (left, right) in trie_proof.path.iter() {
+        let is_bit_one: bool = key_fr.is_odd().into();
+        path.push(if is_bit_one {
+            SMTNode {
+                value: smt_hash_from_u256(right),
+                sibling: smt_hash_from_u256(left),
+            }
+        } else {
+            SMTNode {
+                value: smt_hash_from_u256(left),
+                sibling: smt_hash_from_u256(right),
+            }
+        });
+        key_fr = if is_bit_one {
+            key_fr.mul(&invert_2) - invert_2
+        } else {
+            key_fr.mul(&invert_2)
+        };
+        if is_bit_one {
+            path_part += &path_bit_now
+        };
+        path_bit_now *= 2_u32;
+    }
+
+    let leaf = trie_proof.key.as_ref().map(|h| SMTNode {
+        value: smt_hash_from_bytes(trie_proof.data.as_ref()),
+        sibling: smt_hash_from_bytes(h.as_bytes()),
+    });
+
+    Ok(SMTPath {
+        root,
+        leaf,
+        path,
+        path_part,
+    })
+}


### PR DESCRIPTION
Add zktrie circuit as part of zkevm circuits, this PR add `zktrie` crate which include following features:

1. Re-export `mpt-circuits`
2. Include witness generator for building trie roots required by mpt table, which is wrapped in `scroll-zkevm` before

It also change the block witness and mpt module:

1. The block witness now include the initial trie state for calculating the state roots in each entry of mpt table
2. New entry has been added to build the full mpt table in mpt module

Work left:

- [ ]  Update the depended `mpt-circuit` (`scroll-dev-0111`) for a mpt circuit with lower maxium degree, so the circuit can be added into supercircuit

- [ ]  Update `scroll-zkevm` to adapt with this new `zkevm-circuit` crate and launch testing

