### PR TITLE
Fix `fee` to not reversible in begin tx

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -527,27 +527,14 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
     ) -> Result<(), Error> {
         let gas_fee = tx.gas_price * tx.gas;
 
-        let (
-            caller_balance_sub_fee_pair,
-            caller_balance_sub_value_pair,
-            callee_balance_pair,
-            callee_code_hash,
-        ) = if tx.is_create {
-            (
-                block.rws[step.rw_indices[7]].account_value_pair(),
-                block.rws[step.rw_indices[8]].account_value_pair(),
-                block.rws[step.rw_indices[9]].account_value_pair(),
-                call.code_hash,
-            )
+        let [caller_balance_sub_fee_pair, caller_balance_sub_value_pair, callee_balance_pair] =
+            [7, 8, 9].map(|idx| block.rws[step.rw_indices[idx]].account_value_pair());
+        let callee_code_hash = if tx.is_create {
+            call.code_hash
         } else {
-            (
-                block.rws[step.rw_indices[7]].account_value_pair(),
-                block.rws[step.rw_indices[8]].account_value_pair(),
-                block.rws[step.rw_indices[9]].account_value_pair(),
-                // TODO: handle call to precompiled contracts where we may not have a account read
-                // for code hash.
-                block.rws[step.rw_indices[10]].account_value_pair().0,
-            )
+            // TODO: handle call to precompiled contracts where we may not have a account
+            // read for code hash.
+            block.rws[step.rw_indices[10]].account_value_pair().0
         };
 
         self.tx_id

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -293,7 +293,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             }
 
             cb.require_step_state_transition(StepStateTransition {
-                // 23 reads and writes:
+                // 24 reads and writes:
                 //   - Write CallContext TxId
                 //   - Write CallContext RwCounterEndOfReversion
                 //   - Write CallContext IsPersistent
@@ -301,6 +301,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write caller Account Nonce
                 //   - Write TxAccessListAccount
                 //   - Write TxAccessListAccount
+                //   - Write Account Balance (Not Reversible)
                 //   - Write Account Balance (Reversible)
                 //   - Write Account Balance (Reversible)
                 //   - Write callee Account Nonce (Reversible)
@@ -317,7 +318,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write CallContext IsRoot
                 //   - Write CallContext IsCreate
                 //   - Write CallContext CodeHash
-                rw_counter: Delta(23.expr()),
+                rw_counter: Delta(24.expr()),
                 call_id: To(call_id.expr()),
                 is_root: To(true.expr()),
                 is_create: To(tx_is_create.expr()),
@@ -349,7 +350,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             );
 
             cb.require_step_state_transition(StepStateTransition {
-                // 10 reads and writes:
+                // 11 reads and writes:
                 //   - Write CallContext TxId
                 //   - Write CallContext RwCounterEndOfReversion
                 //   - Write CallContext IsPersistent
@@ -359,8 +360,9 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write TxAccessListAccount
                 //   - Write Account Balance
                 //   - Write Account Balance
+                //   - Write Account Balance
                 //   - Read Account CodeHash
-                rw_counter: Delta(10.expr()),
+                rw_counter: Delta(11.expr()),
                 call_id: To(call_id.expr()),
                 ..StepStateTransition::any()
             });
@@ -398,7 +400,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             );
 
             cb.require_step_state_transition(StepStateTransition {
-                // 10 reads and writes:
+                // 11 reads and writes:
                 //   - Write CallContext TxId
                 //   - Write CallContext RwCounterEndOfReversion
                 //   - Write CallContext IsPersistent
@@ -408,8 +410,9 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write TxAccessListAccount
                 //   - Write Account Balance
                 //   - Write Account Balance
+                //   - Write Account Balance
                 //   - Read Account CodeHash
-                rw_counter: Delta(10.expr() + not::expr(tx_value_is_zero.expr())),
+                rw_counter: Delta(11.expr() + not::expr(tx_value_is_zero.expr())),
                 call_id: To(call_id.expr()),
                 ..StepStateTransition::any()
             });
@@ -447,7 +450,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             }
 
             cb.require_step_state_transition(StepStateTransition {
-                // 23 reads and writes:
+                // 24 reads and writes:
                 //   - Write CallContext TxId
                 //   - Write CallContext RwCounterEndOfReversion
                 //   - Write CallContext IsPersistent
@@ -455,6 +458,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write Account Nonce
                 //   - Write TxAccessListAccount
                 //   - Write TxAccessListAccount
+                //   - Write Account Balance (Not Reversible)
                 //   - Write Account Balance (Reversible)
                 //   - Write Account Balance (Reversible)
                 //   - Read Account CodeHash
@@ -471,7 +475,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write CallContext IsRoot
                 //   - Write CallContext IsCreate
                 //   - Write CallContext CodeHash
-                rw_counter: Delta(23.expr()),
+                rw_counter: Delta(24.expr()),
                 call_id: To(call_id.expr()),
                 is_root: To(true.expr()),
                 is_create: To(tx_is_create.expr()),
@@ -523,19 +527,26 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
     ) -> Result<(), Error> {
         let gas_fee = tx.gas_price * tx.gas;
 
-        let (caller_balance_pair, callee_balance_pair, callee_code_hash) = if tx.is_create {
+        let (
+            caller_balance_sub_fee_pair,
+            caller_balance_sub_value_pair,
+            callee_balance_pair,
+            callee_code_hash,
+        ) = if tx.is_create {
             (
                 block.rws[step.rw_indices[7]].account_value_pair(),
                 block.rws[step.rw_indices[8]].account_value_pair(),
+                block.rws[step.rw_indices[9]].account_value_pair(),
                 call.code_hash,
             )
         } else {
             (
                 block.rws[step.rw_indices[7]].account_value_pair(),
                 block.rws[step.rw_indices[8]].account_value_pair(),
+                block.rws[step.rw_indices[9]].account_value_pair(),
                 // TODO: handle call to precompiled contracts where we may not have a account read
                 // for code hash.
-                block.rws[step.rw_indices[9]].account_value_pair().0,
+                block.rws[step.rw_indices[10]].account_value_pair().0,
             )
         };
 
@@ -609,7 +620,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         self.transfer_with_gas_fee.assign(
             region,
             offset,
-            caller_balance_pair,
+            caller_balance_sub_fee_pair,
+            caller_balance_sub_value_pair,
             callee_balance_pair,
             tx.value,
             gas_fee,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -334,7 +334,8 @@ impl<F: Field, const N_ADDENDS: usize, const INCREASE: bool>
 
 #[derive(Clone, Debug)]
 pub(crate) struct TransferWithGasFeeGadget<F> {
-    sender: UpdateBalanceGadget<F, 3, false>,
+    sender_fee: UpdateBalanceGadget<F, 2, false>,
+    sender_value: UpdateBalanceGadget<F, 2, false>,
     receiver: UpdateBalanceGadget<F, 2, true>,
 }
 
@@ -347,38 +348,52 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
         gas_fee: Word<F>,
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {
-        let sender = UpdateBalanceGadget::construct(
+        let sender_fee =
+            UpdateBalanceGadget::construct(cb, sender_address.expr(), vec![gas_fee], None);
+        let sender_value = UpdateBalanceGadget::construct(
             cb,
             sender_address,
-            vec![value.clone(), gas_fee],
+            vec![value.clone()],
             Some(reversion_info),
         );
         let receiver =
             UpdateBalanceGadget::construct(cb, receiver_address, vec![value], Some(reversion_info));
 
-        Self { sender, receiver }
+        Self {
+            sender_fee,
+            sender_value,
+            receiver,
+        }
     }
 
     pub(crate) fn assign(
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        (sender_balance, sender_balance_prev): (U256, U256),
-        (receiver_balance, receiver_balance_prev): (U256, U256),
+        (sender_balance_sub_fee, prev_sender_balance_sub_fee): (U256, U256),
+        (sender_balance_sub_value, prev_sender_balance_sub_value): (U256, U256),
+        (receiver_balance, prev_receiver_balance): (U256, U256),
         value: U256,
         gas_fee: U256,
     ) -> Result<(), Error> {
-        self.sender.assign(
+        self.sender_fee.assign(
             region,
             offset,
-            sender_balance_prev,
-            vec![value, gas_fee],
-            sender_balance,
+            prev_sender_balance_sub_fee,
+            vec![gas_fee],
+            sender_balance_sub_fee,
+        )?;
+        self.sender_value.assign(
+            region,
+            offset,
+            prev_sender_balance_sub_value,
+            vec![value],
+            sender_balance_sub_value,
         )?;
         self.receiver.assign(
             region,
             offset,
-            receiver_balance_prev,
+            prev_receiver_balance,
             vec![value],
             receiver_balance,
         )?;


### PR DESCRIPTION
Upstream issue https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1235

Reference go-ethereum code:

1. Seems `fee` is transfered in [buyGas function](https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L233).

2. [buyGas function](https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L215) is invoked by [preCheck function](https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L237).

3. `value` is transfered in [this Call invocation](https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L359).

4. Call [get StateDB snapshot](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L184) and [revert snapshot](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L243).

So seems transfer `value` should be reversible but `fee` should not? It is implemented as [transfer_with_fee](https://github.com/scroll-tech/zkevm-circuits/blob/scroll-stable/bus-mapping/src/circuit_input_builder/input_state_ref.rs#L486) and set both as reversible in current zkevm-circuit.