### PR TITLE
scroll-stable-rebase: add OOG error handling for `CALLCODE`, `DELEGATECALL` and `STATICCALL` to `ErrorOOGCall`

### DIFF
--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -92,16 +92,10 @@ pub enum OogError {
     ExtCodeCopy,
     /// Out of Gas for SLOAD and SSTORE
     SloadSstore,
-    /// Out of Gas for CALL
+    /// Out of Gas for CALL, CALLCODE, DELEGATECALL and STATICCALL
     Call,
-    /// Out of Gas for CALLCODE
-    CallCode,
-    /// Out of Gas for DELEGATECALL
-    DelegateCall,
     /// Out of Gas for CREATE2
     Create2,
-    /// Out of Gas for STATICCALL
-    StaticCall,
     /// Out of Gas for SELFDESTRUCT
     SelfDestruct,
 }
@@ -163,11 +157,10 @@ pub(crate) fn get_step_reported_error(op: &OpcodeId, error: &str) -> ExecError {
             OpcodeId::SHA3 => OogError::Sha3,
             OpcodeId::EXTCODECOPY => OogError::ExtCodeCopy,
             OpcodeId::SLOAD | OpcodeId::SSTORE => OogError::SloadSstore,
-            OpcodeId::CALL => OogError::Call,
-            OpcodeId::CALLCODE => OogError::CallCode,
-            OpcodeId::DELEGATECALL => OogError::DelegateCall,
+            OpcodeId::CALL | OpcodeId::CALLCODE | OpcodeId::DELEGATECALL | OpcodeId::STATICCALL => {
+                OogError::Call
+            }
             OpcodeId::CREATE2 => OogError::Create2,
-            OpcodeId::STATICCALL => OogError::StaticCall,
             OpcodeId::SELFDESTRUCT => OogError::SelfDestruct,
             _ => OogError::Constant,
         };

--- a/bus-mapping/src/evm/opcodes/error_oog_call.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_call.rs
@@ -1,13 +1,14 @@
 use super::Opcode;
-use crate::{
-    circuit_input_builder::{CircuitInputStateRef, ExecStep},
-    operation::{AccountField, CallContextField, TxAccessListAccountOp, RW},
-    Error,
-};
+use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
+use crate::operation::{AccountField, CallContextField, TxAccessListAccountOp, RW};
+use crate::Error;
+use eth_types::evm_types::OpcodeId;
 use eth_types::{GethExecStep, ToAddress, ToWord, Word};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
-/// corresponding to the `OpcodeId::CALL` `OpcodeId`.
+/// corresponding to the out of gas errors for [`OpcodeId::CALL`],
+/// [`OpcodeId::CALLCODE`], [`OpcodeId::DELEGATECALL`] and
+/// [`OpcodeId::STATICCALL`].
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct OOGCall;
 
@@ -17,6 +18,12 @@ impl Opcode for OOGCall {
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
         let geth_step = &geth_steps[0];
+        let stack_input_num = match geth_step.op {
+            OpcodeId::CALL | OpcodeId::CALLCODE => 7,
+            OpcodeId::DELEGATECALL | OpcodeId::STATICCALL => 6,
+            op => unreachable!("{op} should not happen in OOGCall"),
+        };
+
         let mut exec_step = state.new_step(geth_step)?;
         let next_step = if geth_steps.len() > 1 {
             Some(&geth_steps[1])
@@ -25,10 +32,10 @@ impl Opcode for OOGCall {
         };
         exec_step.error = state.get_step_err(geth_step, next_step).unwrap();
 
-        let args_offset = geth_step.stack.nth_last(3)?.as_usize();
-        let args_length = geth_step.stack.nth_last(4)?.as_usize();
-        let ret_offset = geth_step.stack.nth_last(5)?.as_usize();
-        let ret_length = geth_step.stack.nth_last(6)?.as_usize();
+        let args_offset = geth_step.stack.nth_last(stack_input_num - 4)?.as_usize();
+        let args_length = geth_step.stack.nth_last(stack_input_num - 3)?.as_usize();
+        let ret_offset = geth_step.stack.nth_last(stack_input_num - 2)?.as_usize();
+        let ret_length = geth_step.stack.nth_last(stack_input_num - 1)?.as_usize();
 
         state.call_expand_memory(args_offset, args_length, ret_offset, ret_length)?;
 
@@ -46,7 +53,7 @@ impl Opcode for OOGCall {
             state.call_context_read(&mut exec_step, current_call.call_id, field, value);
         }
 
-        for i in 0..7 {
+        for i in 0..stack_input_num {
             state.stack_read(
                 &mut exec_step,
                 geth_step.stack.nth_last_filled(i),
@@ -56,8 +63,9 @@ impl Opcode for OOGCall {
 
         state.stack_write(
             &mut exec_step,
-            geth_step.stack.nth_last_filled(6),
-            (0u64).into(), // must fail
+            geth_step.stack.nth_last_filled(stack_input_num - 1),
+            // Must fail.
+            (0_u64).into(),
         )?;
 
         let (_, callee_account) = state.sdb.get_account(&call_address);

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -292,11 +292,8 @@ pub(crate) struct ExecutionConfig<F> {
     error_oog_account_access: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasAccountAccess }>,
     error_oog_sha3: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSHA3 }>,
     error_oog_ext_codecopy: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasEXTCODECOPY }>,
-    error_oog_call_code: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasCALLCODE }>,
-    error_oog_delegate_call: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasDELEGATECALL }>,
     error_oog_exp: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasEXP }>,
     error_oog_create2: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasCREATE2 }>,
-    error_oog_static_call: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSTATICCALL }>,
     error_oog_self_destruct: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSELFDESTRUCT }>,
     error_oog_code_store: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasCodeStore }>,
     error_insufficient_balance: DummyGadget<F, 0, 0, { ExecutionState::ErrorInsufficientBalance }>,
@@ -545,11 +542,8 @@ impl<F: Field> ExecutionConfig<F> {
             error_oog_account_access: configure_gadget!(),
             error_oog_sha3: configure_gadget!(),
             error_oog_ext_codecopy: configure_gadget!(),
-            error_oog_call_code: configure_gadget!(),
-            error_oog_delegate_call: configure_gadget!(),
             error_oog_exp: configure_gadget!(),
             error_oog_create2: configure_gadget!(),
-            error_oog_static_call: configure_gadget!(),
             error_oog_self_destruct: configure_gadget!(),
             error_oog_code_store: configure_gadget!(),
             error_insufficient_balance: configure_gadget!(),
@@ -1250,7 +1244,7 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::ErrorOutOfGasConstant => {
                 assign_exec_step!(self.error_oog_constant)
             }
-            ExecutionState::ErrorOutOfGasCALL => {
+            ExecutionState::ErrorOutOfGasCall => {
                 assign_exec_step!(self.error_oog_call)
             }
             ExecutionState::ErrorOutOfGasDynamicMemoryExpansion => {
@@ -1274,20 +1268,11 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::ErrorOutOfGasEXTCODECOPY => {
                 assign_exec_step!(self.error_oog_ext_codecopy)
             }
-            ExecutionState::ErrorOutOfGasCALLCODE => {
-                assign_exec_step!(self.error_oog_call_code)
-            }
-            ExecutionState::ErrorOutOfGasDELEGATECALL => {
-                assign_exec_step!(self.error_oog_delegate_call)
-            }
             ExecutionState::ErrorOutOfGasEXP => {
                 assign_exec_step!(self.error_oog_exp)
             }
             ExecutionState::ErrorOutOfGasCREATE2 => {
                 assign_exec_step!(self.error_oog_create2)
-            }
-            ExecutionState::ErrorOutOfGasSTATICCALL => {
-                assign_exec_step!(self.error_oog_static_call)
             }
             ExecutionState::ErrorOutOfGasSELFDESTRUCT => {
                 assign_exec_step!(self.error_oog_self_destruct)

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -1,27 +1,36 @@
-use crate::evm_circuit::{
-    execution::ExecutionGadget,
-    param::N_BYTES_GAS,
-    step::ExecutionState,
-    util::{
-        common_gadget::{CommonCallGadget, RestoreContextGadget},
-        constraint_builder::{
-            ConstraintBuilder, StepStateTransition,
-            Transition::{Delta, Same},
+use crate::table::CallContextFieldTag;
+use crate::util::Expr;
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        param::N_BYTES_GAS,
+        step::ExecutionState,
+        util::{
+            common_gadget::{CommonCallGadget, RestoreContextGadget},
+            constraint_builder::{
+                ConstraintBuilder, StepStateTransition,
+                Transition::{Delta, Same},
+            },
+            math_gadget::{IsZeroGadget, LtGadget},
+            CachedRegion, Cell,
         },
-        math_gadget::LtGadget,
-        CachedRegion, Cell,
     },
     witness::{Block, Call, ExecStep, Transaction},
 };
-use crate::table::CallContextFieldTag;
-use crate::util::Expr;
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, U256};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
+/// Gadget to implement the corresponding out of gas errors for
+/// [`OpcodeId::CALL`], [`OpcodeId::CALLCODE`], [`OpcodeId::DELEGATECALL`] and
+/// [`OpcodeId::STATICCALL`].
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorOOGCallGadget<F> {
     opcode: Cell<F>,
+    is_call: IsZeroGadget<F>,
+    is_callcode: IsZeroGadget<F>,
+    is_delegatecall: IsZeroGadget<F>,
+    is_staticcall: IsZeroGadget<F>,
     tx_id: Cell<F>,
     is_static: Cell<F>,
     call: CommonCallGadget<F, false>,
@@ -34,23 +43,37 @@ pub(crate) struct ErrorOOGCallGadget<F> {
 impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
     const NAME: &'static str = "ErrorOutOfGasCall";
 
-    const EXECUTION_STATE: ExecutionState = ExecutionState::ErrorOutOfGasCALL;
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ErrorOutOfGasCall;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
         cb.opcode_lookup(opcode.expr(), 1.expr());
-        // TODO: add CallCode etc. when handle ErrorOutOfGasCALLCODE in furture
-        // implementation
+        let is_call = IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::CALL.expr());
+        let is_callcode = IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::CALLCODE.expr());
+        let is_delegatecall =
+            IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::DELEGATECALL.expr());
+        let is_staticcall =
+            IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::STATICCALL.expr());
+
+        // We do the responsible opcode check explicitly here because we're not
+        // using the SameContextGadget for CALL, CALLCODE, DELEGATECALL or
+        // STATICCALL.
         cb.require_equal(
-            "ErrorOutOfGasCall opcode is Call",
-            opcode.expr(),
-            OpcodeId::CALL.expr(),
+            "ErrorOutOfGasCall opcode should be CALL, CALLCODE, DELEGATECALL or STATICCALL",
+            is_call.expr() + is_callcode.expr() + is_delegatecall.expr() + is_staticcall.expr(),
+            1.expr(),
         );
 
         let rw_counter_end_of_reversion = cb.query_cell();
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let is_static = cb.call_context(None, CallContextFieldTag::IsStatic);
-        let call_gadget = CommonCallGadget::construct(cb, 1.expr(), 0.expr(), 0.expr());
+
+        let call_gadget = CommonCallGadget::construct(
+            cb,
+            is_call.expr(),
+            is_callcode.expr(),
+            is_delegatecall.expr(),
+        );
 
         // Add callee to access list
         let is_warm = cb.query_bool();
@@ -66,7 +89,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         // Check if the amount of gas available is less than the amount of gas required
         let insufficient_gas = LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);
         cb.require_equal(
-            "gas left is less than gas required ",
+            "gas left is less than gas required",
             insufficient_gas.expr(),
             1.expr(),
         );
@@ -94,7 +117,14 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             // Do step state transition
             cb.require_step_state_transition(StepStateTransition {
                 call_id: Same,
-                rw_counter: Delta(14.expr() + cb.curr.state.reversible_write_counter.expr()),
+                // Both CALL and CALLCODE opcodes have an extra stack pop `value` relative to
+                // DELEGATECALL and STATICCALL.
+                rw_counter: Delta(
+                    13.expr()
+                        + is_call.expr()
+                        + is_callcode.expr()
+                        + cb.curr.state.reversible_write_counter.expr(),
+                ),
                 ..StepStateTransition::any()
             });
         });
@@ -124,6 +154,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
 
         Self {
             opcode,
+            is_call,
+            is_callcode,
+            is_delegatecall,
+            is_staticcall,
             tx_id,
             is_static,
             call: call_gadget,
@@ -144,24 +178,36 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         let opcode = step.opcode.unwrap();
+        let is_call_or_callcode =
+            usize::from([OpcodeId::CALL, OpcodeId::CALLCODE].contains(&opcode));
         let [tx_id, is_static] =
             [step.rw_indices[0], step.rw_indices[1]].map(|idx| block.rws[idx].call_context_value());
         let stack_index = 2;
-        let [gas, callee_address, value, cd_offset, cd_length, rd_offset, rd_length] = [
+        let [gas, callee_address] = [
             step.rw_indices[stack_index],
             step.rw_indices[stack_index + 1],
-            step.rw_indices[stack_index + 2],
-            step.rw_indices[stack_index + 3],
-            step.rw_indices[stack_index + 4],
-            step.rw_indices[stack_index + 5],
-            step.rw_indices[stack_index + 6],
+        ]
+        .map(|idx| block.rws[idx].stack_value());
+        let value = if is_call_or_callcode == 1 {
+            block.rws[step.rw_indices[stack_index + 2]].stack_value()
+        } else {
+            U256::zero()
+        };
+        let [cd_offset, cd_length, rd_offset, rd_length] = [
+            step.rw_indices[stack_index + is_call_or_callcode + 2],
+            step.rw_indices[stack_index + is_call_or_callcode + 3],
+            step.rw_indices[stack_index + is_call_or_callcode + 4],
+            step.rw_indices[stack_index + is_call_or_callcode + 5],
         ]
         .map(|idx| block.rws[idx].stack_value());
 
-        let callee_code_hash = block.rws[step.rw_indices[10]].account_value_pair().0;
+        let callee_code_hash = block.rws[step.rw_indices[9 + is_call_or_callcode]]
+            .account_value_pair()
+            .0;
         let callee_exists = !callee_code_hash.is_zero();
 
-        let (is_warm, is_warm_prev) = block.rws[step.rw_indices[11]].tx_access_list_value_pair();
+        let (is_warm, is_warm_prev) =
+            block.rws[step.rw_indices[10 + is_call_or_callcode]].tx_access_list_value_pair();
 
         let memory_expansion_gas_cost = self.call.assign(
             region,
@@ -180,6 +226,27 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
 
         self.opcode
             .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
+
+        self.is_call.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::CALL.as_u64()),
+        )?;
+        self.is_callcode.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::CALLCODE.as_u64()),
+        )?;
+        self.is_delegatecall.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::DELEGATECALL.as_u64()),
+        )?;
+        self.is_staticcall.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::STATICCALL.as_u64()),
+        )?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx_id.low_u64())))?;
@@ -212,24 +279,30 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             Value::known(F::from(call.rw_counter_end_of_reversion as u64)),
         )?;
 
+        // Both CALL and CALLCODE opcodes have an extra stack pop `value` relative to
+        // DELEGATECALL and STATICCALL.
         self.restore_context
-            .assign(region, offset, block, call, step, 14)?;
-        Ok(())
+            .assign(region, offset, block, call, step, 13 + is_call_or_callcode)
     }
 }
 
 #[cfg(test)]
 mod test {
-
     use crate::test_util::CircuitTestBuilder;
+    use eth_types::bytecode::Bytecode;
+    use eth_types::evm_types::OpcodeId;
+    use eth_types::geth_types::Account;
     use eth_types::{address, bytecode};
-    use eth_types::{bytecode::Bytecode, evm_types::OpcodeId, geth_types::Account};
     use eth_types::{Address, ToWord, Word};
-
-    use itertools::Itertools;
     use mock::TestContext;
-
     use std::default::Default;
+
+    const TEST_CALL_OPCODES: &[OpcodeId] = &[
+        OpcodeId::CALL,
+        OpcodeId::CALLCODE,
+        OpcodeId::DELEGATECALL,
+        OpcodeId::STATICCALL,
+    ];
 
     #[derive(Clone, Copy, Debug, Default)]
     struct Stack {
@@ -241,27 +314,30 @@ mod test {
         rd_length: u64,
     }
 
-    fn caller(stack: Stack, caller_is_success: bool) -> Account {
-        let terminator = if caller_is_success {
-            OpcodeId::RETURN
-        } else {
-            OpcodeId::REVERT
-        };
-
-        // Call twice for testing both cold and warm access
-        let bytecode = bytecode! {
+    fn call_bytecode(opcode: OpcodeId, address: Address, stack: Stack) -> Bytecode {
+        let mut bytecode = bytecode! {
             PUSH32(Word::from(stack.rd_length))
             PUSH32(Word::from(stack.rd_offset))
             PUSH32(Word::from(stack.cd_length))
             PUSH32(Word::from(stack.cd_offset))
-            PUSH32(stack.value)
-            PUSH32(Address::repeat_byte(0xff).to_word())
-            PUSH32(Word::from(stack.gas))
-            CALL
-            PUSH1(0)
-            PUSH1(0)
-            .write_op(terminator)
         };
+        if opcode == OpcodeId::CALL || opcode == OpcodeId::CALLCODE {
+            bytecode.push(32, stack.value);
+        }
+        bytecode.append(&bytecode! {
+            PUSH32(address.to_word())
+            PUSH32(Word::from(stack.gas))
+            .write_op(opcode)
+            PUSH1(0)
+            PUSH1(0)
+            .write_op(OpcodeId::REVERT)
+        });
+
+        bytecode
+    }
+
+    fn caller(opcode: OpcodeId, stack: Stack) -> Account {
+        let bytecode = call_bytecode(opcode, Address::repeat_byte(0xff), stack);
 
         Account {
             address: Address::repeat_byte(0xfe),
@@ -283,7 +359,7 @@ mod test {
         }
     }
 
-    fn test_oog(caller: Account, callee: Account, is_root: bool) {
+    fn test_oog(caller: &Account, callee: &Account, is_root: bool) {
         let tx_gas = if is_root { 21100 } else { 25000 };
         let ctx = TestContext::<3, 1>::new(
             None,
@@ -293,12 +369,12 @@ mod test {
                     .balance(Word::from(10u64.pow(19)));
                 accs[1]
                     .address(caller.address)
-                    .code(caller.code)
+                    .code(caller.code.clone())
                     .nonce(caller.nonce)
                     .balance(caller.balance);
                 accs[2]
                     .address(callee.address)
-                    .code(callee.code)
+                    .code(callee.code.clone())
                     .nonce(callee.nonce)
                     .balance(callee.balance);
             },
@@ -317,66 +393,51 @@ mod test {
 
     #[test]
     fn call_with_oog_root() {
-        let stacks = vec![
-            // With gas and memory expansion
-            Stack {
-                gas: 100,
-                cd_offset: 64,
-                cd_length: 320,
-                rd_offset: 0,
-                rd_length: 32,
-                ..Default::default()
-            },
-        ];
-
-        let bytecode = bytecode! {
+        let stack = Stack {
+            gas: 100,
+            cd_offset: 64,
+            cd_length: 320,
+            rd_offset: 0,
+            rd_length: 32,
+            ..Default::default()
+        };
+        let callee = callee(bytecode! {
             PUSH32(Word::from(0))
             PUSH32(Word::from(0))
             STOP
-        };
-        let callees = vec![callee(bytecode)];
-        for (stack, callee) in stacks.into_iter().cartesian_product(callees.into_iter()) {
-            test_oog(caller(stack, true), callee, true);
+        });
+        for opcode in TEST_CALL_OPCODES {
+            test_oog(&caller(*opcode, stack), &callee, true);
         }
     }
 
     #[test]
     fn call_with_oog_internal() {
-        let stacks = vec![
-            // first call stack
-            Stack {
-                gas: 100,
-                cd_offset: 64,
-                cd_length: 320,
-                rd_offset: 0,
-                rd_length: 32,
-                ..Default::default()
-            },
-            // second call stack
-            Stack {
-                gas: 21,
-                cd_offset: 64,
-                cd_length: 320,
-                rd_offset: 0,
-                rd_length: 32,
-                ..Default::default()
-            },
-        ];
-
-        let stack = stacks[1];
-        let bytecode = bytecode! {
-            PUSH32(Word::from(stack.rd_length))
-            PUSH32(Word::from(stack.rd_offset))
-            PUSH32(Word::from(stack.cd_length))
-            PUSH32(Word::from(stack.cd_offset))
-            PUSH32(stack.value)
-            PUSH32(Address::repeat_byte(0xfe).to_word())
-            PUSH32(Word::from(stack.gas))
-            CALL // make this call out of gas
-            PUSH32(Word::from(0))
-            PUSH32(Word::from(0))
+        let caller_stack = Stack {
+            gas: 100,
+            cd_offset: 64,
+            cd_length: 320,
+            rd_offset: 0,
+            rd_length: 32,
+            ..Default::default()
         };
-        let callee = callee(bytecode);
-        test_oog(caller(stacks[0], false), callee, false);
+        let callee_stack = Stack {
+            gas: 21,
+            cd_offset: 64,
+            cd_length: 320,
+            rd_offset: 0,
+            rd_length: 32,
+            ..Default::default()
+        };
+
+        let caller = caller(OpcodeId::CALL, caller_stack);
+        for callee_opcode in TEST_CALL_OPCODES {
+            let callee = callee(call_bytecode(
+                *callee_opcode,
+                Address::repeat_byte(0xfe),
+                callee_stack,
+            ));
+            test_oog(&caller, &callee, false);
+        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -107,11 +107,8 @@ pub enum ExecutionState {
     ErrorOutOfGasSHA3,
     ErrorOutOfGasEXTCODECOPY,
     ErrorOutOfGasSloadSstore,
-    ErrorOutOfGasCALL,
-    ErrorOutOfGasCALLCODE,
-    ErrorOutOfGasDELEGATECALL,
+    ErrorOutOfGasCall,
     ErrorOutOfGasCREATE2,
-    ErrorOutOfGasSTATICCALL,
     ErrorOutOfGasSELFDESTRUCT,
 }
 
@@ -154,11 +151,8 @@ impl ExecutionState {
                 | Self::ErrorOutOfGasSHA3
                 | Self::ErrorOutOfGasEXTCODECOPY
                 | Self::ErrorOutOfGasSloadSstore
-                | Self::ErrorOutOfGasCALL
-                | Self::ErrorOutOfGasCALLCODE
-                | Self::ErrorOutOfGasDELEGATECALL
+                | Self::ErrorOutOfGasCall
                 | Self::ErrorOutOfGasCREATE2
-                | Self::ErrorOutOfGasSTATICCALL
                 | Self::ErrorOutOfGasSELFDESTRUCT
         )
     }

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -85,11 +85,8 @@ impl From<&ExecError> for ExecutionState {
                 OogError::Sha3 => ExecutionState::ErrorOutOfGasSHA3,
                 OogError::ExtCodeCopy => ExecutionState::ErrorOutOfGasEXTCODECOPY,
                 OogError::SloadSstore => ExecutionState::ErrorOutOfGasSloadSstore,
-                OogError::Call => ExecutionState::ErrorOutOfGasCALL,
-                OogError::CallCode => ExecutionState::ErrorOutOfGasCALLCODE,
-                OogError::DelegateCall => ExecutionState::ErrorOutOfGasDELEGATECALL,
+                OogError::Call => ExecutionState::ErrorOutOfGasCall,
                 OogError::Create2 => ExecutionState::ErrorOutOfGasCREATE2,
-                OogError::StaticCall => ExecutionState::ErrorOutOfGasSTATICCALL,
                 OogError::SelfDestruct => ExecutionState::ErrorOutOfGasSELFDESTRUCT,
             },
         }


### PR DESCRIPTION
Rebase PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1127 on `scroll-stable`.