### PR TITLE
fix: other opcodes can also result in insuff balance

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -57,6 +57,7 @@ mod stackonlyop;
 mod stop;
 mod swap;
 
+mod error_insufficient_balance;
 mod error_invalid_jump;
 mod error_invalid_opcode;
 mod error_oog_call;
@@ -86,6 +87,7 @@ use codecopy::Codecopy;
 use codesize::Codesize;
 use create::Create;
 use dup::Dup;
+use error_insufficient_balance::InsufficientBalance;
 use error_invalid_jump::InvalidJump;
 use error_invalid_opcode::InvalidOpcode;
 use error_oog_call::OOGCall;
@@ -286,8 +288,7 @@ fn fn_gen_error_state_associated_ops(error: &ExecError) -> Option<FnGenAssociate
         ExecError::OutOfGas(OogError::SloadSstore) => Some(OOGSloadSstore::gen_associated_ops),
         ExecError::StackOverflow => Some(ErrorStackOogConstant::gen_associated_ops),
         ExecError::StackUnderflow => Some(ErrorStackOogConstant::gen_associated_ops),
-        // call & callcode can encounter InsufficientBalance error, Use pop-7 generic CallOpcode
-        ExecError::InsufficientBalance => Some(CallOpcode::<7>::gen_associated_ops),
+        ExecError::InsufficientBalance => Some(InsufficientBalance::gen_associated_ops),
         ExecError::PrecompileFailed => Some(PrecompileFailed::gen_associated_ops),
         ExecError::WriteProtection => Some(ErrorWriteProtection::gen_associated_ops),
         ExecError::ReturnDataOutOfBounds => Some(ErrorReturnDataOutOfBound::gen_associated_ops),

--- a/bus-mapping/src/evm/opcodes/error_insufficient_balance.rs
+++ b/bus-mapping/src/evm/opcodes/error_insufficient_balance.rs
@@ -1,0 +1,27 @@
+use crate::{
+    circuit_input_builder::{CircuitInputStateRef, ExecStep},
+    Error,
+};
+
+use eth_types::{evm_types::OpcodeId, GethExecStep};
+
+use super::{callop::CallOpcode, create::Create, Opcode};
+
+#[derive(Clone, Debug)]
+pub(crate) struct InsufficientBalance;
+
+impl Opcode for InsufficientBalance {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        match geth_steps[0].op {
+            OpcodeId::CALL | OpcodeId::CALLCODE => {
+                CallOpcode::<7>::gen_associated_ops(state, geth_steps)
+            }
+            OpcodeId::CREATE => Create::<false>::gen_associated_ops(state, geth_steps),
+            OpcodeId::CREATE2 => Create::<true>::gen_associated_ops(state, geth_steps),
+            op => unreachable!("{op} should not be encountered for InsufficientBalance error"),
+        }
+    }
+}


### PR DESCRIPTION
### Description

Different opcodes can result in `InsufficientBalance` error. Only `CALL` and `CALLCODE` were considered prior.

### Issue Link

Closes #354 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update