### PR TITLE
Only stack operations of bus-mapping and circuit for execution state `ErrorPrecompileFailed`

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -62,6 +62,7 @@ mod error_invalid_opcode;
 mod error_oog_call;
 mod error_oog_log;
 mod error_oog_sload_sstore;
+mod error_precompile_failed;
 mod error_stack_oog_constant;
 
 #[cfg(test)]
@@ -86,6 +87,7 @@ use error_invalid_opcode::InvalidOpcode;
 use error_oog_call::OOGCall;
 use error_oog_log::ErrorOOGLog;
 use error_oog_sload_sstore::OOGSloadSstore;
+use error_precompile_failed::PrecompileFailed;
 use error_stack_oog_constant::ErrorStackOogConstant;
 use exp::Exponentiation;
 use extcodecopy::Extcodecopy;
@@ -274,6 +276,7 @@ fn fn_gen_error_state_associated_ops(error: &ExecError) -> Option<FnGenAssociate
         ExecError::StackUnderflow => Some(ErrorStackOogConstant::gen_associated_ops),
         // call & callcode can encounter InsufficientBalance error, Use pop-7 generic CallOpcode
         ExecError::InsufficientBalance => Some(CallOpcode::<7>::gen_associated_ops),
+        ExecError::PrecompileFailed => Some(PrecompileFailed::gen_associated_ops),
 
         // more future errors place here
         _ => {

--- a/bus-mapping/src/evm/opcodes/error_precompile_failed.rs
+++ b/bus-mapping/src/evm/opcodes/error_precompile_failed.rs
@@ -1,0 +1,43 @@
+use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
+use crate::error::ExecError;
+use crate::evm::Opcode;
+use crate::Error;
+use eth_types::evm_types::OpcodeId;
+use eth_types::GethExecStep;
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct PrecompileFailed;
+
+impl Opcode for PrecompileFailed {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        let geth_step = &geth_steps[0];
+        let stack_input_num = match geth_step.op {
+            OpcodeId::CALL | OpcodeId::CALLCODE => 7,
+            OpcodeId::DELEGATECALL | OpcodeId::STATICCALL => 6,
+            op => unreachable!("{op} should not happen in PrecompileFailed"),
+        };
+
+        let mut exec_step = state.new_step(geth_step)?;
+        exec_step.error = Some(ExecError::PrecompileFailed);
+
+        for i in 0..stack_input_num {
+            state.stack_read(
+                &mut exec_step,
+                geth_step.stack.nth_last_filled(i),
+                geth_step.stack.nth_last(i)?,
+            )?;
+        }
+
+        state.stack_write(
+            &mut exec_step,
+            geth_step.stack.nth_last_filled(stack_input_num - 1),
+            // Must fail.
+            (0_u64).into(),
+        )?;
+
+        Ok(vec![exec_step])
+    }
+}

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -161,7 +161,6 @@ fn into_traceconfig(st: StateTest) -> (String, TraceConfig, StateTestResult) {
                 enable_memory: *bus_mapping::util::CHECK_MEM_STRICT,
                 ..Default::default()
             },
-            ..Default::default()
         },
         st.result,
     )

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -84,6 +84,7 @@ mod error_oog_constant;
 mod error_oog_log;
 mod error_oog_sload_sstore;
 mod error_oog_static_memory;
+mod error_precompile_failed;
 mod error_stack;
 mod exp;
 mod extcodecopy;
@@ -152,6 +153,7 @@ use error_oog_call::ErrorOOGCallGadget;
 use error_oog_constant::ErrorOOGConstantGadget;
 use error_oog_log::ErrorOOGLogGadget;
 use error_oog_sload_sstore::ErrorOOGSloadSstoreGadget;
+use error_precompile_failed::ErrorPrecompileFailedGadget;
 use error_stack::ErrorStackGadget;
 use exp::ExponentiationGadget;
 use extcodecopy::ExtcodecopyGadget;
@@ -317,7 +319,7 @@ pub(crate) struct ExecutionConfig<F> {
     error_invalid_creation_code: DummyGadget<F, 0, 0, { ExecutionState::ErrorInvalidCreationCode }>,
     error_return_data_out_of_bound:
         DummyGadget<F, 0, 0, { ExecutionState::ErrorReturnDataOutOfBound }>,
-    error_precompile_failed: DummyGadget<F, 0, 0, { ExecutionState::ErrorPrecompileFailed }>,
+    error_precompile_failed: ErrorPrecompileFailedGadget<F>,
 }
 
 impl<F: Field> ExecutionConfig<F> {

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1203,6 +1203,7 @@ impl<F: Field> ExecutionConfig<F> {
         self.assign_exec_step_int(region, offset, block, transaction, call, step, true)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn assign_exec_step_int(
         &self,
         region: &mut CachedRegion<'_, '_, F>,

--- a/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
@@ -1,0 +1,144 @@
+use crate::evm_circuit::execution::ExecutionGadget;
+use crate::evm_circuit::step::ExecutionState;
+use crate::evm_circuit::util::constraint_builder::ConstraintBuilder;
+use crate::evm_circuit::util::math_gadget::IsZeroGadget;
+use crate::evm_circuit::util::memory_gadget::MemoryAddressGadget;
+use crate::evm_circuit::util::{CachedRegion, Cell, Word};
+use crate::util::Expr;
+use crate::witness::{Block, Call, ExecStep, Transaction};
+use bus_mapping::evm::OpcodeId;
+use eth_types::{Field, ToLittleEndian, U256};
+use halo2_proofs::circuit::Value;
+use halo2_proofs::plonk::Error;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ErrorPrecompileFailedGadget<F> {
+    opcode: Cell<F>,
+    is_call: IsZeroGadget<F>,
+    is_callcode: IsZeroGadget<F>,
+    is_delegatecall: IsZeroGadget<F>,
+    is_staticcall: IsZeroGadget<F>,
+    gas: Word<F>,
+    callee_address: Word<F>,
+    value: Word<F>,
+    cd_address: MemoryAddressGadget<F>,
+    rd_address: MemoryAddressGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for ErrorPrecompileFailedGadget<F> {
+    const NAME: &'static str = "ErrorPrecompileFailed";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ErrorPrecompileFailed;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let opcode = cb.query_cell();
+        cb.opcode_lookup(opcode.expr(), 1.expr());
+
+        let is_call = IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::CALL.expr());
+        let is_callcode = IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::CALLCODE.expr());
+        let is_delegatecall =
+            IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::DELEGATECALL.expr());
+        let is_staticcall =
+            IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::STATICCALL.expr());
+
+        let gas = cb.query_word_rlc();
+        let callee_address = cb.query_word_rlc();
+        let value = cb.query_word_rlc();
+        let cd_offset = cb.query_cell_phase2();
+        let cd_length = cb.query_word_rlc();
+        let rd_offset = cb.query_cell_phase2();
+        let rd_length = cb.query_word_rlc();
+
+        cb.stack_pop(gas.expr());
+        cb.stack_pop(callee_address.expr());
+
+        // `CALL` and `CALLCODE` opcodes have an additional stack pop `value`.
+        cb.condition(is_call.expr() + is_callcode.expr(), |cb| {
+            cb.stack_pop(value.expr())
+        });
+        cb.stack_pop(cd_offset.expr());
+        cb.stack_pop(cd_length.expr());
+        cb.stack_pop(rd_offset.expr());
+        cb.stack_pop(rd_length.expr());
+        cb.stack_push(0.expr());
+
+        let cd_address = MemoryAddressGadget::construct(cb, cd_offset, cd_length);
+        let rd_address = MemoryAddressGadget::construct(cb, rd_offset, rd_length);
+
+        Self {
+            opcode,
+            is_call,
+            is_callcode,
+            is_delegatecall,
+            is_staticcall,
+            gas,
+            callee_address,
+            value,
+            cd_address,
+            rd_address,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _tx: &Transaction,
+        _call: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        let opcode = step.opcode.unwrap();
+        let is_call_or_callcode =
+            usize::from([OpcodeId::CALL, OpcodeId::CALLCODE].contains(&opcode));
+
+        let [gas, callee_address] =
+            [step.rw_indices[0], step.rw_indices[1]].map(|idx| block.rws[idx].stack_value());
+        let value = if is_call_or_callcode == 1 {
+            block.rws[step.rw_indices[2]].stack_value()
+        } else {
+            U256::zero()
+        };
+        let [cd_offset, cd_length, rd_offset, rd_length] = [
+            step.rw_indices[is_call_or_callcode + 2],
+            step.rw_indices[is_call_or_callcode + 3],
+            step.rw_indices[is_call_or_callcode + 4],
+            step.rw_indices[is_call_or_callcode + 5],
+        ]
+        .map(|idx| block.rws[idx].stack_value());
+
+        self.opcode
+            .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
+        self.is_call.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::CALL.as_u64()),
+        )?;
+        self.is_callcode.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::CALLCODE.as_u64()),
+        )?;
+        self.is_delegatecall.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::DELEGATECALL.as_u64()),
+        )?;
+        self.is_staticcall.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::STATICCALL.as_u64()),
+        )?;
+        self.gas.assign(region, offset, Some(gas.to_le_bytes()))?;
+        self.callee_address
+            .assign(region, offset, Some(callee_address.to_le_bytes()))?;
+        self.value
+            .assign(region, offset, Some(value.to_le_bytes()))?;
+        self.cd_address
+            .assign(region, offset, cd_offset, cd_length)?;
+        self.rd_address
+            .assign(region, offset, rd_offset, rd_length)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Only implement stack operations for `ErrorPrecompileFailed` (not full support).

Fixed the failed cases of `testool`, tested with below commands:
```
cd testool
cargo run --release -- --inspect callcodeNonConst_d0_g0_v1
cargo run --release -- --inspect delegatecallNonConst_d0_g0_v1
```

Since the RW map is sorted by stack pointer (for Stack tag and same call id). `ErrorPrecompileFailed` only returns an error and didn't handle stack operations. It causes a failed cases of RW rows as:
```
row_prev - is_write=true, value = 1
--- miss the stack pop of failed precompile as: is_write=false, value = 1
--- miss the stack push of failed precompile as: is_write=true, value = 0 (is_success)
row - is_write=false, value = 0
```