### PR TITLE
fix: sanity check for `MemoryAddressGadget`

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -115,6 +115,19 @@ impl<F: Field> MemoryAddressGadget<F> {
         let memory_offset_bytes = memory_offset.to_le_bytes();
         let memory_length_bytes = memory_length.to_le_bytes();
         let memory_length_is_zero = memory_length.is_zero();
+
+        // Both Memory offset (when memory_length != 0) and length must be less than
+        // 2^40.
+        let max_mem_addr = U256::from(1_u64 << (8 * N_BYTES_MEMORY_ADDRESS));
+        if (!memory_length_is_zero && memory_offset >= max_mem_addr)
+            || memory_length >= max_mem_addr
+        {
+            panic!(
+                "memory offset {} or length {} overflow {} bytes",
+                memory_offset, memory_length, N_BYTES_MEMORY_ADDRESS
+            );
+        }
+
         self.memory_offset.assign(
             region,
             offset,


### PR DESCRIPTION
### Summary

1. Add sanity check to panic if ~~either `memory_offset` or~~ `memory_length` is greater than or equal to `2^40` (already has a constraint for `memory_offset` if memory_length != 0).

~~2. Constrain `memory_length (Cell) == memory_length_bytes (MemoryAddress)` for `Memory length decomposition into 5 bytes` (as `memory_offset`). `memory_offset` has already been constrained in this gadget before. (May fix to not add this constraint)~~

As https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1215#issuecomment-1433085205, it seems that `MemoryAddressGadget` is designed for successful case (may extend for error case - may add a generic parameter S and replace `MemoryAddress<F>` with `RandomLinearCombination<F, S>`).