### PR TITLE
Bug-fix: handle tx.to = 0x0 correctly

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -520,6 +520,7 @@ pub fn get_dummy_tx(chain_id: u64) -> (TransactionRequest, Signature) {
         .nonce(0)
         .gas(0)
         .gas_price(U256::zero())
+        .to(Address::zero())
         .value(U256::zero())
         .data(Bytes::default())
         .chain_id(chain_id);

--- a/mock/src/transaction.rs
+++ b/mock/src/transaction.rs
@@ -68,6 +68,15 @@ lazy_static! {
                 .gas_price(word!("0x4d2"))
                 .input(Bytes::from(b"hello"))
                 .build(),
+            MockTransaction::default()
+                .transaction_idx(6u64)
+                .from(AddrOrWallet::random(&mut rng))
+                .to(AddrOrWallet::Addr(Address::zero()))
+                .nonce(word!("0x0"))
+                .value(word!("0x0"))
+                .gas_price(word!("0x4d2"))
+                .input(Bytes::from(b"hello"))
+                .build(),
         ]
     };
 }

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag, TxFieldTag as TxContextFieldTag},
 };
-use eth_types::{Field, ToLittleEndian, ToScalar};
+use eth_types::{Address, Field, ToLittleEndian, ToScalar};
 use ethers_core::utils::{get_contract_address, keccak256, rlp::RlpStream};
 use gadgets::util::{and, expr_from_bytes, not, or, Expr};
 use halo2_proofs::plonk::Error;
@@ -563,6 +563,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             .assign(region, offset, caller_address)?;
         let callee_address = tx
             .callee_address
+            .unwrap_or(Address::zero())
             .to_scalar()
             .expect("unexpected Address -> Scalar conversion failure");
         self.tx_callee_address
@@ -578,7 +579,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 if tx.is_create {
                     get_contract_address(tx.caller_address, tx.nonce)
                 } else {
-                    tx.callee_address
+                    tx.callee_address.unwrap_or(Address::zero())
                 }
                 .to_scalar()
                 .expect("unexpected Address -> Scalar conversion failure"),

--- a/zkevm-circuits/src/rlp_circuit.rs
+++ b/zkevm-circuits/src/rlp_circuit.rs
@@ -455,6 +455,16 @@ impl<F: Field> RlpCircuitConfig<F> {
             //     "interm == is_simple_tag "
             //     is_simple_tag.clone()
             // )
+            cb.condition(
+                is_simple_tag.clone(),
+                |cb| {
+                    cb.require_equal(
+                        "tag_length =? 1",
+                        meta.query_advice(rlp_table.tag_length_eq_one, Rotation::cur()),
+                        tlength_eq.clone(),
+                    );
+                }
+            );
             // if tag_index == tag_length && tag_length == 1
             cb.condition(
                 is_simple_tag.clone() * tindex_eq_tlength.clone() * tlength_eq.clone(),
@@ -1376,6 +1386,11 @@ impl<F: Field> RlpCircuitConfig<F> {
                             ("is_prefix_tag", self.is_prefix_tag, is_prefix_tag),
                             ("is_dp_tag", self.is_dp_tag, is_dp_tag),
                             ("tag_index", rlp_table.tag_rindex, (row.tag_rindex as u64)),
+                            (
+                                "tag_length_eq_one",
+                                rlp_table.tag_length_eq_one,
+                                (row.tag_length == 1) as u64,
+                            ),
                             ("data_type", rlp_table.data_type, (row.data_type as u64)),
                             ("index", self.index, (row.index as u64)),
                             ("rindex", self.rindex, (rindex)),
@@ -1524,6 +1539,11 @@ impl<F: Field> RlpCircuitConfig<F> {
                             ("is_prefix_tag", self.is_prefix_tag, is_prefix_tag),
                             ("is_dp_tag", self.is_dp_tag, is_dp_tag),
                             ("tag_rindex", rlp_table.tag_rindex, row.tag_rindex as u64),
+                            (
+                                "tag_length_eq_one",
+                                rlp_table.tag_length_eq_one,
+                                (row.tag_length == 1) as u64,
+                            ),
                             ("data_type", rlp_table.data_type, row.data_type as u64),
                             ("index", self.index, row.index as u64),
                             ("rindex", self.rindex, rindex),

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1747,6 +1747,8 @@ pub struct RlpTable {
     /// `TxSign` (transaction data that needs to be signed) or `TxHash`
     /// (signed transaction's data).
     pub data_type: Column<Advice>,
+    /// Denotes if the tag_length is equal to 1
+    pub tag_length_eq_one: Column<Advice>,
 }
 
 impl<F: Field> LookupTable<F> for RlpTable {
@@ -1757,6 +1759,7 @@ impl<F: Field> LookupTable<F> for RlpTable {
             self.tag_rindex.into(),
             self.value_acc.into(),
             self.data_type.into(),
+            self.tag_length_eq_one.into(),
         ]
     }
 
@@ -1767,6 +1770,7 @@ impl<F: Field> LookupTable<F> for RlpTable {
             String::from("tag_rindex"),
             String::from("value_acc"),
             String::from("data_type"),
+            String::from("tag_length_eq_one"),
         ]
     }
 }
@@ -1780,6 +1784,7 @@ impl RlpTable {
             tag_rindex: meta.advice_column(),
             value_acc: meta.advice_column_in(SecondPhase),
             data_type: meta.advice_column(),
+            tag_length_eq_one: meta.advice_column(),
         }
     }
 
@@ -1787,7 +1792,7 @@ impl RlpTable {
     pub fn dev_assignments<F: Field>(
         txs: Vec<SignedTransaction>,
         challenges: &Challenges<Value<F>>,
-    ) -> Vec<[Value<F>; 5]> {
+    ) -> Vec<[Value<F>; 6]> {
         let mut assignments = vec![];
         for signed_tx in txs {
             for row in signed_tx
@@ -1803,6 +1808,7 @@ impl RlpTable {
                     Value::known(F::from(row.tag_rindex as u64)),
                     row.value_acc,
                     Value::known(F::from(row.data_type as u64)),
+                    Value::known(F::from((row.tag_length == 1) as u64)),
                 ]);
             }
         }

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -1932,4 +1932,21 @@ mod tx_circuit_tests {
         )
         .is_err(),);
     }
+
+    #[test]
+    fn tx_circuit_to_is_zero() {
+        const MAX_TXS: usize = 1;
+        const MAX_CALLDATA: usize = 32;
+
+        let chain_id: u64 = mock::MOCK_CHAIN_ID.as_u64();
+        let mut tx = mock::CORRECT_MOCK_TXS[0].clone();
+        tx.to = Some(AddrOrWallet::from(address!(
+            "0x0000000000000000000000000000000000000000"
+        )));
+
+        assert_eq!(
+            run::<Fr>(vec![tx.into()], chain_id, MAX_TXS, MAX_CALLDATA),
+            Ok(())
+        );
+    }
 }

--- a/zkevm-circuits/src/witness/rlp_encode/common.rs
+++ b/zkevm-circuits/src/witness/rlp_encode/common.rs
@@ -288,31 +288,11 @@ pub fn handle_address<F: FieldExt>(
     rows: &mut Vec<RlpWitnessRow<Value<F>>>,
     data_type: RlpDataType,
     tag: RlpTxTag,
-    value: Address,
+    value: Option<Address>,
     mut idx: usize,
 ) -> usize {
-    let value_bytes = value.as_fixed_bytes();
-
-    if value == Address::zero() && rlp_data[idx] == 0x80 {
-        assert_eq!(
-            rlp_data[idx], 0x80,
-            "RLP data mismatch({:?}): value = {}",
-            tag, rlp_data[idx]
-        );
-        rows.push(RlpWitnessRow {
-            tx_id,
-            index: idx + 1,
-            data_type,
-            value: rlp_data[idx],
-            value_acc: Value::known(F::zero()),
-            value_rlc_acc: Value::known(F::zero()),
-            tag,
-            tag_length: 1,
-            tag_rindex: 1,
-            length_acc: 0,
-        });
-        idx += 1;
-    } else {
+    if let Some(value) = value {
+        let value_bytes = value.as_fixed_bytes();
         assert_eq!(
             rlp_data[idx], 0x94,
             "RLP data mismatch({:?}): value = {}",
@@ -354,6 +334,25 @@ pub fn handle_address<F: FieldExt>(
             });
             idx += 1;
         }
+    } else {
+        assert_eq!(
+            rlp_data[idx], 0x80,
+            "RLP data mismatch({:?}): value = {}",
+            tag, rlp_data[idx],
+        );
+        rows.push(RlpWitnessRow {
+            tx_id,
+            index: idx + 1,
+            data_type,
+            value: rlp_data[idx],
+            value_acc: Value::known(F::zero()),
+            value_rlc_acc: Value::known(F::zero()),
+            tag,
+            tag_length: 1,
+            tag_rindex: 1,
+            length_acc: 0,
+        });
+        idx += 1;
     }
 
     idx

--- a/zkevm-circuits/src/witness/rlp_encode/tx.rs
+++ b/zkevm-circuits/src/witness/rlp_encode/tx.rs
@@ -379,7 +379,7 @@ mod tests {
             Value::known(r + Fr::one() + Fr::one()),
         );
 
-        let callee_address = mock::MOCK_ACCOUNTS[0];
+        let callee_address = Some(mock::MOCK_ACCOUNTS[0]);
         let call_data = rand_bytes(55);
         let tx = Transaction {
             nonce: 1,
@@ -475,7 +475,7 @@ mod tests {
         let nonce = 0x123456u64;
         let gas_price = 0x234567u64.into();
         let gas = 0x345678u64;
-        let callee_address = mock::MOCK_ACCOUNTS[1];
+        let callee_address = Some(mock::MOCK_ACCOUNTS[1]);
         let value = 0x456789u64.into();
         let call_data = rand_bytes(2048);
         let tx = Transaction {

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -42,7 +42,7 @@ pub struct Transaction {
     /// The caller address
     pub caller_address: Address,
     /// The callee address
-    pub callee_address: Address,
+    pub callee_address: Option<Address>,
     /// Whether it's a create transaction
     pub is_create: bool,
     /// The ether amount of the transaction
@@ -85,8 +85,8 @@ impl Transaction {
             block_number: 0, // FIXME
             id: 0,           // need to be changed to correct value
             caller_address: Address::zero(),
-            callee_address: Address::zero(),
-            is_create: true, // callee = 0
+            callee_address: Some(Address::zero()),
+            is_create: false, // callee_address != None
             chain_id,
             v: dummy_sig.v,
             r: dummy_sig.r,
@@ -177,7 +177,12 @@ impl Transaction {
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::CalleeAddress as u64)),
                 Value::known(F::zero()),
-                Value::known(self.callee_address.to_scalar().unwrap()),
+                Value::known(
+                    self.callee_address
+                        .unwrap_or(Address::zero())
+                        .to_scalar()
+                        .unwrap(),
+                ),
             ],
             [
                 Value::known(F::from(self.id as u64)),
@@ -296,10 +301,10 @@ impl Encodable for Transaction {
         s.append(&Word::from(self.nonce));
         s.append(&self.gas_price);
         s.append(&Word::from(self.gas));
-        if self.callee_address == Address::zero() {
-            s.append(&""); // address == 0, rlp = 0x80
+        if self.callee_address.is_none() {
+            s.append(&"");
         } else {
-            s.append(&self.callee_address);
+            s.append(&self.callee_address.unwrap());
         }
         s.append(&self.value);
         s.append(&self.call_data);
@@ -324,10 +329,10 @@ impl Encodable for SignedTransaction {
         s.append(&Word::from(self.tx.nonce));
         s.append(&self.tx.gas_price);
         s.append(&Word::from(self.tx.gas));
-        if self.tx.callee_address == Address::zero() {
-            s.append(&""); // address == 0, rlp = 0x80
+        if self.tx.callee_address.is_none() {
+            s.append(&"");
         } else {
-            s.append(&self.tx.callee_address);
+            s.append(&self.tx.callee_address.unwrap());
         }
         s.append(&self.tx.value);
         s.append(&self.tx.call_data);
@@ -340,25 +345,23 @@ impl Encodable for SignedTransaction {
 impl From<MockTransaction> for Transaction {
     fn from(mock_tx: MockTransaction) -> Self {
         let is_create = mock_tx.to.is_none();
-        let callee_address = match mock_tx.to {
-            Some(to) => to.address(),
-            None => Address::zero(),
-        };
         let sig = Signature {
             r: mock_tx.r.expect("tx expected to be signed"),
             s: mock_tx.s.expect("tx expected to be signed"),
             v: mock_tx.v.expect("tx expected to be signed").as_u64(),
         };
         let (rlp_unsigned, rlp_signed) = {
-            let legacy_tx = TransactionRequest::new()
+            let mut legacy_tx = TransactionRequest::new()
                 .from(mock_tx.from.address())
                 .nonce(mock_tx.nonce)
                 .gas_price(mock_tx.gas_price)
                 .gas(mock_tx.gas)
-                .to(callee_address)
                 .value(mock_tx.value)
                 .data(mock_tx.input.clone())
                 .chain_id(mock_tx.chain_id.as_u64());
+            if !is_create {
+                legacy_tx = legacy_tx.to(mock_tx.to.clone().map(|to| to.address()).unwrap());
+            }
 
             let unsigned = legacy_tx.rlp().to_vec();
 
@@ -374,7 +377,7 @@ impl From<MockTransaction> for Transaction {
             gas: mock_tx.gas.as_u64(),
             gas_price: mock_tx.gas_price,
             caller_address: mock_tx.from.address(),
-            callee_address,
+            callee_address: mock_tx.to.clone().map(|to| to.address()),
             is_create,
             value: mock_tx.value,
             call_data: mock_tx.input.to_vec(),
@@ -420,7 +423,7 @@ pub(super) fn tx_convert(
             .value(tx.value)
             .data(tx.input.clone())
             .chain_id(chain_id);
-        if tx.to != Address::zero() {
+        if !tx.is_create() {
             legacy_tx = legacy_tx.to(tx.to);
         }
 
@@ -429,6 +432,8 @@ pub(super) fn tx_convert(
 
         (unsigned, signed)
     };
+
+    let callee_address = if tx.is_create() { None } else { Some(tx.to) };
 
     Transaction {
         block_number: tx.block_num,
@@ -439,7 +444,7 @@ pub(super) fn tx_convert(
         gas: tx.gas,
         gas_price: tx.gas_price,
         caller_address: tx.from,
-        callee_address: tx.to,
+        callee_address,
         is_create: tx.is_create(),
         value: tx.value,
         call_data: tx.input.clone(),

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -301,10 +301,10 @@ impl Encodable for Transaction {
         s.append(&Word::from(self.nonce));
         s.append(&self.gas_price);
         s.append(&Word::from(self.gas));
-        if self.callee_address.is_none() {
-            s.append(&"");
+        if let Some(addr) = self.callee_address {
+            s.append(&addr);
         } else {
-            s.append(&self.callee_address.unwrap());
+            s.append(&"");
         }
         s.append(&self.value);
         s.append(&self.call_data);
@@ -329,10 +329,10 @@ impl Encodable for SignedTransaction {
         s.append(&Word::from(self.tx.nonce));
         s.append(&self.tx.gas_price);
         s.append(&Word::from(self.tx.gas));
-        if self.tx.callee_address.is_none() {
-            s.append(&"");
+        if let Some(addr) = self.tx.callee_address {
+            s.append(&addr);
         } else {
-            s.append(&self.tx.callee_address.unwrap());
+            s.append(&"");
         }
         s.append(&self.tx.value);
         s.append(&self.tx.call_data);
@@ -360,7 +360,7 @@ impl From<MockTransaction> for Transaction {
                 .data(mock_tx.input.clone())
                 .chain_id(mock_tx.chain_id.as_u64());
             if !is_create {
-                legacy_tx = legacy_tx.to(mock_tx.to.clone().map(|to| to.address()).unwrap());
+                legacy_tx = legacy_tx.to(mock_tx.to.as_ref().map(|to| to.address()).unwrap());
             }
 
             let unsigned = legacy_tx.rlp().to_vec();
@@ -377,7 +377,7 @@ impl From<MockTransaction> for Transaction {
             gas: mock_tx.gas.as_u64(),
             gas_price: mock_tx.gas_price,
             caller_address: mock_tx.from.address(),
-            callee_address: mock_tx.to.clone().map(|to| to.address()),
+            callee_address: mock_tx.to.as_ref().map(|to| to.address()),
             is_create,
             value: mock_tx.value,
             call_data: mock_tx.input.to_vec(),


### PR DESCRIPTION
### Description



### Issue Link

[issue#352](https://github.com/scroll-tech/zkevm-circuits/issues/352)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

