### PR TITLE
CI: fix failed workflows for forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,6 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: Run light tests # light tests are run in parallel
         uses: actions-rs/cargo@v1
         with:
@@ -134,9 +131,6 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:
@@ -181,9 +175,6 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
         uses: actions-rs/cargo@v1
@@ -223,9 +214,6 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:
@@ -271,9 +259,6 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,9 +73,6 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       # Run an initial build in a separate step to split the build time from execution time
       - name: Build bins
         run: cargo build --bin gen_blockchain_data

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -62,9 +62,6 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:


### PR DESCRIPTION
### Description

Fix the failed CI workflows in PR https://github.com/scroll-tech/zkevm-circuits/pull/361.

Delete `webfactory/ssh-agent` with ssh-private-key. Since [scroll-tech/halo2-lib](https://github.com/scroll-tech/halo2-lib) has already been set to public.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update