### PR TITLE
CI: add `SECRET_REPO_DEPLOY_KEY` for private crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - scroll-stable
 
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 ## `actions-rs/toolchain@v1` overwrite set to false so that
 ## `rust-toolchain` is always used and the only source of truth.
 
@@ -89,6 +92,9 @@ jobs:
         # https://github.com/actions/cache/issues/810
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: Run light tests # light tests are run in parallel
         uses: actions-rs/cargo@v1
         with:
@@ -153,6 +159,9 @@ jobs:
         # https://github.com/actions/cache/issues/810
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:
@@ -210,6 +219,9 @@ jobs:
         # https://github.com/actions/cache/issues/810
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
         uses: actions-rs/cargo@v1
@@ -262,6 +274,9 @@ jobs:
         # https://github.com/actions/cache/issues/810
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:
@@ -320,6 +335,9 @@ jobs:
         # https://github.com/actions/cache/issues/810
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - scroll-stable
 
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   consecutiveness:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-integration-tests')
@@ -83,6 +86,9 @@ jobs:
         # https://github.com/actions/cache/issues/810
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       # Run an initial build in a separate step to split the build time from execution time
       - name: Build bins
         run: cargo build --bin gen_blockchain_data

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - scroll-stable
 
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   skip_check:
     runs-on: ubuntu-latest
@@ -72,6 +75,9 @@ jobs:
         # https://github.com/actions/cache/issues/810
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -50,6 +50,9 @@ itertools = "0.10.1"
 mock = { path = "../mock" }
 pretty_assertions = "1.0.0"
 
+# Should delete after testing.
+halo2_ecc = { git = "ssh://git@github.com/scroll-tech/halo2-ecc.git", branch = "halo2-ecc-ecdsa-0129" }
+
 [features]
 default = ["test","onephase"]
 test = ["ethers-signers", "mock"]

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -50,9 +50,6 @@ itertools = "0.10.1"
 mock = { path = "../mock" }
 pretty_assertions = "1.0.0"
 
-# Should delete after testing.
-halo2_ecc = { git = "ssh://git@github.com/scroll-tech/halo2-ecc.git", branch = "halo2-ecc-ecdsa-0129" }
-
 [features]
 default = ["test","onephase"]
 test = ["ethers-signers", "mock"]


### PR DESCRIPTION
Tested with temporary fix to add `halo2-ecc` as:

https://github.com/scroll-tech/zkevm-circuits/actions/runs/4061700532/jobs/6991976076
https://github.com/scroll-tech/zkevm-circuits/actions/runs/4061700537/jobs/6991976006