### PR TITLE
OOG error Circuit for `EXP`

### DIFF
--- a/.github/proverCiScripts/benchmarks_result_reporting/reporting_main.py
+++ b/.github/proverCiScripts/benchmarks_result_reporting/reporting_main.py
@@ -1,0 +1,35 @@
+import argparse, json
+from pprint import pprint
+import reporting_modules as rmod
+
+env = json.load(open('/home/ubuntu/env.json'))
+cstats = '/home/ubuntu/cpu.stats'
+mstats = '/home/ubuntu/mem.stats'
+
+def main():
+    parser = argparse.ArgumentParser(
+                    prog = 'BenchmarkResults',
+                    usage = 'python3 reporting_main.py 13 EVM 19',
+                    description = 'Writes circuit benchmark results to postgresql, uploads logfiles to s3 bucket',
+                    )
+    parser.add_argument('pr') 
+    parser.add_argument('circuit')
+    parser.add_argument('degree')
+    parser.add_argument('test_id')
+    args = parser.parse_args()
+    pr, circuit, degree, test_id = (args.pr, args.circuit, args.degree, args.test_id)
+    test_result = rmod.log_processor(pr,circuit, degree)
+    cpustats, memstats, sysstat = rmod.calc_stats(cstats,mstats)
+    data = rmod.prepare_result_dataframe(test_result, sysstat, env, test_id)
+    table = 'testresults_circuitbenchmark'
+    engine = rmod.pgsql_engine(env['db'])
+    data.to_sql(table,engine,if_exists='append')
+    ms = rmod.write_mem_time(engine,memstats, test_id)
+    cs = rmod.write_cpuall_time(engine,cpustats, test_id)
+
+    url = f'{env["grafana_dashboard_prefix"]}{test_id}'.replace(" ", "")
+    print(f'Test Result: {url}')
+
+if __name__ == '__main__':
+    main()
+    

--- a/.github/proverCiScripts/benchmarks_result_reporting/reporting_modules.py
+++ b/.github/proverCiScripts/benchmarks_result_reporting/reporting_modules.py
@@ -1,0 +1,194 @@
+import pandas as pd, json, datetime, itertools
+from sqlalchemy import create_engine, text
+import warnings, time, os
+
+
+warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action='ignore', category=UserWarning)
+pd.options.mode.chained_assignment = None
+
+def pgsql_engine(pgsqldb):
+    '''
+    creates a psql engine instance
+    '''
+    user     = pgsqldb['user']
+    password = pgsqldb['password']
+    host     = pgsqldb['host']
+    database = pgsqldb['database']
+    engine   = create_engine(f'postgresql://{user}:{password}@{host}:5432/{database}')
+
+    return engine
+
+def prepare_result_dataframe(test_result, sysstat,env, test_id):
+    '''
+    prepares postgres data (in the form of dataframe) for table circuit_benchmarks
+    '''
+    try:
+        r = {
+            'pull_request'          : test_result['pull_request'],
+            'test_id'               : test_id,
+            'circuit'               : test_result['circuit'],
+            'degree'                : test_result['degree'],
+            'test_result'           : test_result['result'],
+            'test_date'             : datetime.datetime.now().date(),
+            'setup_gen'             : test_result['setup_gen'],
+            'proof_gen'             : test_result['proof_gen'],
+            'proof_ver'             : test_result['proof_ver'],
+            'max_ram'               : sysstat['max_ram'],
+            'cpu_all_Average'       : sysstat['cpu_all_Average'],
+            'cpu_all_Max'           : sysstat['cpu_all_Max'],
+            'cpu_count'             : sysstat['cpu_count'],
+            'sysstats_url'          : f'{env["grafana_dashboard_prefix"]}{test_id}',
+            'logsurl'               : f'{env["s3endpoint"]}{test_id}.tar.gz'
+        }
+
+    except Exception as e:
+        print(e)
+
+    test_id = r['test_id']
+    r = pd.DataFrame([r])
+    r = r.set_index('test_date')
+    
+    return r
+
+def write_mem_time(engine, mem_statistics, test_id, dummy=False):
+    '''
+    adds mem stats df as time series data to table mem_stats
+    '''
+    table = 'testresults_cbmemtime'
+    mem_statistics['dummy'] = mem_statistics['timestamp'].apply(lambda x: f'{dummy}')
+    mem_statistics['test_id'] = mem_statistics['timestamp'].apply(lambda x: f'{test_id}')
+    mem_statistics.to_sql(table,engine,if_exists='append',index=False)
+
+def write_cpuall_time(engine, cpu_statistics, test_id, dummy=False):
+    '''
+    adds cpu stats df as time series data to table mem_stats
+    '''
+    table = 'testresults_cbcpualltime'
+    cpu_statistics['dummy'] = cpu_statistics['timestamp'].apply(lambda x: f'{dummy}')
+    cpu_statistics['test_id'] = cpu_statistics['timestamp'].apply(lambda x: f'{test_id}')
+    cpu_statistics.to_sql(table,engine,if_exists='append',index=False)
+
+def calc_stats(cstats,mstats): 
+    '''
+    returns 2 dataframes with cpu/mem stats to be consumed by postgresql engine
+    returns a dict with average/max cpu and max ram utilization durint the benchmark
+    '''
+    dfcpu,cpus = load_stats(cstats)
+    cpustats,cpu_all_Max,cpu_all_Average = process_cpustats(dfcpu)
+    dfmem, _ = load_stats(mstats)
+    memstats,max_ram = process_memstats(dfmem)
+    sysstat = {
+        'cpu_all_Average': cpu_all_Average,
+        'cpu_all_Max'    : cpu_all_Max,
+        'cpu_count'      : cpus,
+        'max_ram'        : f'{max_ram}Gb'
+    }
+    
+    return cpustats, memstats, sysstat
+
+def log_processor(pull_request,circuit, degree):
+    '''
+    Exports test metadata and result metrics from prover logfile
+    '''
+    SETUP_PREFIX     = "[Setup generation]"
+    PROOFGEN_PREFIX  = "[Proof generation]"
+    PROOFVER_PREFIX  = "[Proof verification]"
+    logfile = [i for i in os.listdir('/home/ubuntu/') if 'proverlog' in i][0]
+    f = open(f'/home/ubuntu/{logfile}', 'r')
+    logdata = f.read()
+    logdata = logdata.split("\n")
+    running = [i for i in logdata if 'running' in i and 'test' in i][0].split()[1]
+    if running != '0':
+        r = [i.split(":")[1].split(".")[0].replace(" ","") for i in logdata if 'test result' in i][0]
+        if r == 'ok':
+            result = 'PASSED'
+            try:
+                sg = ''.join(g[0] for g in itertools.groupby([i for i in logdata if 'End' in i and SETUP_PREFIX in i ][0])).split('.', 1)[-1]
+            except:
+                sg = 'None'
+            try:
+                pg = ''.join(g[0] for g in itertools.groupby([i for i in logdata if 'End' in i and PROOFGEN_PREFIX in i ][0])).split('.', 1)[-1]
+            except:
+                pg = 'None'                
+            try:
+                pv = ''.join(g[0] for g in itertools.groupby([i for i in logdata if 'End' in i and PROOFVER_PREFIX in i ][0])).split('.', 1)[-1]
+            except:
+                pv = 'None'
+            logdata = {
+                    'pull_request': pull_request,
+                    'circuit'     : circuit,
+                    'degree'      : degree,
+                    'result'      : result,
+                    'setup_gen'   : sg,
+                    'proof_gen'   : pg,
+                    'proof_ver'   : pv
+                }
+        else:
+            result = 'FAILED'
+            logdata = {
+                'pull_request': pull_request,
+                'circuit'     : circuit,
+                'degree'      : degree,
+                'result'      : result,
+                'setup_gen'   : 'None',
+                'proof_gen'   : 'None',
+                'proof_ver'   : 'None'
+            }        
+
+    else:
+        result = 'None'
+        logdata = {
+            'pull_request': pull_request,
+            'circuit'     : circuit,
+            'degree'      : degree,
+            'result'      : result,
+            'setup_gen'   : 'NoTestExecuted',
+            'proof_gen'   : 'NoTestExecuted',
+            'proof_ver'   : 'NoTestExecuted'
+            }
+
+    
+    return logdata
+
+def load_stats(file):
+    '''
+    loads raw mem/cpu sar data from csv to dataframe
+    '''
+    try:
+        with open(file,'r') as filedata:
+            filedatalist = [i for i in filedata.read().splitlines()]
+            header = [i for i in filedatalist if 'LINUX-RESTART' in i][0]
+            cpus = header.split('(')[1].split()[0]
+            cpudatalist = [i for i in filedatalist if 'LINUX-RESTART' not in i]
+            columns = cpudatalist[0].split(';')
+            cpudatalist = [i for i in cpudatalist if 'hostname' not in i]
+            df = pd.DataFrame([i.split(';') for i in cpudatalist], columns=columns)
+        return df, cpus
+    except Exception as e:
+        print(e)
+        return None
+
+def process_cpustats(statsdf):
+    '''
+    accepts cpu stats raw data from csv and returns a dataframe for further processing
+    '''
+    statsdf = statsdf[['timestamp', '%idle']]
+    statsdf['%idle']   = pd.to_numeric(statsdf['%idle'])
+    statsdf['utilizationall'] = statsdf['%idle'].apply(lambda x:round(float(100) - x, 2 ))
+    statsdf = statsdf[['timestamp','utilizationall']]
+    cpu_all_Max = statsdf['utilizationall'].max()
+    cpu_all_Average = statsdf['utilizationall'].mean()
+    return statsdf, cpu_all_Max,cpu_all_Average
+
+
+def process_memstats(df):
+    '''
+    accepts ram stats raw data  and returns a dataframe for further processing
+    '''
+    statsdf = df[['timestamp', 'kbmemused']]
+    statsdf['kbmemused']   = pd.to_numeric(statsdf['kbmemused'])
+    statsdf['utilizationgb']   = statsdf['kbmemused'].apply(lambda x: round(x/float(1000000),2))
+    statsdf = statsdf[['timestamp','utilizationgb']]
+    max_ram = statsdf['utilizationgb'].max()
+    return statsdf, max_ram

--- a/.github/proverCiScripts/execBench.sh
+++ b/.github/proverCiScripts/execBench.sh
@@ -29,6 +29,18 @@ case $circuit in
     "super")
         run_suffix="super_circuit_prover"
         ;;
+    "bytecode")
+        run_suffix="bytecode_circuit_prover"
+        ;;
+    "pi")
+        run_suffix="pi_circuit_prover"
+        ;;
+    "exp")
+        run_suffix="exp_circuit_prover"
+        ;;
+    "copy")
+        run_suffix="copy_circuit_prover"
+        ;;
     *)
         echo "No proper value"
         exit 1
@@ -40,3 +52,5 @@ logfile=$_date--${circuit}_bench-$k.proverlog
 
 export RUST_BACKTRACE=1
 DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > "$target_dir/$logfile" 2>&1
+
+exit 0

--- a/.github/proverCiScripts/getSysstat.sh
+++ b/.github/proverCiScripts/getSysstat.sh
@@ -6,22 +6,5 @@ prnumber=$1
 base_dir="/home/ubuntu/CI_Prover_Benches/"
 target_dir="$base_dir"PR"$prnumber"
 
-sar -uh > cpu.stats
-sar -rh > mem.stats
-
-sed -i -e '1,5d' cpu.stats
-sed -i -e '1,5d' mem.stats
-sed -i -e '$ d' cpu.stats
-sed -i -e '$ d' mem.stats
-
-minIdleCPU=$(cat cpu.stats | awk '{ print $8 }' | sed  's/%//g' | sort -n | head -1)
-maxUsedCPU=$(bc <<< "scale=2; 100-$minIdleCPU")
-maxMemUsed=$(cat mem.stats | awk '{ print $4 }' | sed 's/G//g' | sort -n | tail -1)
-
 logfile=$(ls $target_dir | grep proverlog | xargs -n 1 basename)
 tail -12 $target_dir/$logfile
-
-echo "Maximum CPU Usage at $maxUsedCPU%"
-echo "Maximum Mem Usage at ${maxMemUsed}Gb"
-
-mv $target_dir/$logfile /home/ubuntu/CI_Prover_Benches/ProverLogs/"$logfile"_PR"$prnumber"

--- a/.github/proverCiScripts/processResults.sh
+++ b/.github/proverCiScripts/processResults.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+#set -x
+
+prnumber=$1
+label=$2
+degree=$3
+base_dir="/home/ubuntu/CI_Prover_Benches/"
+target_dir="$base_dir"PR"$prnumber"
+
+rm -f ~/*.stats
+rm -f ~/*.proverlog
+rm -f ~/*.tar.gz
+
+scp prover:$target_dir/*proverlog ~/
+scp ~/actions-runner/zkevm_circuits_prover/zkevm-circuits/zkevm-circuits/.github/proverCiScripts/sadf.sh prover:~/
+ssh prover "bash -s" <<EOF
+./sadf.sh
+rm -f sadf.sh
+EOF
+
+scp prover:~/*.stats ~/
+
+
+l=$(echo $label | tr -d '"') 
+circuit=$(echo $l |  awk '{print $2}')
+time=$(date +%s)
+test_id=$circuit-$degree-Benchmark-PR$prnumber--$time
+
+tar -czvf ~/$test_id.tar.gz ~/*proverlog ~/*.stats
+aws s3 cp ~/$test_id.tar.gz s3://zkevm-chain-testing --profile cirunner
+echo "Log file uploaded at : https://zkevm-chain-testing.s3.eu-central-1.amazonaws.com/$test_id"".tar.gz"
+/usr/bin/python3 .github/proverCiScripts/benchmarks_result_reporting/reporting_main.py  "$prnumber" "$circuit" "$degree" "$test_id"
+
+ssh prover "bash -s" <<EOF
+rm -f $target_dir/*proverlog
+rm -f ~/*.stats
+EOF
+
+rm -rf ~/*proverlog
+rm -rf ~/*.stats
+rm -rf ~/$test_id.tar.gz

--- a/.github/proverCiScripts/sadf.sh
+++ b/.github/proverCiScripts/sadf.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sleep 5
+sudo rm -f /var/log/sysstat/sar*
+sacount=$(sudo find /var/log/sysstat/ -type f | wc -l)
+previousdays=$(expr 1 - $sacount)
+while [ $previousdays -lt 0 ] 
+  do
+    sadf $previousdays -d >> cpu.stats
+    sadf $previousdays -d -- -r >> mem.stats
+    (( previousdays++ ))
+  done
+sadf -d >> cpu.stats
+sadf -d -- -r >> mem.stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,24 @@ concurrency:
 ## `rust-toolchain` is always used and the only source of truth.
 
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          cancel_others: 'true'
+          concurrent_skipping: 'same_content_newer'
+          paths_ignore: '["**/README.md"]'
+
   test:
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
+
     name: Test
     runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
 
@@ -61,7 +78,10 @@ jobs:
           args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks serial_ -- --ignored --test-threads 1
 
   build:
-    if: github.event.pull_request.draft == false
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Build target ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -111,7 +131,10 @@ jobs:
           args: --verbose --release --all-features -p circuit-benchmarks --no-run
 
   bitrot:
-    if: github.event.pull_request.draft == false
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Bitrot check
     runs-on: ubuntu-latest
@@ -149,7 +172,10 @@ jobs:
           args: --benches --examples --all-features
 
   doc-links:
-    if: github.event.pull_request.draft == false
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Intra-doc links
     runs-on: ubuntu-latest
@@ -193,7 +219,10 @@ jobs:
           args: --no-deps --all --document-private-items
 
   fmt:
-    if: github.event.pull_request.draft == false
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Rustfmt
     timeout-minutes: 30

--- a/.github/workflows/gh-actions-prover-benches.yml
+++ b/.github/workflows/gh-actions-prover-benches.yml
@@ -15,7 +15,7 @@ jobs:
       - run: .github/proverCiScripts/wakeUpProver.sh
         shell: bash
       - run: |
-          ssh prover "bash -s" -- < .github/proverCiScripts/rsSysstat.sh
+          ssh prover "bash -s" -- < .github/proverCiScripts/rsSysstat.sh "${{ env.PR_NUMBER }}"
       - run: |
           ssh prover "bash -s" -- < .github/proverCiScripts/prepareProver.sh "${{ env.PR_NUMBER }}" "${{ github.workspace }}"
       - run: .github/proverCiScripts/deployToProver.sh "${{ env.PR_NUMBER }}" "${{ github.workspace }}"
@@ -25,6 +25,12 @@ jobs:
         shell: bash
       - run: |
           ssh prover "bash -s" -- < .github/proverCiScripts/getSysstat.sh "${{ env.PR_NUMBER }}"
-      - run: .github/proverCiScripts/shutdownProver.sh
+      - name: Calculate Benchmark Result
+        if: success() || failure()
+        run: .github/proverCiScripts/processResults.sh "${{ env.PR_NUMBER }}" '"${{ github.event.label.name }}"' "19"
+        shell: bash
+      - name: PowerOff prover
+        if: always()
+        run: .github/proverCiScripts/shutdownProver.sh
         shell: bash
 

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,8 +10,23 @@ on:
       - main
 
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          cancel_others: 'true'
+          concurrent_skipping: 'same_content_newer'
+          paths_ignore: '["**/README.md"]'
+
   clippy:
-    if: github.event.pull_request.draft == false
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Clippy
     timeout-minutes: 30

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,14 @@ exp_bench: ## Run Exp Circuit benchmarks
 
 circuit_benches: evm_bench state_bench ## Run All Circuit benchmarks
 
+stats_state_circuit: # Print a table with State Circuit stats by ExecState/opcode
+	@cargo test -p zkevm-circuits --features=test,warn-unimplemented get_state_states_stats -- --nocapture --ignored
+
+stats_evm_circuit: # Print a table with EVM Circuit stats by ExecState/opcode
+	@cargo test -p zkevm-circuits --features=test,warn-unimplemented get_evm_states_stats -- --nocapture --ignored
+
+stats_copy_circuit: # Print a table with Copy Circuit stats by ExecState/opcode
+	@cargo test -p zkevm-circuits --features=test,warn-unimplemented get_copy_states_stats -- --nocapture --ignored
+
 
 .PHONY: clippy doc fmt test test_benches test-all evm_bench state_bench circuit_benches help

--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ to use for your circuit in the bench process.
 -   State Circuit prover benches. -> `DEGREE=18 make state_bench`
 
 You can also run all benchmarks by running: `make circuit_benches DEGREE=18`.
+
+## GH Actions Benchmark Results
+
+Circuit Benchmark Results are accessible here: https://grafana.zkevm-testnet.org/d/vofy8DAVz/circuit-benchmarks?orgId=1
+
+- circuit_benchmarks panel displays:
+    - overall test result
+    - timers and system statistics
+    - url for downloading prover log and sys stat files
+    - clickable sysstats_url element that loads the memory and cpu utilization profiles for the given test

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -390,6 +390,58 @@ pub struct BuilderClient<P: JsonRpcClient> {
     circuits_params: CircuitsParams,
 }
 
+/// Get State Accesses from TxExecTraces
+pub fn get_state_accesses(
+    eth_block: &EthBlock,
+    geth_traces: &[eth_types::GethExecTrace],
+) -> Result<AccessSet, Error> {
+    let mut block_access_trace = vec![Access::new(
+        None,
+        RW::WRITE,
+        AccessValue::Account {
+            address: eth_block
+                .author
+                .ok_or(Error::EthTypeError(eth_types::Error::IncompleteBlock))?,
+        },
+    )];
+    for (tx_index, tx) in eth_block.transactions.iter().enumerate() {
+        let geth_trace = &geth_traces[tx_index];
+        let tx_access_trace = gen_state_access_trace(eth_block, tx, geth_trace)?;
+        block_access_trace.extend(tx_access_trace);
+    }
+
+    Ok(AccessSet::from(block_access_trace))
+}
+
+/// Build a partial StateDB from step 3
+pub fn build_state_code_db(
+    proofs: Vec<eth_types::EIP1186ProofResponse>,
+    codes: HashMap<Address, Vec<u8>>,
+) -> (StateDB, CodeDB) {
+    let mut sdb = StateDB::new();
+    for proof in proofs {
+        let mut storage = HashMap::new();
+        for storage_proof in proof.storage_proof {
+            storage.insert(storage_proof.key, storage_proof.value);
+        }
+        sdb.set_account(
+            &proof.address,
+            state_db::Account {
+                nonce: proof.nonce,
+                balance: proof.balance,
+                storage,
+                code_hash: proof.code_hash,
+            },
+        )
+    }
+
+    let mut code_db = CodeDB::new();
+    for (_address, code) in codes {
+        code_db.insert(code.clone());
+    }
+    (sdb, code_db)
+}
+
 impl<P: JsonRpcClient> BuilderClient<P> {
     /// Create a new BuilderClient
     pub async fn new(
@@ -451,26 +503,10 @@ impl<P: JsonRpcClient> BuilderClient<P> {
 
     /// Step 2. Get State Accesses from TxExecTraces
     pub fn get_state_accesses(
-        &self,
         eth_block: &EthBlock,
         geth_traces: &[eth_types::GethExecTrace],
     ) -> Result<AccessSet, Error> {
-        let mut block_access_trace = vec![Access::new(
-            None,
-            RW::WRITE,
-            AccessValue::Account {
-                address: eth_block
-                    .author
-                    .ok_or(Error::EthTypeError(eth_types::Error::IncompleteBlock))?,
-            },
-        )];
-        for (tx_index, tx) in eth_block.transactions.iter().enumerate() {
-            let geth_trace = &geth_traces[tx_index];
-            let tx_access_trace = gen_state_access_trace(eth_block, tx, geth_trace)?;
-            block_access_trace.extend(tx_access_trace);
-        }
-
-        Ok(AccessSet::from(block_access_trace))
+        get_state_accesses(eth_block, geth_traces)
     }
 
     /// Step 3. Query geth for all accounts, storage keys, and codes from
@@ -511,32 +547,10 @@ impl<P: JsonRpcClient> BuilderClient<P> {
 
     /// Step 4. Build a partial StateDB from step 3
     pub fn build_state_code_db(
-        &self,
         proofs: Vec<eth_types::EIP1186ProofResponse>,
         codes: HashMap<Address, Vec<u8>>,
     ) -> (StateDB, CodeDB) {
-        let mut sdb = StateDB::new();
-        for proof in proofs {
-            let mut storage = HashMap::new();
-            for storage_proof in proof.storage_proof {
-                storage.insert(storage_proof.key, storage_proof.value);
-            }
-            sdb.set_account(
-                &proof.address,
-                state_db::Account {
-                    nonce: proof.nonce,
-                    balance: proof.balance,
-                    storage,
-                    code_hash: proof.code_hash,
-                },
-            )
-        }
-
-        let mut code_db = CodeDB::new();
-        for (_address, code) in codes {
-            code_db.insert(code.clone());
-        }
-        (sdb, code_db)
+        build_state_code_db(proofs, codes)
     }
 
     /// Step 5. For each step in TxExecTraces, gen the associated ops and state
@@ -575,9 +589,9 @@ impl<P: JsonRpcClient> BuilderClient<P> {
     > {
         let (eth_block, geth_traces, history_hashes, prev_state_root) =
             self.get_block(block_num).await?;
-        let access_set = self.get_state_accesses(&eth_block, &geth_traces)?;
+        let access_set = Self::get_state_accesses(&eth_block, &geth_traces)?;
         let (proofs, codes) = self.get_state(block_num, access_set).await?;
-        let (state_db, code_db) = self.build_state_code_db(proofs, codes);
+        let (state_db, code_db) = Self::build_state_code_db(proofs, codes);
         let builder = self.gen_inputs_from_state(
             state_db,
             code_db,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -335,10 +335,9 @@ impl<'a> CircuitInputStateRef<'a> {
         field: AccountField,
         value: Word,
         value_prev: Word,
-    ) -> Result<(), Error> {
+    ) {
         let op = AccountOp::new(address, field, value, value_prev);
         self.push_op(step, RW::READ, op);
-        Ok(())
     }
 
     /// Push a write type [`AccountOp`] into the

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -467,7 +467,7 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
                 AccountField::CodeHash,
                 callee_code_hash_word,
                 callee_code_hash_word,
-            )?;
+            );
 
             // 3. Call to account with empty code.
             if is_empty_code_hash {

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -55,6 +55,7 @@ mod swap;
 mod error_invalid_jump;
 mod error_invalid_opcode;
 mod error_oog_call;
+mod error_oog_exp;
 mod error_oog_log;
 mod error_oog_sload_sstore;
 mod error_return_data_outofbound;
@@ -79,6 +80,7 @@ use dup::Dup;
 use error_invalid_jump::InvalidJump;
 use error_invalid_opcode::InvalidOpcode;
 use error_oog_call::OOGCall;
+use error_oog_exp::OOGExp;
 use error_oog_log::ErrorOOGLog;
 use error_oog_sload_sstore::OOGSloadSstore;
 use error_return_data_outofbound::ErrorReturnDataOutOfBound;
@@ -269,12 +271,13 @@ fn fn_gen_error_state_associated_ops(error: &ExecError) -> Option<FnGenAssociate
         ExecError::InvalidOpcode => Some(InvalidOpcode::gen_associated_ops),
         ExecError::OutOfGas(OogError::Call) => Some(OOGCall::gen_associated_ops),
         ExecError::OutOfGas(OogError::Constant) => Some(ErrorStackOogConstant::gen_associated_ops),
+        ExecError::OutOfGas(OogError::Exp) => Some(OOGExp::gen_associated_ops),
+        ExecError::OutOfGas(OogError::Log) => Some(ErrorOOGLog::gen_associated_ops),
         ExecError::OutOfGas(OogError::SloadSstore) => Some(OOGSloadSstore::gen_associated_ops),
         ExecError::StackOverflow => Some(ErrorStackOogConstant::gen_associated_ops),
         ExecError::StackUnderflow => Some(ErrorStackOogConstant::gen_associated_ops),
         // call & callcode can encounter InsufficientBalance error, Use pop-7 generic CallOpcode
         ExecError::InsufficientBalance => Some(CallOpcode::<7>::gen_associated_ops),
-        ExecError::OutOfGas(OogError::Log) => Some(ErrorOOGLog::gen_associated_ops),
         ExecError::ReturnDataOutOfBounds => Some(ErrorReturnDataOutOfBound::gen_associated_ops),
 
         // more future errors place here

--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -69,7 +69,7 @@ impl Opcode for Balance {
             AccountField::CodeHash,
             code_hash.to_word(),
             code_hash.to_word(),
-        )?;
+        );
         if exists {
             state.account_read(
                 &mut exec_step,
@@ -77,7 +77,7 @@ impl Opcode for Balance {
                 AccountField::Balance,
                 balance,
                 balance,
-            )?;
+            );
         }
 
         // Write the BALANCE result to stack.

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -106,7 +106,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             AccountField::CodeHash,
             callee_code_hash_word,
             callee_code_hash_word,
-        )?;
+        );
 
         let is_warm = state.sdb.check_account_in_access_list(&callee_address);
         state.push_op_reversible(
@@ -157,7 +157,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             AccountField::Balance,
             caller_balance,
             caller_balance,
-        )?;
+        );
 
         // Transfer value only for CALL opcode, insufficient_balance = false
         // and value > 0.

--- a/bus-mapping/src/evm/opcodes/error_oog_call.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_call.rs
@@ -76,7 +76,7 @@ impl Opcode for OOGCall {
             AccountField::CodeHash,
             callee_code_hash_word,
             callee_code_hash_word,
-        )?;
+        );
 
         let is_warm = state.sdb.check_account_in_access_list(&call_address);
         state.push_op(

--- a/bus-mapping/src/evm/opcodes/error_oog_exp.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_exp.rs
@@ -1,0 +1,36 @@
+use super::{Opcode, OpcodeId};
+use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
+use crate::error::{ExecError, OogError};
+use crate::Error;
+use eth_types::GethExecStep;
+
+/// Placeholder structure used to implement [`Opcode`] trait over it
+/// corresponding to the [`OogError::Exp`](crate::error::OogError::Exp).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct OOGExp;
+
+impl Opcode for OOGExp {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        let geth_step = &geth_steps[0];
+        debug_assert_eq!(geth_step.op, OpcodeId::EXP);
+
+        let mut exec_step = state.new_step(geth_step)?;
+        exec_step.error = Some(ExecError::OutOfGas(OogError::Exp));
+
+        for i in 0..2 {
+            state.stack_read(
+                &mut exec_step,
+                geth_step.stack.nth_last_filled(i),
+                geth_step.stack.nth_last(i)?,
+            )?;
+        }
+
+        state.gen_restore_context_ops(&mut exec_step, geth_steps)?;
+        state.handle_return(geth_step)?;
+
+        Ok(vec![exec_step])
+    }
+}

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -120,7 +120,7 @@ fn gen_extcodecopy_step(
         AccountField::CodeHash,
         code_hash.to_word(),
         code_hash.to_word(),
-    )?;
+    );
     Ok(exec_step)
 }
 

--- a/bus-mapping/src/evm/opcodes/extcodehash.rs
+++ b/bus-mapping/src/evm/opcodes/extcodehash.rs
@@ -67,7 +67,7 @@ impl Opcode for Extcodehash {
             AccountField::CodeHash,
             code_hash.to_word(),
             code_hash.to_word(),
-        )?;
+        );
 
         // Stack write of the result of EXTCODEHASH.
         state.stack_write(&mut exec_step, stack_address, steps[1].stack.last()?)?;

--- a/bus-mapping/src/evm/opcodes/extcodesize.rs
+++ b/bus-mapping/src/evm/opcodes/extcodesize.rs
@@ -63,7 +63,7 @@ impl Opcode for Extcodesize {
             AccountField::CodeHash,
             code_hash.to_word(),
             code_hash.to_word(),
-        )?;
+        );
         let code_size = if exists {
             state.code(code_hash)?.len()
         } else {

--- a/bus-mapping/src/evm/opcodes/selfbalance.rs
+++ b/bus-mapping/src/evm/opcodes/selfbalance.rs
@@ -32,7 +32,7 @@ impl Opcode for Selfbalance {
             AccountField::Balance,
             self_balance,
             self_balance,
-        )?;
+        );
 
         // Stack write of self_balance
         state.stack_write(

--- a/circuit-benchmarks/src/bytecode_circuit.rs
+++ b/circuit-benchmarks/src/bytecode_circuit.rs
@@ -26,6 +26,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_bytecode_circuit_prover() {
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         let degree: u32 = var("DEGREE")
             .unwrap_or_else(|_| "15".to_string())
             .parse()
@@ -56,7 +59,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -70,7 +73,10 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -92,7 +98,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/constants.rs
+++ b/circuit-benchmarks/src/constants.rs
@@ -1,0 +1,5 @@
+// Prefixes to be used in benchmarks' log messages for
+// consistent logging and log parsing
+pub const SETUP_PREFIX: &str = "[Setup generation]";
+pub const PROOFGEN_PREFIX: &str = "[Proof generation]";
+pub const PROOFVER_PREFIX: &str = "[Proof verification]";

--- a/circuit-benchmarks/src/copy_circuit.rs
+++ b/circuit-benchmarks/src/copy_circuit.rs
@@ -30,6 +30,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_copy_circuit_prover() {
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         let degree: u32 = var("DEGREE")
             .unwrap_or_else(|_| "14".to_string())
             .parse()
@@ -49,7 +52,7 @@ mod tests {
         let circuit = CopyCircuit::<Fr>::new_from_block(&block);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -62,7 +65,10 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -77,7 +83,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -25,6 +25,9 @@ mod evm_circ_benches {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_evm_circuit_prover() {
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         //Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "EVM Circuit";
 
@@ -56,7 +59,7 @@ mod evm_circ_benches {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -69,7 +72,10 @@ mod evm_circ_benches {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -91,7 +97,7 @@ mod evm_circ_benches {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/exp_circuit.rs
+++ b/circuit-benchmarks/src/exp_circuit.rs
@@ -31,7 +31,9 @@ mod tests {
     #[test]
     fn bench_exp_circuit_prover() {
         env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
-
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         //Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Exp Circuit";
 
@@ -57,7 +59,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree as u32, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -70,7 +72,10 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -92,7 +97,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/lib.rs
+++ b/circuit-benchmarks/src/lib.rs
@@ -31,3 +31,7 @@ pub mod copy_circuit;
 #[cfg(test)]
 #[cfg(feature = "benches")]
 pub mod exp_circuit;
+
+#[cfg(test)]
+#[cfg(feature = "benches")]
+pub mod constants;

--- a/circuit-benchmarks/src/packed_multi_keccak.rs
+++ b/circuit-benchmarks/src/packed_multi_keccak.rs
@@ -22,6 +22,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_packed_multi_keccak_circuit_prover() {
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         //Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Packed Multi-Keccak Circuit";
 
@@ -43,7 +46,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -56,7 +59,10 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -78,7 +84,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/pi_circuit.rs
+++ b/circuit-benchmarks/src/pi_circuit.rs
@@ -25,6 +25,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_pi_circuit_prover() {
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         //Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Pi Circuit";
 
@@ -57,7 +60,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree as u32, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -70,7 +73,10 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -92,7 +98,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/state_circuit.rs
+++ b/circuit-benchmarks/src/state_circuit.rs
@@ -24,6 +24,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_state_circuit_prover() {
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         //Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "State Circuit";
 
@@ -41,7 +44,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -57,7 +60,10 @@ mod tests {
         let instances: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -79,7 +85,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -29,6 +29,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_super_circuit_prover() {
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         //Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Super Circuit";
 
@@ -92,7 +95,7 @@ mod tests {
         let instance_refs: Vec<&[Fr]> = instance.iter().map(|v| &v[..]).collect();
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -105,7 +108,10 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -127,7 +133,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/tx_circuit.rs
+++ b/circuit-benchmarks/src/tx_circuit.rs
@@ -24,7 +24,9 @@ mod tests {
     #[test]
     fn bench_tx_circuit_prover() {
         env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
-
+        let setup_prfx = crate::constants::SETUP_PREFIX;
+        let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
+        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         //Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Tx Circuit";
 
@@ -47,7 +49,7 @@ mod tests {
         let circuit = TxCircuit::<Fr>::new(max_txs, MAX_CALLDATA, chain_id, txs);
 
         // Bench setup generation
-        let setup_message = format!("Setup generation with degree = {}", degree);
+        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree as u32, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -60,7 +62,10 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
+        let proof_message = format!(
+            "{} {} with degree = {}",
+            BENCHMARK_ID, proof_gen_prfx, degree
+        );
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -82,7 +87,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
+        let start3 = start_timer!(|| format!("{} {}", BENCHMARK_ID, proof_ver_prfx));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/eth-types/src/evm_types.rs
+++ b/eth-types/src/evm_types.rs
@@ -136,6 +136,10 @@ impl GasCost {
     pub const MEMORY_EXPANSION_LINEAR_COEFF: Self = Self(3);
     /// Constant gas for LOG[0-4] op codes
     pub const LOG: Self = Self(375);
+    /// Constant gas for LOG[0-4] op codes
+    /// Times ceil exponent byte size for the EXP instruction, EIP-158 changed
+    /// it from 10 to 50.
+    pub const EXP_BYTE_TIMES: Self = Self(50);
 }
 
 impl GasCost {

--- a/eth-types/src/evm_types/opcode_ids.rs
+++ b/eth-types/src/evm_types/opcode_ids.rs
@@ -4,8 +4,8 @@ use core::fmt::Debug;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{de, Deserialize, Serialize};
-use std::fmt;
 use std::str::FromStr;
+use std::{fmt, matches};
 use strum_macros::EnumIter;
 
 /// Opcode enum. One-to-one corresponding to an `u8` value.
@@ -663,9 +663,9 @@ impl OpcodeId {
         }
     }
 
-    /// Returns the constant min & stack pointer of `OpcodeId`
-    pub const fn valid_stack_ptr_range(&self) -> (u32, u32) {
-        match self {
+    /// Returns invalid stack pointers of `OpcodeId`
+    pub fn invalid_stack_ptrs(&self) -> Vec<u32> {
+        let (min_stack_ptr, max_stack_ptr): (u32, u32) = match self {
             // `min_stack_pointer` 0 means stack overflow never happen, for example, `OpcodeId::ADD`
             // can only encounter underflow error, but never encounter overflow error.
             // `max_stack_pointer` means max stack poniter for op code normally run. for example,
@@ -816,7 +816,14 @@ impl OpcodeId {
             OpcodeId::REVERT => (0, 1022),
             OpcodeId::SELFDESTRUCT => (0, 1023),
             _ => (0, 0),
-        }
+        };
+
+        debug_assert!(max_stack_ptr <= 1024);
+
+        (0..min_stack_ptr)
+            // Range (1025..=1024) is valid and it should be converted to an empty vector.
+            .chain(max_stack_ptr.checked_add(1).unwrap()..=1024)
+            .collect()
     }
 
     /// Returns `true` if the `OpcodeId` has memory access
@@ -867,10 +874,20 @@ impl OpcodeId {
         }
     }
 
+    /// Returns the all valid opcodes.
+    pub fn valid_opcodes() -> Vec<Self> {
+        (u8::MIN..=u8::MAX).fold(vec![], |mut acc, val| {
+            if !matches!(val.into(), Self::INVALID(_)) {
+                acc.push(val.into());
+            }
+            acc
+        })
+    }
+
     /// Returns the all invalid opcodes.
     pub fn invalid_opcodes() -> Vec<Self> {
         (u8::MIN..=u8::MAX).fold(vec![], |mut acc, val| {
-            if let Self::INVALID(val) = val.into() {
+            if matches!(val.into(), Self::INVALID(_)) {
                 acc.push(Self::INVALID(val));
             }
             acc

--- a/integration-tests/tests/circuit_input_builder.rs
+++ b/integration-tests/tests/circuit_input_builder.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "circuit_input_builder")]
 
-use bus_mapping::circuit_input_builder::{BuilderClient, CircuitsParams};
+use bus_mapping::circuit_input_builder::{
+    build_state_code_db, get_state_accesses, BuilderClient, CircuitsParams,
+};
 use integration_tests::{get_client, log_init, GenDataOutput};
 use lazy_static::lazy_static;
 use log::trace;
@@ -32,14 +34,14 @@ async fn test_circuit_input_builder_block(block_num: u64) {
         cli.get_block(block_num).await.unwrap();
 
     // 2. Get State Accesses from TxExecTraces
-    let access_set = cli.get_state_accesses(&eth_block, &geth_trace).unwrap();
+    let access_set = get_state_accesses(&eth_block, &geth_trace).unwrap();
     trace!("AccessSet: {:#?}", access_set);
 
     // 3. Query geth for all accounts, storage keys, and codes from Accesses
     let (proofs, codes) = cli.get_state(block_num, access_set).await.unwrap();
 
     // 4. Build a partial StateDB from step 3
-    let (state_db, code_db) = cli.build_state_code_db(proofs, codes);
+    let (state_db, code_db) = build_state_code_db(proofs, codes);
     trace!("StateDB: {:#?}", state_db);
 
     // 5. For each step in TxExecTraces, gen the associated ops and state

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -51,3 +51,4 @@ pretty_assertions = "1.0.0"
 default = []
 test = ["ethers-signers", "mock"]
 test-circuits = []
+warn-unimplemented = ["eth-types/warn-unimplemented"]

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -1175,3 +1175,43 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod copy_circuit_stats {
+    use crate::evm_circuit::step::ExecutionState;
+    use crate::stats::{bytecode_prefix_op_big_rws, print_circuit_stats_by_states};
+
+    /// Prints the stats of Copy circuit per execution state.  See
+    /// `print_circuit_stats_by_states` for more details.
+    ///
+    /// Run with:
+    /// `cargo test -p zkevm-circuits --release --all-features
+    /// get_evm_states_stats -- --nocapture --ignored`
+    #[ignore]
+    #[test]
+    fn get_copy_states_stats() {
+        print_circuit_stats_by_states(
+            |state| {
+                // TODO: Enable CREATE/CREATE2 once they are supported
+                matches!(
+                    state,
+                    ExecutionState::RETURNDATACOPY
+                        | ExecutionState::CODECOPY
+                        | ExecutionState::LOG
+                        | ExecutionState::CALLDATACOPY
+                        | ExecutionState::EXTCODECOPY
+                        | ExecutionState::RETURN_REVERT
+                )
+            },
+            bytecode_prefix_op_big_rws,
+            |block, _, _| {
+                assert!(block.copy_events.len() <= 1);
+                block
+                    .copy_events
+                    .iter()
+                    .map(|c| c.bytes.len() * 2)
+                    .sum::<usize>()
+            },
+        );
+    }
+}

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -406,12 +406,11 @@ pub mod test {
 #[cfg(test)]
 mod evm_circuit_stats {
     use crate::evm_circuit::step::ExecutionState;
+    use crate::stats::print_circuit_stats_by_states;
     use crate::test_util::CircuitTestBuilder;
-
-    use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData};
-
-    use mock::test_ctx::{helpers::*, TestContext};
-    use strum::IntoEnumIterator;
+    use eth_types::{bytecode, evm_types::OpcodeId, ToWord};
+    use mock::test_ctx::TestContext;
+    use mock::MOCK_ACCOUNTS;
 
     #[test]
     pub fn empty_evm_circuit_no_padding() {
@@ -432,67 +431,48 @@ mod evm_circuit_stats {
         .run();
     }
 
-    /// This function prints to stdout a table with all the implemented states
-    /// and their responsible opcodes with the following stats:
-    /// - height: number of rows in the EVM circuit used by the execution state
-    /// - gas: gas value used for the opcode execution
-    /// - height/gas: ratio between circuit cost and gas cost
+    /// Prints the stats of EVM circuit per execution state.  See
+    /// `print_circuit_stats_by_states` for more details.
     ///
     /// Run with:
-    /// `cargo test -p zkevm-circuits --release get_evm_states_stats --
-    /// --nocapture --ignored`
+    /// `cargo test -p zkevm-circuits --release --all-features
+    /// get_evm_states_stats -- --nocapture --ignored`
     #[ignore]
     #[test]
-    pub fn get_evm_states_stats() {
-        let mut implemented_states = Vec::new();
-        for state in ExecutionState::iter() {
-            let height = state.get_step_height_option();
-            if let Some(h) = height {
-                implemented_states.push((state, h));
-            }
-        }
-
-        let mut stats = Vec::new();
-        for (state, h) in implemented_states {
-            for opcode in state.responsible_opcodes() {
-                let mut code = bytecode! {
-                    PUSH2(0x8000)
-                    PUSH2(0x00)
-                    PUSH2(0x10)
-                    PUSH2(0x20)
-                    PUSH2(0x30)
+    fn get_evm_states_stats() {
+        print_circuit_stats_by_states(
+            |state| {
+                // TODO: Enable CREATE/CREATE2 once they are supported
+                !matches!(
+                    state,
+                    ExecutionState::ErrorInvalidOpcode
+                        | ExecutionState::CREATE
+                        | ExecutionState::CREATE2
+                        | ExecutionState::SELFDESTRUCT
+                )
+            },
+            |opcode| match opcode {
+                OpcodeId::RETURNDATACOPY => {
+                    bytecode! {
+                    PUSH1(0x00) // retLength
+                    PUSH1(0x00) // retOffset
+                    PUSH1(0x00) // argsLength
+                    PUSH1(0x00) // argsOffset
+                    PUSH1(0x00) // value
+                    PUSH32(MOCK_ACCOUNTS[3].to_word())
+                    PUSH32(0x1_0000) // gas
+                    CALL
+                    PUSH2(0x01) // size
+                    PUSH2(0x00) // offset
+                    PUSH2(0x00) // destOffset
+                    }
+                }
+                _ => bytecode! {
                     PUSH2(0x40)
                     PUSH2(0x50)
-                };
-                code.write_op(opcode);
-                code.write_op(OpcodeId::STOP);
-                let block: GethData = TestContext::<2, 1>::new(
-                    None,
-                    account_0_code_account_1_no_code(code),
-                    tx_from_1_to_0,
-                    |block, _tx| block.number(0xcafeu64),
-                )
-                .unwrap()
-                .into();
-                let gas_cost = block.geth_traces[0].struct_logs[7].gas_cost.0;
-                stats.push((state, opcode, h, gas_cost));
-            }
-        }
-
-        println!(
-            "| {: <14} | {: <14} | {: <2} | {: >6} | {: <5} |",
-            "state", "opcode", "h", "g", "h/g"
+                },
+            },
+            |_, state, _| state.get_step_height_option().unwrap(),
         );
-        println!("| ---            | ---            | ---|    --- | ---   |");
-        for (state, opcode, height, gas_cost) in stats {
-            println!(
-                "| {: <14?} | {: <14?} | {: >2} | {: >6} | {: >1.3} |",
-                state,
-                opcode,
-                height,
-                gas_cost,
-                height as f64 / gas_cost as f64
-            );
-        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -64,6 +64,7 @@ mod error_invalid_jump;
 mod error_invalid_opcode;
 mod error_oog_call;
 mod error_oog_constant;
+mod error_oog_exp;
 mod error_oog_log;
 mod error_oog_sload_sstore;
 mod error_oog_static_memory;
@@ -133,6 +134,7 @@ use error_invalid_jump::ErrorInvalidJumpGadget;
 use error_invalid_opcode::ErrorInvalidOpcodeGadget;
 use error_oog_call::ErrorOOGCallGadget;
 use error_oog_constant::ErrorOOGConstantGadget;
+use error_oog_exp::ErrorOOGExpGadget;
 use error_oog_log::ErrorOOGLogGadget;
 use error_oog_sload_sstore::ErrorOOGSloadSstoreGadget;
 use error_return_data_oo_bound::ErrorReturnDataOutOfBoundGadget;
@@ -276,6 +278,7 @@ pub(crate) struct ExecutionConfig<F> {
     // error gadgets
     error_oog_call: ErrorOOGCallGadget<F>,
     error_oog_constant: ErrorOOGConstantGadget<F>,
+    error_oog_exp: ErrorOOGExpGadget<F>,
     error_oog_sload_sstore: ErrorOOGSloadSstoreGadget<F>,
     error_oog_static_memory_gadget:
         DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasStaticMemoryExpansion }>,
@@ -287,7 +290,6 @@ pub(crate) struct ExecutionConfig<F> {
     error_oog_account_access: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasAccountAccess }>,
     error_oog_sha3: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSHA3 }>,
     error_oog_ext_codecopy: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasEXTCODECOPY }>,
-    error_oog_exp: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasEXP }>,
     error_oog_create2: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasCREATE2 }>,
     error_oog_self_destruct: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSELFDESTRUCT }>,
     error_oog_code_store: DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasCodeStore }>,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -399,6 +399,14 @@ impl<F: Field> ExecutionConfig<F> {
                     1.expr(),
                 )
             });
+            // For every step, is_create and is_root are boolean.
+            cb.condition(q_step.clone(), |cb| {
+                cb.require_boolean(
+                    "step.is_create is boolean",
+                    step_curr.state.is_create.expr(),
+                );
+                cb.require_boolean("step.is_root is boolean", step_curr.state.is_root.expr());
+            });
             // q_step needs to be enabled on the last row
             cb.condition(q_step_last, |cb| {
                 cb.require_equal("q_step == 1", q_step.clone(), 1.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_exp.rs
@@ -1,0 +1,216 @@
+use crate::evm_circuit::execution::ExecutionGadget;
+use crate::evm_circuit::param::N_BYTES_GAS;
+use crate::evm_circuit::step::ExecutionState;
+use crate::evm_circuit::util::common_gadget::RestoreContextGadget;
+use crate::evm_circuit::util::constraint_builder::Transition::{Delta, Same};
+use crate::evm_circuit::util::constraint_builder::{ConstraintBuilder, StepStateTransition};
+use crate::evm_circuit::util::math_gadget::{ByteSizeGadget, LtGadget};
+use crate::evm_circuit::util::{CachedRegion, Cell, Word};
+use crate::evm_circuit::witness::{Block, Call, ExecStep, Transaction};
+use crate::table::CallContextFieldTag;
+use crate::util::Expr;
+use eth_types::evm_types::{GasCost, OpcodeId};
+use eth_types::{Field, ToLittleEndian};
+use halo2_proofs::circuit::Value;
+use halo2_proofs::plonk::Error;
+
+/// Gadget to implement the corresponding out of gas errors for
+/// [`OpcodeId::EXP`].
+#[derive(Clone, Debug)]
+pub(crate) struct ErrorOOGExpGadget<F> {
+    opcode: Cell<F>,
+    rw_counter_end_of_reversion: Cell<F>,
+    base: Word<F>,
+    exponent: Word<F>,
+    exponent_byte_size: ByteSizeGadget<F>,
+    insufficient_gas_cost: LtGadget<F, N_BYTES_GAS>,
+    restore_context: RestoreContextGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for ErrorOOGExpGadget<F> {
+    const NAME: &'static str = "ErrorOutOfGasEXP";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ErrorOutOfGasEXP;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let opcode = cb.query_cell();
+        cb.opcode_lookup(opcode.expr(), 1.expr());
+
+        cb.require_equal(
+            "ErrorOutOfGasEXP opcode must be EXP",
+            opcode.expr(),
+            OpcodeId::EXP.expr(),
+        );
+
+        let base = cb.query_word_rlc();
+        let exponent = cb.query_word_rlc();
+        cb.stack_pop(base.expr());
+        cb.stack_pop(exponent.expr());
+
+        let exponent_byte_size = ByteSizeGadget::construct(cb, &exponent);
+
+        let insufficient_gas_cost = LtGadget::construct(
+            cb,
+            cb.curr.state.gas_left.expr(),
+            // static_gas = 10
+            // dynamic_gas = exponent_byte_size * 50
+            // gas_cost = dynamic_gas + static_gas
+            exponent_byte_size.byte_size() * GasCost::EXP_BYTE_TIMES.0.expr()
+                + OpcodeId::EXP.constant_gas_cost().expr(),
+        );
+
+        cb.require_equal(
+            "Gas left is less than gas cost",
+            insufficient_gas_cost.expr(),
+            1.expr(),
+        );
+
+        // Current call must fail.
+        cb.call_context_lookup(false.expr(), None, CallContextFieldTag::IsSuccess, 0.expr());
+
+        let rw_counter_end_of_reversion = cb.query_cell();
+        cb.call_context_lookup(
+            false.expr(),
+            None,
+            CallContextFieldTag::RwCounterEndOfReversion,
+            rw_counter_end_of_reversion.expr(),
+        );
+
+        // Go to EndTx only when is_root.
+        let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
+        cb.require_equal(
+            "Go to EndTx only when is_root",
+            cb.curr.state.is_root.expr(),
+            is_to_end_tx,
+        );
+
+        // When it's a root call.
+        cb.condition(cb.curr.state.is_root.expr(), |cb| {
+            // Do step state transition.
+            cb.require_step_state_transition(StepStateTransition {
+                call_id: Same,
+                rw_counter: Delta(4.expr() + cb.curr.state.reversible_write_counter.expr()),
+                ..StepStateTransition::any()
+            });
+        });
+
+        // When it's an internal call, need to restore caller's state as finishing this
+        // call. Restore caller state to next StepState.
+        let restore_context = cb.condition(1.expr() - cb.curr.state.is_root.expr(), |cb| {
+            RestoreContextGadget::construct(
+                cb,
+                0.expr(),
+                0.expr(),
+                0.expr(),
+                0.expr(),
+                0.expr(),
+                0.expr(),
+            )
+        });
+
+        // Constrain RwCounterEndOfReversion.
+        let rw_counter_end_of_step =
+            cb.curr.state.rw_counter.expr() + cb.rw_counter_offset() - 1.expr();
+        cb.require_equal(
+            "rw_counter_end_of_reversion = rw_counter_end_of_step + reversible_counter",
+            rw_counter_end_of_reversion.expr(),
+            rw_counter_end_of_step + cb.curr.state.reversible_write_counter.expr(),
+        );
+
+        Self {
+            opcode,
+            rw_counter_end_of_reversion,
+            base,
+            exponent,
+            exponent_byte_size,
+            insufficient_gas_cost,
+            restore_context,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _tx: &Transaction,
+        call: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        let opcode = step.opcode.unwrap();
+        let [base, exponent] = [0, 1].map(|idx| block.rws[step.rw_indices[idx]].stack_value());
+
+        log::debug!(
+            "ErrorOutOfGasEXP: gas_left = {}, gas_cost = {}",
+            step.gas_left,
+            step.gas_cost,
+        );
+
+        self.opcode
+            .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
+        self.rw_counter_end_of_reversion.assign(
+            region,
+            offset,
+            Value::known(F::from(call.rw_counter_end_of_reversion as u64)),
+        )?;
+        self.base.assign(region, offset, Some(base.to_le_bytes()))?;
+        self.exponent
+            .assign(region, offset, Some(exponent.to_le_bytes()))?;
+        self.exponent_byte_size.assign(region, offset, exponent)?;
+        self.insufficient_gas_cost.assign_value(
+            region,
+            offset,
+            Value::known(F::from(step.gas_left)),
+            Value::known(F::from(step.gas_cost)),
+        )?;
+        self.restore_context
+            .assign(region, offset, block, call, step, 4)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::evm_circuit::test::rand_word;
+    use crate::test_util::CircuitTestBuilder;
+    use eth_types::evm_types::{GasCost, OpcodeId};
+    use eth_types::{bytecode, U256};
+    use mock::test_ctx::helpers::account_0_code_account_1_no_code;
+    use mock::TestContext;
+
+    #[test]
+    fn test_oog_exp() {
+        test_ok(U256::zero());
+        test_ok(U256::one());
+        test_ok(1023.into());
+        test_ok(U256::MAX);
+        test_ok(rand_word());
+    }
+
+    fn test_ok(exponent: U256) {
+        let code = bytecode! {
+            PUSH32(exponent)
+            PUSH32(rand_word())
+            EXP
+        };
+
+        let gas_cost = OpcodeId::PUSH32.constant_gas_cost().0 * 2
+            + OpcodeId::EXP.constant_gas_cost().0
+            + ((exponent.bits() as u64 + 7) / 8) * GasCost::EXP_BYTE_TIMES.0;
+
+        let ctx = TestContext::<2, 1>::new(
+            None,
+            account_0_code_account_1_no_code(code),
+            |mut txs, accs| {
+                // Decrease expected gas cost (by 1) to trigger out of gas error.
+                txs[0]
+                    .from(accs[1].address)
+                    .to(accs[0].address)
+                    .gas((GasCost::TX.0 + gas_cost - 1).into());
+            },
+            |block, _tx| block.number(0xcafe_u64),
+        )
+        .unwrap();
+
+        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
@@ -1,13 +1,13 @@
 use crate::evm_circuit::{
     execution::ExecutionGadget,
     step::ExecutionState,
+    table::{FixedTableTag, Lookup},
     util::{
         common_gadget::RestoreContextGadget,
         constraint_builder::{
             ConstraintBuilder, StepStateTransition,
             Transition::{Delta, Same},
         },
-        math_gadget::LtGadget,
         CachedRegion, Cell,
     },
     witness::{Block, Call, ExecStep, Transaction},
@@ -17,15 +17,9 @@ use crate::util::Expr;
 use eth_types::Field;
 use halo2_proofs::{circuit::Value, plonk::Error};
 
-const N_BYTES_STACK: usize = 2;
-
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorStackGadget<F> {
     opcode: Cell<F>,
-    min_stack_pointer: Cell<F>,
-    max_stack_pointer: Cell<F>,
-    is_overflow: LtGadget<F, N_BYTES_STACK>,
-    is_underflow: LtGadget<F, N_BYTES_STACK>,
     rw_counter_end_of_reversion: Cell<F>,
     restore_context: RestoreContextGadget<F>,
 }
@@ -39,40 +33,22 @@ impl<F: Field> ExecutionGadget<F> for ErrorStackGadget<F> {
         let opcode = cb.query_cell();
         cb.opcode_lookup(opcode.expr(), 1.expr());
 
-        let min_stack_pointer = cb.query_cell();
-        let max_stack_pointer = cb.query_cell();
-        let rw_counter_end_of_reversion = cb.query_cell();
-
-        cb.opcode_stack_lookup(
-            opcode.expr(),
-            min_stack_pointer.expr(),
-            max_stack_pointer.expr(),
-        );
-        // Check whether current stack pointer is underflow or overflow
-
-        let is_overflow = LtGadget::construct(
-            cb,
-            cb.curr.state.stack_pointer.expr(),
-            min_stack_pointer.expr(),
-        );
-        let is_underflow = LtGadget::construct(
-            cb,
-            max_stack_pointer.expr(),
-            cb.curr.state.stack_pointer.expr(),
-        );
-        // is_overflow and is_underflow is bool ensure by LtGadget.
-
-        // constrain one of [is_underflow, is_overflow] must be true when stack error
-        // happens
-        cb.require_equal(
-            "is_underflow + is_overflow = 1",
-            is_underflow.expr() + is_overflow.expr(),
-            1.expr(),
+        cb.add_lookup(
+            "Responsible opcode lookup for invalid stack pointer",
+            Lookup::Fixed {
+                tag: FixedTableTag::ResponsibleOpcode.expr(),
+                values: [
+                    Self::EXECUTION_STATE.as_u64().expr(),
+                    opcode.expr(),
+                    cb.curr.state.stack_pointer.expr(),
+                ],
+            },
         );
 
         // current call must be failed.
         cb.call_context_lookup(false.expr(), None, CallContextFieldTag::IsSuccess, 0.expr());
 
+        let rw_counter_end_of_reversion = cb.query_cell();
         cb.call_context_lookup(
             false.expr(),
             None,
@@ -124,10 +100,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorStackGadget<F> {
 
         Self {
             opcode,
-            min_stack_pointer,
-            max_stack_pointer,
-            is_overflow,
-            is_underflow,
             rw_counter_end_of_reversion,
             restore_context,
         }
@@ -143,29 +115,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorStackGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         let opcode = step.opcode.unwrap();
-
-        let (min_stack, max_stack) = opcode.valid_stack_ptr_range();
-
         self.opcode
             .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
-        // Inputs/Outputs
-        self.min_stack_pointer
-            .assign(region, offset, Value::known(F::from(min_stack as u64)))?;
-        self.max_stack_pointer
-            .assign(region, offset, Value::known(F::from(max_stack as u64)))?;
-
-        self.is_overflow.assign(
-            region,
-            offset,
-            F::from(step.stack_pointer as u64),
-            F::from(min_stack as u64),
-        )?;
-        self.is_underflow.assign(
-            region,
-            offset,
-            F::from(max_stack as u64),
-            F::from(step.stack_pointer as u64),
-        )?;
 
         self.rw_counter_end_of_reversion.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/exp.rs
@@ -1,4 +1,5 @@
 use bus_mapping::evm::OpcodeId;
+use eth_types::evm_types::GasCost;
 use eth_types::{Field, ToLittleEndian, ToScalar, U256};
 use gadgets::util::{and, not, split_u256, sum, Expr};
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -174,13 +175,15 @@ impl<F: Field> ExecutionGadget<F> for ExponentiationGadget<F> {
         // bytes that can represent the exponent value.
         let exponent_byte_size = ByteSizeGadget::construct(cb, &exponent_rlc);
 
-        // Finally we build an expression for the dynamic gas cost.
-        let dynamic_gas_cost = 50.expr() * exponent_byte_size.byte_size();
+        // Finally we build an expression for the dynamic gas cost as:
+        // dynamic_gas = 50 * exponent_byte_size
+        let dynamic_gas_cost = GasCost::EXP_BYTE_TIMES.0.expr() * exponent_byte_size.byte_size();
         let step_state_transition = StepStateTransition {
             rw_counter: Transition::Delta(3.expr()), // 2 stack pops, 1 stack push
             program_counter: Transition::Delta(1.expr()),
             stack_pointer: Transition::Delta(1.expr()),
             gas_left: Transition::Delta(
+                // gas_cost = static_gas (10) + dynamic_gas
                 -OpcodeId::EXP.constant_gas_cost().expr() - dynamic_gas_cost,
             ),
             ..Default::default()

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -161,7 +161,18 @@ impl ExecutionState {
             || self.halts_in_exception()
     }
 
-    pub(crate) fn responsible_opcodes(&self) -> Vec<OpcodeId> {
+    pub(crate) fn responsible_opcodes(&self) -> Vec<ResponsibleOp> {
+        if matches!(self, Self::ErrorStack) {
+            return OpcodeId::valid_opcodes()
+                .into_iter()
+                .flat_map(|op| {
+                    op.invalid_stack_ptrs()
+                        .into_iter()
+                        .map(move |stack_ptr| ResponsibleOp::InvalidStackPtr(op, stack_ptr))
+                })
+                .collect();
+        }
+
         match self {
             Self::STOP => vec![OpcodeId::STOP],
             Self::ADD_SUB => vec![OpcodeId::ADD, OpcodeId::SUB],
@@ -304,6 +315,9 @@ impl ExecutionState {
             Self::ErrorInvalidOpcode => OpcodeId::invalid_opcodes(),
             _ => vec![],
         }
+        .into_iter()
+        .map(Into::into)
+        .collect()
     }
 
     pub fn get_step_height_option(&self) -> Option<usize> {
@@ -313,6 +327,31 @@ impl ExecutionState {
     pub fn get_step_height(&self) -> usize {
         self.get_step_height_option()
             .unwrap_or_else(|| panic!("Execution state unknown: {:?}", self))
+    }
+}
+
+/// Enum of Responsible opcode mapping to execution state.
+#[derive(Debug)]
+pub(crate) enum ResponsibleOp {
+    /// Raw opcode
+    Op(OpcodeId),
+    /// Corresponding to ExecutionState::ErrorStack
+    InvalidStackPtr(OpcodeId, u32),
+}
+
+/// Helper for easy transform from a raw OpcodeId to ResponsibleOp.
+impl From<OpcodeId> for ResponsibleOp {
+    fn from(opcode: OpcodeId) -> Self {
+        Self::Op(opcode)
+    }
+}
+
+impl ResponsibleOp {
+    pub(crate) fn opcode(&self) -> OpcodeId {
+        *match self {
+            ResponsibleOp::Op(opcode) => opcode,
+            ResponsibleOp::InvalidStackPtr(opcode, _) => opcode,
+        }
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -1,4 +1,4 @@
-use crate::evm_circuit::step::ExecutionState;
+use crate::evm_circuit::step::{ExecutionState, ResponsibleOp};
 use crate::impl_expr;
 pub use crate::table::TxContextFieldTag;
 use bus_mapping::evm::OpcodeId;
@@ -26,7 +26,6 @@ pub enum FixedTableTag {
     ResponsibleOpcode,
     Pow2,
     ConstantGasCost,
-    OpcodeStack,
 }
 impl_expr!(FixedTableTag);
 
@@ -78,17 +77,22 @@ impl FixedTableTag {
             })),
             Self::ResponsibleOpcode => {
                 Box::new(ExecutionState::iter().flat_map(move |execution_state| {
-                    execution_state
-                        .responsible_opcodes()
-                        .into_iter()
-                        .map(move |opcode| {
+                    execution_state.responsible_opcodes().into_iter().map(
+                        move |responsible_opcode| {
+                            let (op, aux) = match responsible_opcode {
+                                ResponsibleOp::Op(op) => (op, F::zero()),
+                                ResponsibleOp::InvalidStackPtr(op, stack_ptr) => {
+                                    (op, F::from(u64::from(stack_ptr)))
+                                }
+                            };
                             [
                                 tag,
                                 F::from(execution_state.as_u64()),
-                                F::from(opcode.as_u64()),
-                                F::zero(),
+                                F::from(op.as_u64()),
+                                aux,
                             ]
-                        })
+                        },
+                    )
                 }))
             }
             Self::Pow2 => Box::new((0..256).map(move |value| {
@@ -108,18 +112,6 @@ impl FixedTableTag {
                             F::from(opcode.as_u64()),
                             F::from(opcode.constant_gas_cost().0),
                             F::zero(),
-                        ]
-                    }),
-            ),
-            Self::OpcodeStack => Box::new(
-                OpcodeId::iter()
-                    .filter(move |opcode| opcode.constant_gas_cost().0 > 0)
-                    .map(move |opcode| {
-                        [
-                            tag,
-                            F::from(opcode.as_u64()),
-                            F::from(opcode.valid_stack_ptr_range().0 as u64),
-                            F::from(opcode.valid_stack_ptr_range().1 as u64),
                         ]
                     }),
             ),

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -551,22 +551,6 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         );
     }
 
-    // look up opcode's min and max stack pointer
-    pub(crate) fn opcode_stack_lookup(
-        &mut self,
-        opcode: Expression<F>,
-        min_stack: Expression<F>,
-        max_stack: Expression<F>,
-    ) {
-        self.add_lookup(
-            "op code stack info",
-            Lookup::Fixed {
-                tag: FixedTableTag::OpcodeStack.expr(),
-                values: [opcode, min_stack, max_stack],
-            },
-        );
-    }
-
     // Opcode
 
     pub(crate) fn opcode_lookup(&mut self, opcode: Expression<F>, is_code: Expression<F>) {

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -184,8 +184,12 @@ pub struct ContractCreateGadget<F, const IS_CREATE2: bool> {
     caller_address: RandomLinearCombination<F, N_BYTES_ACCOUNT_ADDRESS>,
     /// Sender nonce of the contract creation tx.
     nonce: RlpU64Gadget<F>,
-    /// Keccak256 hash of init code, used for CREATE2.
-    code_hash: RandomLinearCombination<F, N_BYTES_WORD>,
+    /// Keccak256 hash of init code, used for CREATE2. We don't use a
+    /// RandomLinearCombination here since we require both keccak and word
+    /// RLC in the case of init code hash, for BeginTx and
+    /// CREATE2 respectively. Instead, we store just the bytes and calculate the
+    /// appropriate RLC wherever needed.
+    code_hash: [Cell<F>; N_BYTES_WORD],
     /// Random salt for CREATE2.
     salt: RandomLinearCombination<F, N_BYTES_WORD>,
 }
@@ -195,8 +199,8 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     pub(crate) fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
         let caller_address = cb.query_keccak_rlc();
         let nonce = RlpU64Gadget::construct(cb);
-        let code_hash = cb.query_word_rlc();
-        let salt = cb.query_word_rlc();
+        let code_hash = array_init::array_init(|_| cb.query_byte());
+        let salt = cb.query_keccak_rlc();
 
         Self {
             caller_address,
@@ -223,12 +227,17 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
 
         self.nonce.assign(region, offset, caller_nonce)?;
 
-        for (word, value) in [(&self.code_hash, code_hash), (&self.salt, salt)] {
-            word.assign(
-                region,
-                offset,
-                Some(value.map(|v| v.to_le_bytes()).unwrap_or_default()),
-            )?;
+        self.salt.assign(
+            region,
+            offset,
+            Some(salt.map(|v| v.to_le_bytes()).unwrap_or_default()),
+        )?;
+        for (c, v) in self
+            .code_hash
+            .iter()
+            .zip(code_hash.map(|v| v.to_le_bytes()).unwrap_or_default())
+        {
+            c.assign(region, offset, Value::known(F::from(v as u64)))?;
         }
 
         Ok(())
@@ -244,13 +253,32 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         self.nonce.value()
     }
 
-    /// Code hash RLC.
-    pub(crate) fn code_hash_rlc(&self) -> Expression<F> {
-        self.code_hash.expr()
+    /// Code hash word RLC.
+    pub(crate) fn code_hash_word_rlc(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
+        cb.word_rlc::<N_BYTES_WORD>(
+            self.code_hash
+                .iter()
+                .map(Expr::expr)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        )
     }
 
-    /// Salt RLC.
-    pub(crate) fn salt_rlc(&self) -> Expression<F> {
+    /// Code hash keccak RLC.
+    pub(crate) fn code_hash_keccak_rlc(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
+        cb.keccak_rlc::<N_BYTES_WORD>(
+            self.code_hash
+                .iter()
+                .map(Expr::expr)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    /// Salt keccak RLC.
+    pub(crate) fn salt_keccak_rlc(&self) -> Expression<F> {
         self.salt.expr()
     }
 
@@ -267,11 +295,11 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     /// Length of the input data to the keccak hash function.
     pub(crate) fn input_length(&self) -> Expression<F> {
         if IS_CREATE2 {
-            // 0xff | caller_address | salt | code_hash
+            // | 0xff | caller_address | salt | code_hash |
+            // |------|----------------|------|-----------|
+            // | 1    | 20             | 32   | 32        |
             (1 + 20 + 32 + 32).expr()
         } else {
-            // RLP([caller_address, caller_nonce])
-            //
             // | prefix | addr-prefix | addr | nonce-bytes       |
             // |--------|-------------|------|-------------------|
             // | 1      | 1           | 20   | rlp_length(nonce) |
@@ -284,15 +312,19 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         let challenges = cb.challenges().keccak_powers_of_randomness::<21>();
         let challenge_power_20 = challenges[19].clone();
         if IS_CREATE2 {
-            // RLC(0xff | caller_address | salt | code_hash)
+            // RLC(le-bytes([0xff | caller_address | salt | code_hash]))
+            //
+            // | 0xff | caller address | salt | init code hash |
+            // |------|----------------|------|----------------|
+            // | 1    | 20             | 32   | 32             |
             let challenge_power_16 = challenges[15].clone();
             let challenge_power_32 = challenge_power_16.square();
             let challenge_power_64 = challenge_power_32.clone().square();
             let challenge_power_84 = challenge_power_64.clone() * challenge_power_20;
             (0xff.expr() * challenge_power_84)
                 + (self.caller_address_rlc() * challenge_power_64)
-                + (self.salt_rlc() * challenge_power_32)
-                + self.code_hash_rlc()
+                + (self.salt_keccak_rlc() * challenge_power_32)
+                + self.code_hash_keccak_rlc(cb)
         } else {
             // RLC(RLP([caller_address, caller_nonce]))
             let challenge_power_21 = challenges[20].clone();
@@ -310,42 +342,66 @@ mod test {
     use super::super::test_util::*;
     use super::ContractCreateGadget;
     use eth_types::{Field, ToAddress, ToLittleEndian, ToWord, Word};
-    use gadgets::util::Expr;
+    use gadgets::util::{not, Expr};
     use halo2_proofs::halo2curves::bn256::Fr;
 
-    use crate::evm_circuit::{
-        param::N_BYTES_WORD,
-        util::{
-            constraint_builder::ConstraintBuilder, CachedRegion, Cell, RandomLinearCombination,
-        },
-    };
+    use crate::evm_circuit::util::{constraint_builder::ConstraintBuilder, CachedRegion, Cell};
 
     #[derive(Clone)]
-    struct ContractCreateGadgetContainer<F> {
-        create_gadget: ContractCreateGadget<F, false>,
+    struct ContractCreateGadgetContainer<F, const IS_CREATE2: bool> {
+        create_gadget: ContractCreateGadget<F, IS_CREATE2>,
         input_len_expected: Cell<F>,
-        input_rlc_expected: RandomLinearCombination<F, N_BYTES_WORD>,
+        create_input_rlc_expected: [Cell<F>; 32],
+        create2_input_rlc_expected: [Cell<F>; 85],
     }
 
-    impl<F: Field> MathGadgetContainer<F> for ContractCreateGadgetContainer<F> {
+    impl<F: Field, const IS_CREATE2: bool> MathGadgetContainer<F>
+        for ContractCreateGadgetContainer<F, IS_CREATE2>
+    {
         fn configure_gadget_container(cb: &mut ConstraintBuilder<F>) -> Self {
             let create_gadget = ContractCreateGadget::construct(cb);
             let input_len_expected = cb.query_cell();
-            let input_rlc_expected = cb.query_keccak_rlc();
+            let create_input_rlc_expected = array_init::array_init(|_| cb.query_byte());
+            let create2_input_rlc_expected = array_init::array_init(|_| cb.query_byte());
             cb.require_equal(
                 "RLP length correct",
                 input_len_expected.expr(),
                 create_gadget.input_length(),
             );
-            cb.require_equal(
-                "RLP-encoding correct",
-                input_rlc_expected.expr(),
-                create_gadget.input_rlc(cb),
-            );
+            cb.condition(IS_CREATE2.expr(), |cb| {
+                cb.require_equal(
+                    "CREATE2 RLP-encoding correct",
+                    cb.keccak_rlc::<85>(
+                        create2_input_rlc_expected
+                            .iter()
+                            .map(Expr::expr)
+                            .collect::<Vec<_>>()
+                            .try_into()
+                            .unwrap(),
+                    ),
+                    create_gadget.input_rlc(cb),
+                );
+            });
+            cb.condition(not::expr(IS_CREATE2.expr()), |cb| {
+                cb.require_equal(
+                    "CREATE RLP-encoding correct",
+                    cb.keccak_rlc::<32>(
+                        create_input_rlc_expected
+                            .iter()
+                            .map(Expr::expr)
+                            .collect::<Vec<_>>()
+                            .try_into()
+                            .unwrap(),
+                    ),
+                    create_gadget.input_rlc(cb),
+                );
+            });
+
             Self {
                 create_gadget,
                 input_len_expected,
-                input_rlc_expected,
+                create_input_rlc_expected,
+                create2_input_rlc_expected,
             }
         }
 
@@ -357,15 +413,50 @@ mod test {
             let offset = 0;
             let caller_address = witnesses[0].to_address();
             let caller_nonce = witnesses[1].as_u64();
-            let rlp_encoding = witnesses[2];
-            let rlp_length = witnesses[3].as_u64();
+            let input_len = witnesses[2].as_u64();
+            let (salt, init_code_hash) = if IS_CREATE2 {
+                (Some(witnesses[5]), Some(witnesses[6]))
+            } else {
+                (None, None)
+            };
 
-            self.create_gadget
-                .assign(region, offset, caller_address, caller_nonce, None, None)?;
+            self.create_gadget.assign(
+                region,
+                offset,
+                caller_address,
+                caller_nonce,
+                init_code_hash,
+                salt,
+            )?;
             self.input_len_expected
-                .assign(region, offset, Value::known(F::from(rlp_length)))?;
-            self.input_rlc_expected
-                .assign(region, offset, Some(rlp_encoding.to_le_bytes()))?;
+                .assign(region, offset, Value::known(F::from(input_len)))?;
+            if IS_CREATE2 {
+                for c in self.create_input_rlc_expected.iter() {
+                    c.assign(region, offset, Value::known(F::zero()))?;
+                }
+                for (c, v) in self.create2_input_rlc_expected.iter().zip(
+                    [
+                        witnesses[6].to_le_bytes().as_ref(), // 32-byte init code hash
+                        witnesses[5].to_le_bytes().as_ref(), // 32-byte salt
+                        witnesses[4].to_le_bytes()[0..20].as_ref(), // 20-byte address
+                        witnesses[3].to_le_bytes()[0..1].as_ref(), // 0xff
+                    ]
+                    .concat(),
+                ) {
+                    c.assign(region, offset, Value::known(F::from(v as u64)))?;
+                }
+            } else {
+                for (c, v) in self
+                    .create_input_rlc_expected
+                    .iter()
+                    .zip(witnesses[3].to_le_bytes())
+                {
+                    c.assign(region, offset, Value::known(F::from(v as u64)))?;
+                }
+                for c in self.create2_input_rlc_expected.iter() {
+                    c.assign(region, offset, Value::known(F::zero()))?;
+                }
+            }
 
             Ok(())
         }
@@ -399,12 +490,14 @@ mod test {
                 )
             };
             try_test!(
-                ContractCreateGadgetContainer<Fr>,
+                ContractCreateGadgetContainer<Fr, false>,
                 vec![
                     caller_address.to_word(),
                     Word::from(caller_nonce),
+                    rlp_len,
                     rlp_word,
-                    rlp_len
+                    Word::default(),
+                    Word::default(),
                 ],
                 true
             );
@@ -412,8 +505,22 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn create2_address() {
-        todo!()
+        let caller_address = mock::MOCK_ACCOUNTS[0];
+        let salt = Word::from(0xbeefcafedeadu64);
+        let code_hash = Word::from(0xdeadcafeu64);
+        try_test!(
+            ContractCreateGadgetContainer<Fr, true>,
+            vec![
+                caller_address.to_word(),
+                Word::default(),
+                85u64.into(),
+                Word::from(0xffu64),
+                caller_address.to_word(),
+                salt,
+                code_hash,
+            ],
+            true
+        )
     }
 }

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -31,6 +31,9 @@ pub mod table;
 #[cfg(any(feature = "test", test))]
 pub mod test_util;
 
+#[cfg(any(feature = "test", test))]
+mod stats;
+
 pub mod tx_circuit;
 pub mod util;
 pub mod witness;

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -606,125 +606,34 @@ fn queries<F: Field>(meta: &mut VirtualCells<'_, F>, c: &StateCircuitConfig<F>) 
 #[cfg(test)]
 mod state_circuit_stats {
     use crate::evm_circuit::step::ExecutionState;
-    use bus_mapping::{circuit_input_builder::ExecState, mock::BlockData};
-    use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData, Address};
-    use mock::{eth, test_ctx::TestContext, MOCK_ACCOUNTS};
-    use strum::IntoEnumIterator;
+    use crate::stats::{bytecode_prefix_op_big_rws, print_circuit_stats_by_states};
 
-    /// This function prints to stdout a table with all the implemented states
-    /// and their responsible opcodes with the following stats:
-    /// - height: number of rows in the State circuit used by the execution
-    ///   state
-    /// - gas: gas value used for the opcode execution
-    /// - height/gas: ratio between circuit cost and gas cost
+    /// Prints the stats of State circuit per execution state.  See
+    /// `print_circuit_stats_by_states` for more details.
     ///
     /// Run with:
-    /// `cargo test -p zkevm-circuits --release get_state_states_stats --
-    /// --nocapture --ignored`
+    /// `cargo test -p zkevm-circuits --release --all-features
+    /// get_state_states_stats -- --nocapture --ignored`
     #[ignore]
     #[test]
     pub fn get_state_states_stats() {
-        // Get the list of implemented execution states by configuring the EVM Circuit
-        // and querying the step height for each possible execution state (only those
-        // implemented will return a Some value).
-
-        let mut implemented_states = Vec::new();
-        for state in ExecutionState::iter() {
-            let height = state.get_step_height_option();
-            if height.is_some() {
-                implemented_states.push(state);
-            }
-        }
-
-        let mut stats = Vec::new();
-        for state in implemented_states {
-            for opcode in state.responsible_opcodes() {
-                let mut code = bytecode! {
-                    PUSH2(0x100)
-                    MLOAD // Expand memory a bit
-                    PUSH2(0x00)
-                    EXTCODESIZE // Warm up 0x0 address
-                    PUSH2(0x8000)
-                    PUSH2(0x00)
-                    PUSH2(0x10)
-                    PUSH2(0x20)
-                    PUSH2(0x30)
-                };
-                // Make sure that opcodes that take an address as argument use addres 0x0, which
-                // will exist in the test.
-                match opcode {
-                    OpcodeId::BALANCE
-                    | OpcodeId::EXTCODESIZE
-                    | OpcodeId::EXTCODECOPY
-                    | OpcodeId::SELFDESTRUCT
-                    | OpcodeId::EXTCODEHASH => code.append(&bytecode! {
-                        PUSH2(0x40)
-                        PUSH2(0x00)
-                    }),
-                    OpcodeId::CALL
-                    | OpcodeId::CALLCODE
-                    | OpcodeId::DELEGATECALL
-                    | OpcodeId::STATICCALL => code.append(&bytecode! {
-                        PUSH2(0x00)
-                        PUSH2(0x50)
-                    }),
-                    _ => code.append(&bytecode! {
-                        PUSH2(0x40)
-                        PUSH2(0x50)
-                    }),
-                };
-                code.write_op(opcode);
-                code.write_op(OpcodeId::STOP);
-                let block: GethData = TestContext::<3, 1>::new(
-                    None,
-                    |accs| {
-                        accs[0]
-                            .address(MOCK_ACCOUNTS[0])
-                            .balance(eth(10))
-                            .code(code.clone());
-                        accs[1].address(MOCK_ACCOUNTS[1]).balance(eth(10));
-                        accs[2].address(Address::zero()).balance(eth(10)).code(code);
-                    },
-                    |mut txs, accs| {
-                        txs[0]
-                            .from(accs[1].address)
-                            .to(accs[0].address)
-                            .input(vec![1, 2, 3, 4, 5, 6, 7].into());
-                    },
-                    |block, _tx| block.number(0xcafeu64),
+        print_circuit_stats_by_states(
+            |state| {
+                // TODO: Enable CREATE/CREATE2 once they are supported
+                !matches!(
+                    state,
+                    ExecutionState::ErrorInvalidOpcode
+                        | ExecutionState::CREATE
+                        | ExecutionState::CREATE2
+                        | ExecutionState::SELFDESTRUCT
                 )
-                .unwrap()
-                .into();
-                let mut builder =
-                    BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
-                builder
-                    .handle_block(&block.eth_block, &block.geth_traces)
-                    .unwrap();
-                let step_index = 1 + 11; // 1 is for the BeginTx, 11 for the bytecode opcodes.
-                let step = &builder.block.txs[0].steps()[step_index];
-                let step_next = &builder.block.txs[0].steps()[step_index + 1];
-                assert_eq!(ExecState::Op(opcode), step.exec_state);
-                let h = step_next.rwc.0 - step.rwc.0;
-
-                let gas_cost = block.geth_traces[0].struct_logs[11].gas_cost.0;
-                stats.push((state, opcode, h, gas_cost));
-            }
-        }
-
-        println!(
-            "| {: <14} | {: <14} | {: <2} | {: >6} | {: <5} |",
-            "state", "opcode", "h", "g", "h/g"
+            },
+            bytecode_prefix_op_big_rws,
+            |block, _, step_index| {
+                let step = &block.txs[0].steps()[step_index];
+                let step_next = &block.txs[0].steps()[step_index + 1];
+                step_next.rwc.0 - step.rwc.0
+            },
         );
-        println!("| ---            | ---            | ---|    --- | ---   |");
-        for (state, opcode, height, gas_cost) in stats {
-            println!(
-                "| {: <14?} | {: <14?} | {: >2} | {: >6} | {: >1.3} |",
-                state,
-                opcode,
-                height,
-                gas_cost,
-                height as f64 / gas_cost as f64
-            );
-        }
     }
 }

--- a/zkevm-circuits/src/stats.rs
+++ b/zkevm-circuits/src/stats.rs
@@ -156,7 +156,8 @@ pub(crate) fn print_circuit_stats_by_states(
         if !fn_filter(state) {
             continue;
         }
-        for opcode in state.responsible_opcodes() {
+        for responsible_op in state.responsible_opcodes() {
+            let opcode = responsible_op.opcode();
             let mut code = bytecode! {
                 PUSH2(0x00)
                 EXTCODESIZE // Warm up 0x0 address

--- a/zkevm-circuits/src/stats.rs
+++ b/zkevm-circuits/src/stats.rs
@@ -1,0 +1,248 @@
+use crate::evm_circuit::step::ExecutionState;
+use bus_mapping::{
+    circuit_input_builder::{self, CircuitsParams, ExecState},
+    mock::BlockData,
+};
+use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData, Address, Bytecode, ToWord};
+use mock::{eth, test_ctx::TestContext, MOCK_ACCOUNTS};
+use strum::IntoEnumIterator;
+
+/// Helper type to print formatted tables in MarkDown
+pub(crate) struct DisplayTable<const N: usize> {
+    header: [String; N],
+    rows: Vec<[String; N]>,
+}
+
+impl<const N: usize> DisplayTable<N> {
+    pub(crate) fn new(header: [String; N]) -> Self {
+        Self {
+            header,
+            rows: Vec::new(),
+        }
+    }
+    fn push_row(&mut self, row: [String; N]) {
+        self.rows.push(row)
+    }
+    fn print_row(row: &[String; N], rows_width: &[usize; N]) {
+        for (i, h) in row.iter().enumerate() {
+            if i == 0 {
+                print!("|");
+            }
+            print!(" {:width$} |", h, width = rows_width[i]);
+        }
+        println!();
+    }
+    pub(crate) fn print(&self) {
+        let mut rows_width = [0; N];
+        for row in std::iter::once(&self.header).chain(self.rows.iter()) {
+            for (i, s) in row.iter().enumerate() {
+                if s.len() > rows_width[i] {
+                    rows_width[i] = s.len();
+                }
+            }
+        }
+        Self::print_row(&self.header, &rows_width);
+        for (i, width) in rows_width.iter().enumerate() {
+            if i == 0 {
+                print!("|");
+            }
+            print!(" {:-<width$} |", "", width = width);
+        }
+        println!();
+        for row in &self.rows {
+            Self::print_row(row, &rows_width);
+        }
+    }
+}
+
+/// Generate the prefix bytecode to trigger a big amount of rw operations
+pub(crate) fn bytecode_prefix_op_big_rws(opcode: OpcodeId) -> Bytecode {
+    match opcode {
+        OpcodeId::CODECOPY | OpcodeId::CALLDATACOPY => {
+            bytecode! {
+                PUSH4(0x1000) // size
+                PUSH2(0x00) // offset
+                PUSH2(0x00) // destOffset
+            }
+        }
+        OpcodeId::RETURNDATACOPY => {
+            bytecode! {
+                PUSH1(0x00) // retLength
+                PUSH1(0x00) // retOffset
+                PUSH1(0x00) // argsLength
+                PUSH1(0x00) // argsOffset
+                PUSH1(0x00) // value
+                PUSH32(MOCK_ACCOUNTS[3].to_word())
+                PUSH32(0x1_0000) // gas
+                CALL
+                PUSH4(0x1000) // size
+                PUSH2(0x00) // offset
+                PUSH2(0x00) // destOffset
+            }
+        }
+        OpcodeId::LOG0
+        | OpcodeId::LOG1
+        | OpcodeId::LOG2
+        | OpcodeId::LOG3
+        | OpcodeId::LOG4
+        | OpcodeId::SHA3
+        | OpcodeId::RETURN
+        | OpcodeId::REVERT => bytecode! {
+            PUSH4(0x1000) // size
+            PUSH2(0x00) // offset
+        },
+        OpcodeId::EXTCODECOPY => bytecode! {
+            PUSH4(0x1000) // size
+            PUSH2(0x00) // offset
+            PUSH2(0x00) // destOffset
+            PUSH2(0x00) // address
+        },
+        _ => bytecode! {
+            PUSH2(0x40)
+            PUSH2(0x50)
+        },
+    }
+}
+
+/// This function prints to stdout a table with all the implemented states
+/// and their responsible opcodes with the following stats:
+/// - height: number of rows in a circuit used by the execution state
+/// - gas: gas value used for the opcode execution
+/// - height/gas: ratio between circuit cost and gas cost
+///
+/// The TestContext is as follows:
+/// - `MOCK_ACCOUNTS[0]` calls `MOCK_ACCOUNTS[1]` which has a proxy code that
+///   calls `MOCK_ACCOUNT[2]` which has the main code
+/// - `0x0` account has a copy of the main code
+/// - `MOCK_ACCOUNTS[3]` has a small code that returns a 0-memory chunk
+pub(crate) fn print_circuit_stats_by_states(
+    // Function to select which opcodes to analyze.  When this returns false,
+    // the opcode is skipped.
+    fn_filter: impl Fn(ExecutionState) -> bool,
+    // Function to generate bytecode that will be prefixed to the opcode,
+    // useful to set up arguments that cause worst height/gas case.
+    fn_bytecode_prefix_op: impl Fn(OpcodeId) -> Bytecode,
+    // Function that calculates the circuit height used by an opcode.  This function takes the
+    // circuit input builder Block, the current execution state, and the step index in circuit
+    // input builder tx.
+    fn_height: impl Fn(&circuit_input_builder::Block, ExecutionState, usize) -> usize,
+) {
+    let mut implemented_states = Vec::new();
+    for state in ExecutionState::iter() {
+        let height = state.get_step_height_option();
+        if height.is_some() {
+            implemented_states.push(state);
+        }
+    }
+    let smallcode = bytecode! {
+        PUSH4(0x1000) // size
+        PUSH2(0x00) // offset
+        RETURN
+    };
+    let proxy_code = bytecode! {
+        PUSH2(0x1000) // retLength
+        PUSH1(0x00) // retOffset
+        PUSH1(0x00) // argsLength
+        PUSH1(0x00) // argsOffset
+        PUSH1(0x00) // value
+        PUSH32(MOCK_ACCOUNTS[2].to_word())
+        PUSH32(800_000) // gas
+        CALL
+        STOP
+    };
+
+    let mut table = DisplayTable::new(["state", "opcode", "h", "g", "h/g"].map(|s| s.into()));
+    for state in implemented_states {
+        if !fn_filter(state) {
+            continue;
+        }
+        for opcode in state.responsible_opcodes() {
+            let mut code = bytecode! {
+                PUSH2(0x00)
+                EXTCODESIZE // Warm up 0x0 address
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH2(0x00)
+                PUSH2(0x10)
+                PUSH2(0x20)
+                PUSH2(0x30)
+            };
+            let bytecode_prefix_op = fn_bytecode_prefix_op(opcode);
+            code.append(&bytecode_prefix_op);
+            code.write_op(opcode);
+            let opcode_pc = code.code.len() - 1;
+            // let opcode_step_index = (proxy_code.num_opcodes - 1 + code.num_opcodes) - 1;
+            code.write_op(OpcodeId::STOP);
+            let block: GethData = TestContext::<10, 1>::new(
+                None,
+                |accs| {
+                    accs[0].address(MOCK_ACCOUNTS[0]).balance(eth(10));
+                    accs[1]
+                        .address(MOCK_ACCOUNTS[1])
+                        .balance(eth(10))
+                        .code(proxy_code.clone());
+                    accs[2]
+                        .address(MOCK_ACCOUNTS[2])
+                        .balance(eth(10))
+                        .code(code.clone());
+                    accs[3].address(MOCK_ACCOUNTS[3]).code(smallcode.clone());
+                    accs[4].address(Address::zero()).balance(eth(10)).code(code);
+                },
+                |mut txs, accs| {
+                    txs[0]
+                        .from(accs[0].address)
+                        .to(accs[1].address)
+                        .input(vec![1, 2, 3, 4, 5, 6, 7].into());
+                },
+                |block, _tx| block.number(0xcafeu64),
+            )
+            .unwrap()
+            .into();
+            let mut builder = BlockData::new_from_geth_data_with_params(
+                block.clone(),
+                CircuitsParams {
+                    max_rws: 16_000,
+                    max_copy_rows: 8_000,
+                    ..CircuitsParams::default()
+                },
+            )
+            .new_circuit_input_builder();
+            builder
+                .handle_block(&block.eth_block, &block.geth_traces)
+                .unwrap();
+            // Find the step that executed our opcode by filtering on second call (because
+            // we run it via proxy) and the PC where we wrote the opcode.
+            let (step_index, step) = builder.block.txs[0]
+                .steps()
+                .iter()
+                .enumerate()
+                .find(|(_, s)| s.call_index == 1 && s.pc.0 == opcode_pc)
+                .unwrap();
+            assert_eq!(ExecState::Op(opcode), step.exec_state);
+            let h = fn_height(&builder.block, state, step_index);
+
+            // Substract 1 to step_index to remove the `BeginTx` step, which doesn't appear
+            // in the geth trace.
+            let geth_step = &block.geth_traces[0].struct_logs[step_index - 1];
+            assert_eq!(opcode, geth_step.op);
+            let gas_cost = geth_step.gas_cost.0;
+            table.push_row([
+                format!("{:?}", state),
+                format!("{:?}", opcode),
+                format!("{}", h),
+                format!("{}", gas_cost),
+                format!("{:1.3}", h as f64 / gas_cost as f64),
+            ]);
+        }
+    }
+
+    table.print();
+}


### PR DESCRIPTION
Spec Markdown PR https://github.com/scroll-tech/zkevm-specs/pull/58

### Summary

~~1. Add and export `byte_size_value` function from `ByteSizeGadget` (which is also used to calculate gas cost in `ErrorOOGExpGadget`). And rename original `byte_size` to `byte_size_expr`.~~

2. Implement `ErrorOOGExpGadget` to handle OOG error of `EXP` opcode.