### PR TITLE
Feat: speed up the witness assignment of RLP/Tx circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,14 +623,18 @@ dependencies = [
  "bus-mapping",
  "env_logger",
  "eth-types",
+ "ethers",
  "ethers-signers",
  "halo2_proofs",
  "itertools",
  "keccak256",
+ "log",
  "mock",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
+ "tokio",
+ "url",
  "zkevm-circuits",
 ]
 

--- a/circuit-benchmarks/Cargo.toml
+++ b/circuit-benchmarks/Cargo.toml
@@ -17,9 +17,13 @@ rand = "0.8"
 itertools = "0.10"
 eth-types = { path = "../eth-types" }
 env_logger = "0.9"
+log="0.4"
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 ethers-signers = "0.17.0"
+ethers = { version = "0.17.0", features = ["ethers-solc"] }
 mock = { path="../mock" }
 rand_chacha = "0.3"
+url="2.2.2"
 
 [features]
 default = []

--- a/circuit-benchmarks/src/tx_circuit.rs
+++ b/circuit-benchmarks/src/tx_circuit.rs
@@ -3,6 +3,7 @@
 #[cfg(test)]
 mod tests {
     use ark_std::{end_timer, start_timer};
+    use bus_mapping::circuit_input_builder::{BuilderClient, CircuitsParams};
     use env_logger::Env;
     use halo2_proofs::plonk::{create_proof, keygen_pk, keygen_vk, verify_proof};
     use halo2_proofs::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG, ParamsVerifierKZG};
@@ -15,32 +16,69 @@ mod tests {
             Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
         },
     };
+    use log;
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
     use zkevm_circuits::tx_circuit::TxCircuit;
+    use zkevm_circuits::util::SubCircuit;
+    use zkevm_circuits::witness::block_convert;
 
-    use crate::bench_params::DEGREE;
+    // use crate::bench_params::DEGREE;
+    use bus_mapping::rpc::GethClient;
+    use ethers::providers::Http;
+    use url::Url;
+
+    fn get_client() -> GethClient<Http> {
+        let geth_url = "http://52.37.45.56:30303";
+        let transport = Http::new(Url::parse(geth_url).expect("invalid url"));
+        GethClient::new(transport)
+    }
 
     #[cfg_attr(not(feature = "benches"), ignore)]
-    #[test]
-    fn bench_tx_circuit_prover() {
+    #[tokio::test]
+    async fn bench_tx_circuit_prover() {
         env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
 
         // Approximate value, adjust with changes on the TxCircuit.
-        const ROWS_PER_TX: usize = 175_000;
-        const MAX_TXS: usize = 2_usize.pow(DEGREE as u32) / ROWS_PER_TX;
-        const MAX_CALLDATA: usize = 1024;
+        let degree = std::env::var("DEGREE")
+            .expect("DEGREE Not Set")
+            .parse::<usize>()
+            .expect("DEGREE should be int");
+        // const ROWS_PER_TX: usize = 175_000;
+        // const MAX_TXS: usize = 2_usize.pow(degree as u32) / ROWS_PER_TX;
+        // const MAX_CALLDATA: usize = 1024;
 
         let mut rng = ChaCha20Rng::seed_from_u64(42);
 
-        let chain_id: u64 = mock::MOCK_CHAIN_ID.low_u64();
-        let txs = vec![mock::CORRECT_MOCK_TXS[0].clone().into()];
-        let circuit = TxCircuit::<Fr>::new(MAX_TXS, MAX_CALLDATA, chain_id, txs);
+        let block_num = 16140307_u64;
+        log::info!("test super circuit, block number: {}", block_num);
+        let cli = get_client();
+        // target k = 19
+        let params = CircuitsParams {
+            max_rws: 4_000_000,
+            max_txs: 500,
+            max_calldata: 2_000_000,
+            max_inner_blocks: 64,
+            max_bytecode: 3_000_000,
+            keccak_padding: None,
+        };
+        let cli = BuilderClient::new(cli, params).await.unwrap();
+        let (builder, _) = cli.gen_inputs(block_num).await.unwrap();
+
+        if builder.block.txs.is_empty() {
+            log::info!("skip empty block");
+            return;
+        }
+        let block = block_convert(&builder.block, &builder.code_db).unwrap();
+        // let chain_id: u64 = mock::MOCK_CHAIN_ID.low_u64();
+        // let txs = vec![mock::CORRECT_MOCK_TXS[0].clone().into()];
+        // let circuit = TxCircuit::<Fr>::new(MAX_TXS, MAX_CALLDATA, chain_id, txs);
+        let circuit = TxCircuit::new_from_block(&block);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", DEGREE);
+        let setup_message = format!("Setup generation with degree = {}", degree);
         let start1 = start_timer!(|| setup_message);
-        let general_params = ParamsKZG::<Bn256>::setup(DEGREE as u32, &mut rng);
+        let general_params = ParamsKZG::<Bn256>::setup(degree as u32, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
         end_timer!(start1);
 
@@ -51,7 +89,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Tx Circuit Proof generation with degree = {}", DEGREE);
+        let proof_message = format!("Tx Circuit Proof generation with degree = {}", degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,

--- a/gadgets/src/is_zero.rs
+++ b/gadgets/src/is_zero.rs
@@ -112,7 +112,9 @@ impl<F: Field> IsZeroInstruction<F> for IsZeroChip<F> {
     ) -> Result<(), Error> {
         let config = self.config();
 
-        let value_invert = value.map(|value| value.invert().unwrap_or(F::zero()));
+        // postpone the invert to prover which has batch_invert function to
+        // amortize among all is_zero_chip assignments.
+        let value_invert = value.into_field().invert();
         region.assign_advice(
             || "witness inverse of value",
             config.value_inv,


### PR DESCRIPTION
The calldata parts of RLP and Tx circuits involve a lot of `is_zero_chip.assign()` which will call `F.invert()`. Note that for inverting a vector of fields we can use the `batch_invert()` method to amortize the expensive operation `F.invert()`(In a modern cpu, one invert took about 17000 ns. 

We can postpone the invert operations to prover by using the `Assigned<F>` type. This trick applies to several other circuits (such as state_circuit).

A few data here.  Before this pr, the tx_circuit alone needs about **695s** to finish (212s x 2 = 424s in synthesis).
```
··End:     SimpleFloorPlanner synthesize ...........................................212.253s // should x2 as we have two phases.
End:     Tx Circuit Proof generation with degree = 22 ..............................694.402s
```
After the pr, the tx_circuit needs **280s** to finish(5.6s x2 = 11.2s in synthesis).
```
··End:     SimpleFloorPlanner synthesize ...........................................5.576s
End:     Tx Circuit Proof generation with degree = 22 ..............................280.423s
```