### PR TITLE
Fix: update according to previous comment of Uint64 overflow PR

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -21,7 +21,7 @@ use eth_types::{
     evm_types::{
         gas_utils::memory_expansion_gas_cost, Gas, GasCost, MemoryAddress, OpcodeId, StackAddress,
     },
-    Address, GethExecStep, ToAddress, ToBigEndian, ToWord, Word, H256, U256,
+    Address, Bytecode, GethExecStep, ToAddress, ToBigEndian, ToWord, Word, H256, U256,
 };
 use ethers_core::utils::{get_contract_address, get_create2_address};
 use keccak256::EMPTY_HASH;
@@ -1501,5 +1501,64 @@ impl<'a> CircuitInputStateRef<'a> {
         }
 
         Ok(())
+    }
+
+    /// Generate copy steps for bytecode.
+    pub(crate) fn gen_copy_steps_for_bytecode(
+        &mut self,
+        exec_step: &mut ExecStep,
+        bytecode: &Bytecode,
+        src_addr: u64,
+        dst_addr: u64,
+        src_addr_end: u64,
+        bytes_left: u64,
+    ) -> Result<Vec<(u8, bool)>, Error> {
+        let mut copy_steps = Vec::with_capacity(bytes_left as usize);
+        for idx in 0..bytes_left {
+            let addr = src_addr.checked_add(idx).unwrap_or(src_addr_end);
+            let step = if addr < src_addr_end {
+                let code = bytecode.code.get(addr as usize).unwrap();
+                (code.value, code.is_code)
+            } else {
+                (0, false)
+            };
+            copy_steps.push(step);
+            self.memory_write(exec_step, (dst_addr + idx).into(), step.0)?;
+        }
+
+        Ok(copy_steps)
+    }
+
+    /// Generate copy steps for call data.
+    pub(crate) fn gen_copy_steps_for_call_data(
+        &mut self,
+        exec_step: &mut ExecStep,
+        src_addr: u64,
+        dst_addr: u64,
+        src_addr_end: u64,
+        bytes_left: u64,
+    ) -> Result<Vec<(u8, bool)>, Error> {
+        let mut copy_steps = Vec::with_capacity(bytes_left as usize);
+        for idx in 0..bytes_left {
+            let addr = src_addr.checked_add(idx).unwrap_or(src_addr_end);
+            let value = if addr < src_addr_end {
+                let byte =
+                    self.call_ctx()?.call_data[(addr - self.call()?.call_data_offset) as usize];
+                if !self.call()?.is_root {
+                    self.push_op(
+                        exec_step,
+                        RW::READ,
+                        MemoryOp::new(self.call()?.caller_id, addr.into(), byte),
+                    );
+                }
+                byte
+            } else {
+                0
+            };
+            copy_steps.push((value, false));
+            self.memory_write(exec_step, (dst_addr + idx).into(), value)?;
+        }
+
+        Ok(copy_steps)
     }
 }

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -1,7 +1,7 @@
 use super::Opcode;
 use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::circuit_input_builder::{CopyDataType, CopyEvent, NumberOrHash};
-use crate::operation::{CallContextField, MemoryOp, RW};
+use crate::operation::CallContextField;
 use crate::Error;
 use eth_types::GethExecStep;
 
@@ -17,14 +17,13 @@ impl Opcode for Calldatacopy {
         let mut exec_steps = vec![gen_calldatacopy_step(state, geth_step)?];
 
         // reconstruction
-        let memory_offset = geth_step.stack.nth_last(0)?.as_u64();
-        // Reset data offset to the maximum value of Uint64 if overflow.
-        let data_offset = u64::try_from(geth_step.stack.nth_last(1)?).unwrap_or(u64::MAX);
-        let length = geth_step.stack.nth_last(2)?.as_usize();
+        let memory_offset = geth_step.stack.nth_last(0)?;
+        let data_offset = geth_step.stack.nth_last(1)?;
+        let length = geth_step.stack.nth_last(2)?;
         let call_ctx = state.call_ctx_mut()?;
         let memory = &mut call_ctx.memory;
 
-        memory.copy_from(memory_offset, &call_ctx.call_data, data_offset, length);
+        memory.copy_from(memory_offset, data_offset, length, &call_ctx.call_data);
 
         let copy_event = gen_copy_event(state, geth_step)?;
         state.push_copy(&mut exec_steps[0], copy_event);
@@ -90,68 +89,35 @@ fn gen_calldatacopy_step(
     Ok(exec_step)
 }
 
-fn gen_copy_steps(
-    state: &mut CircuitInputStateRef,
-    exec_step: &mut ExecStep,
-    src_addr: u64,
-    dst_addr: u64,
-    src_addr_end: u64,
-    bytes_left: u64,
-    is_root: bool,
-) -> Result<Vec<(u8, bool)>, Error> {
-    let mut copy_steps = Vec::with_capacity(bytes_left as usize);
-    for idx in 0..bytes_left {
-        let addr = src_addr.checked_add(idx).unwrap_or(src_addr_end);
-        let value = if addr < src_addr_end {
-            let byte =
-                state.call_ctx()?.call_data[(addr - state.call()?.call_data_offset) as usize];
-            if !is_root {
-                state.push_op(
-                    exec_step,
-                    RW::READ,
-                    MemoryOp::new(state.call()?.caller_id, addr.into(), byte),
-                );
-            }
-            byte
-        } else {
-            0
-        };
-        copy_steps.push((value, false));
-        state.memory_write(exec_step, (dst_addr + idx).into(), value)?;
-    }
-
-    Ok(copy_steps)
-}
-
 fn gen_copy_event(
     state: &mut CircuitInputStateRef,
     geth_step: &GethExecStep,
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
-    let memory_offset = geth_step.stack.nth_last(0)?.as_u64();
-    // Reset data offset to the maximum value of Uint64 if overflow.
-    let data_offset = u64::try_from(geth_step.stack.nth_last(1)?).unwrap_or(u64::MAX);
+
+    let memory_offset = geth_step.stack.nth_last(0)?;
+    let data_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?.as_u64();
 
     let call_data_offset = state.call()?.call_data_offset;
     let call_data_length = state.call()?.call_data_length;
 
-    let (src_addr, src_addr_end) = (
-        // Set source start to the minimum value of data offset and call data length for avoiding
-        // overflow.
-        call_data_offset + data_offset.min(call_data_length),
-        call_data_offset + call_data_length,
-    );
+    let dst_addr = memory_offset.as_u64();
+    let src_addr_end = call_data_offset + call_data_length;
+
+    // Reset offset to Uint64 maximum value if overflow, and set source start to the
+    // minimum value of offset and code size.
+    let src_addr = u64::try_from(data_offset)
+        .unwrap_or(u64::MAX)
+        .min(src_addr_end);
 
     let mut exec_step = state.new_step(geth_step)?;
-    let copy_steps = gen_copy_steps(
-        state,
+    let copy_steps = state.gen_copy_steps_for_call_data(
         &mut exec_step,
         src_addr,
-        memory_offset,
+        dst_addr,
         src_addr_end,
         length,
-        state.call()?.is_root,
     )?;
 
     let (src_type, src_id) = if state.call()?.is_root {
@@ -167,7 +133,7 @@ fn gen_copy_event(
         src_addr_end,
         dst_type: CopyDataType::Memory,
         dst_id: NumberOrHash::Number(state.call()?.call_id),
-        dst_addr: memory_offset,
+        dst_addr,
         log_id: None,
         rw_counter_start,
         bytes: copy_steps,

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -20,11 +20,9 @@ impl Opcode for Codecopy {
         let mut exec_steps = vec![gen_codecopy_step(state, geth_step)?];
 
         // reconstruction
-
-        let dest_offset = geth_step.stack.nth_last(0)?.as_u64();
-        // Reset code offset to the maximum value of Uint64 if overflow.
-        let code_offset = u64::try_from(geth_step.stack.nth_last(1)?).unwrap_or(u64::MAX);
-        let length = geth_step.stack.nth_last(2)?.as_u64();
+        let dst_offset = geth_step.stack.nth_last(0)?;
+        let code_offset = geth_step.stack.nth_last(1)?;
+        let length = geth_step.stack.nth_last(2)?;
 
         let code_hash = state.call()?.code_hash;
         let code = state.code(code_hash)?;
@@ -32,7 +30,7 @@ impl Opcode for Codecopy {
         let call_ctx = state.call_ctx_mut()?;
         let memory = &mut call_ctx.memory;
 
-        memory.copy_from(dest_offset, &code, code_offset, length as usize);
+        memory.copy_from(dst_offset, code_offset, length, &code);
 
         let copy_event = gen_copy_event(state, geth_step)?;
         state.push_copy(&mut exec_steps[0], copy_event);
@@ -66,59 +64,37 @@ fn gen_codecopy_step(
     Ok(exec_step)
 }
 
-fn gen_copy_steps(
-    state: &mut CircuitInputStateRef,
-    exec_step: &mut ExecStep,
-    src_addr: u64,
-    dst_addr: u64,
-    src_addr_end: u64,
-    bytes_left: u64,
-    bytecode: &Bytecode,
-) -> Result<Vec<(u8, bool)>, Error> {
-    let mut copy_steps = Vec::with_capacity(bytes_left as usize);
-    for idx in 0..bytes_left {
-        let addr = src_addr.checked_add(idx).unwrap_or(src_addr_end);
-        let step = if addr < src_addr_end {
-            let code = bytecode.code.get(addr as usize).unwrap();
-            (code.value, code.is_code)
-        } else {
-            (0, false)
-        };
-        copy_steps.push(step);
-        state.memory_write(exec_step, (dst_addr + idx).into(), step.0)?;
-    }
-
-    Ok(copy_steps)
-}
-
 fn gen_copy_event(
     state: &mut CircuitInputStateRef,
     geth_step: &GethExecStep,
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
 
-    let dst_offset = geth_step.stack.nth_last(0)?.as_u64();
-    // Reset code offset to the maximum value of Uint64 if overflow.
-    let code_offset = u64::try_from(geth_step.stack.nth_last(1)?).unwrap_or(u64::MAX);
+    let dst_offset = geth_step.stack.nth_last(0)?;
+    let code_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?.as_u64();
 
     let code_hash = state.call()?.code_hash;
     let bytecode: Bytecode = state.code(code_hash)?.into();
     let code_size = bytecode.code.len() as u64;
-    // Set source start to the minimum value of code offset and code size for
-    // avoiding overflow.
-    let src_addr = code_offset.min(code_size);
+
+    let dst_addr = dst_offset.as_u64();
     let src_addr_end = code_size;
 
+    // Reset offset to Uint64 maximum value if overflow, and set source start to the
+    // minimum value of offset and code size.
+    let src_addr = u64::try_from(code_offset)
+        .unwrap_or(u64::MAX)
+        .min(src_addr_end);
+
     let mut exec_step = state.new_step(geth_step)?;
-    let copy_steps = gen_copy_steps(
-        state,
+    let copy_steps = state.gen_copy_steps_for_bytecode(
         &mut exec_step,
+        &bytecode,
         src_addr,
-        dst_offset,
+        dst_addr,
         src_addr_end,
         length,
-        &bytecode,
     )?;
 
     Ok(CopyEvent {
@@ -128,7 +104,7 @@ fn gen_copy_event(
         src_addr_end,
         dst_type: CopyDataType::Memory,
         dst_id: NumberOrHash::Number(state.call()?.call_id),
-        dst_addr: dst_offset,
+        dst_addr,
         log_id: None,
         rw_counter_start,
         bytes: copy_steps,

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -19,17 +19,16 @@ impl Opcode for Returndatacopy {
 
         // reconstruction
         let geth_step = &geth_steps[0];
-        let dest_offset = geth_step.stack.nth_last(0)?;
-        let offset = geth_step.stack.nth_last(1)?;
-        let size = geth_step.stack.nth_last(2)?;
+        let dst_offset = geth_step.stack.nth_last(0)?;
+        let src_offset = geth_step.stack.nth_last(1)?;
+        let length = geth_step.stack.nth_last(2)?;
 
         // can we reduce this clone?
         let return_data = state.call_ctx()?.return_data.clone();
 
         let call_ctx = state.call_ctx_mut()?;
         let memory = &mut call_ctx.memory;
-        let length = size.as_usize();
-        memory.copy_from(dest_offset.as_u64(), &return_data, offset.as_u64(), length);
+        memory.copy_from(dst_offset, src_offset, length, &return_data);
 
         let copy_event = gen_copy_event(state, geth_step)?;
         state.push_copy(&mut exec_steps[0], copy_event);

--- a/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
@@ -5,7 +5,7 @@ use crate::{
         step::ExecutionState,
         util::{
             and,
-            common_gadget::{SameContextGadget, WordRangeGadget},
+            common_gadget::{SameContextGadget, WordByteCapGadget},
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::LtGadget,
             CachedRegion, Cell, Word,
@@ -28,10 +28,9 @@ const NUM_PREV_BLOCK_ALLOWED: u64 = 257;
 #[derive(Clone, Debug)]
 pub(crate) struct BlockHashGadget<F> {
     same_context: SameContextGadget<F>,
-    block_number_word: WordRangeGadget<F, N_BYTES_U64>,
+    block_number: WordByteCapGadget<F, N_BYTES_U64>,
     current_block_number: Cell<F>,
     block_hash: Word<F>,
-    block_lt: LtGadget<F, N_BYTES_U64>,
     diff_lt: LtGadget<F, N_BYTES_U64>,
 }
 
@@ -41,11 +40,10 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::BLOCKHASH;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let block_number_word = WordRangeGadget::construct(cb);
-        let block_number = block_number_word.valid_value_expr();
-        cb.stack_pop(block_number_word.original_word_expr());
-
         let current_block_number = cb.query_cell();
+        let block_number = WordByteCapGadget::construct(cb, current_block_number.expr());
+        cb.stack_pop(block_number.original_word());
+
         // FIXME
         //cb.block_lookup(
         //    BlockContextFieldTag::Number.expr(),
@@ -55,28 +53,23 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
 
         let block_hash = cb.query_word_rlc();
 
-        let block_lt = LtGadget::construct(cb, block_number.expr(), current_block_number.expr());
         let diff_lt = LtGadget::construct(
             cb,
             current_block_number.expr(),
-            NUM_PREV_BLOCK_ALLOWED.expr() + block_number.expr(),
+            NUM_PREV_BLOCK_ALLOWED.expr() + block_number.valid_value(),
         );
 
-        let is_valid_block_number = and::expr([
-            block_number_word.within_range_expr(),
-            block_lt.expr(),
-            diff_lt.expr(),
-        ]);
+        let is_valid = and::expr([block_number.lt_cap(), diff_lt.expr()]);
 
-        cb.condition(is_valid_block_number.expr(), |cb| {
+        cb.condition(is_valid.expr(), |cb| {
             cb.block_lookup(
                 BlockContextFieldTag::BlockHash.expr(),
-                block_number,
+                block_number.valid_value(),
                 block_hash.expr(),
             );
         });
 
-        cb.condition(not::expr(is_valid_block_number), |cb| {
+        cb.condition(not::expr(is_valid), |cb| {
             cb.require_zero(
                 "Invalid block number for block hash lookup",
                 block_hash.expr(),
@@ -96,10 +89,9 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
         let same_context = SameContextGadget::construct(cb, opcode, step_state_transition);
         Self {
             same_context,
-            block_number_word,
+            block_number,
             current_block_number,
             block_hash,
-            block_lt,
             diff_lt,
         }
     }
@@ -115,31 +107,24 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
+        let current_block_number = block.context.ctxs[&tx.block_number].number;
+        let current_block_number = current_block_number
+            .to_scalar()
+            .expect("unexpected U256 -> Scalar conversion failure");
+
         let block_number = block.rws[step.rw_indices[0]].stack_value();
-        self.block_number_word
-            .assign(region, offset, block_number)?;
+        self.block_number
+            .assign(region, offset, block_number, current_block_number)?;
         let block_number: F = block_number.to_scalar().unwrap();
 
-        let current_block_number = block.context.ctxs[&tx.block_number].number;
-        self.current_block_number.assign(
-            region,
-            offset,
-            Value::known(
-                current_block_number
-                    .to_scalar()
-                    .expect("unexpected U256 -> Scalar conversion failure"),
-            ),
-        )?;
-        let current_block_number: F = current_block_number.to_scalar().unwrap();
+        self.current_block_number
+            .assign(region, offset, Value::known(current_block_number))?;
 
         self.block_hash.assign(
             region,
             offset,
             Some(block.rws[step.rw_indices[1]].stack_value().to_le_bytes()),
         )?;
-
-        self.block_lt
-            .assign(region, offset, block_number, current_block_number)?;
 
         self.diff_lt.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
@@ -28,7 +28,7 @@ const NUM_PREV_BLOCK_ALLOWED: u64 = 257;
 #[derive(Clone, Debug)]
 pub(crate) struct BlockHashGadget<F> {
     same_context: SameContextGadget<F>,
-    block_number_word: WordRangeGadget<F>,
+    block_number_word: WordRangeGadget<F, N_BYTES_U64>,
     current_block_number: Cell<F>,
     block_hash: Word<F>,
     block_lt: LtGadget<F, N_BYTES_U64>,
@@ -41,8 +41,8 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::BLOCKHASH;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let block_number_word = WordRangeGadget::construct(cb, N_BYTES_U64);
-        let block_number = block_number_word.valid_value_expr(N_BYTES_U64);
+        let block_number_word = WordRangeGadget::construct(cb);
+        let block_number = block_number_word.valid_value_expr();
         cb.stack_pop(block_number_word.original_word_expr());
 
         let current_block_number = cb.query_cell();
@@ -117,7 +117,7 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
 
         let block_number = block.rws[step.rw_indices[0]].stack_value();
         self.block_number_word
-            .assign(region, offset, N_BYTES_U64, block_number)?;
+            .assign(region, offset, block_number)?;
         let block_number: F = block_number.to_scalar().unwrap();
 
         let current_block_number = block.context.ctxs[&tx.block_number].number;

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -4,12 +4,11 @@ use crate::{
         param::{N_BYTES_MEMORY_WORD_SIZE, N_BYTES_U64},
         step::ExecutionState,
         util::{
-            common_gadget::{SameContextGadget, WordByteRangeGadget},
+            common_gadget::{SameContextGadget, WordByteCapGadget},
             constraint_builder::{
                 ConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
-            math_gadget::LtGadget,
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
             not, select, CachedRegion, Cell,
         },
@@ -28,8 +27,7 @@ use std::cmp::min;
 pub(crate) struct CallDataCopyGadget<F> {
     same_context: SameContextGadget<F>,
     memory_address: MemoryAddressGadget<F>,
-    data_offset_word: WordByteRangeGadget<F, N_BYTES_U64>,
-    data_offset_lt_call_data_length: LtGadget<F, N_BYTES_U64>,
+    data_offset: WordByteCapGadget<F, N_BYTES_U64>,
     src_id: Cell<F>,
     call_data_length: Cell<F>,
     call_data_offset: Cell<F>, // Only used in the internal call
@@ -46,28 +44,18 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let length = cb.query_word_rlc();
-        let memory_offset = cb.query_cell_phase2();
-        let data_offset_word = WordByteRangeGadget::construct(cb);
-
-        // Reset data offset to the maximum value of Uint64 if overflow.
-        let data_offset = select::expr(
-            data_offset_word.within_range(),
-            data_offset_word.valid_value(),
-            u64::MAX.expr(),
-        );
-
-        // Pop memory_offset, data_offset, length from stack
-        cb.stack_pop(memory_offset.expr());
-        cb.stack_pop(data_offset_word.original_word());
-        cb.stack_pop(length.expr());
-
-        let memory_address = MemoryAddressGadget::construct(cb, memory_offset, length);
         let src_id = cb.query_cell();
         let call_data_length = cb.query_cell();
         let call_data_offset = cb.query_cell();
-        let data_offset_lt_call_data_length =
-            LtGadget::construct(cb, data_offset.expr(), call_data_length.expr());
+
+        let length = cb.query_word_rlc();
+        let memory_offset = cb.query_cell_phase2();
+        let data_offset = WordByteCapGadget::construct(cb, call_data_length.expr());
+
+        // Pop memory_offset, data_offset, length from stack
+        cb.stack_pop(memory_offset.expr());
+        cb.stack_pop(data_offset.original_word());
+        cb.stack_pop(length.expr());
 
         // Lookup the calldata_length and caller_address in Tx context table or
         // Call context table
@@ -107,6 +95,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
 
         // Calculate the next memory size and the gas cost for this memory
         // access
+        let memory_address = MemoryAddressGadget::construct(cb, memory_offset, length);
         let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);
         let memory_copier_gas = MemoryCopierGasGadget::construct(
             cb,
@@ -121,19 +110,23 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             CopyDataType::Memory.expr(),
         );
         cb.condition(memory_address.has_length(), |cb| {
+            // Set source start to the minimun value of data offset and call data length.
+            let src_addr = call_data_offset.expr()
+                + select::expr(
+                    data_offset.lt_cap(),
+                    data_offset.valid_value(),
+                    call_data_length.expr(),
+                );
+
+            let src_addr_end = call_data_offset.expr() + call_data_length.expr();
+
             cb.copy_table_lookup(
                 src_id.expr(),
                 src_tag,
                 cb.curr.state.call_id.expr(),
                 CopyDataType::Memory.expr(),
-                call_data_offset.expr()
-                    // Set source start to the minimun value of data offset and call data length.
-                    + select::expr(
-                        data_offset_lt_call_data_length.expr(),
-                        data_offset,
-                        call_data_length.expr(),
-                    ),
-                call_data_offset.expr() + call_data_length.expr(),
+                src_addr,
+                src_addr_end,
                 memory_address.offset(),
                 memory_address.length(),
                 0.expr(), // for CALLDATACOPY rlc_acc is 0
@@ -164,8 +157,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
         Self {
             same_context,
             memory_address,
-            data_offset_word,
-            data_offset_lt_call_data_length,
+            data_offset,
             src_id,
             call_data_length,
             call_data_offset,
@@ -192,7 +184,6 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
         let memory_address = self
             .memory_address
             .assign(region, offset, memory_offset, length)?;
-        let data_offset_within_range = self.data_offset_word.assign(region, offset, data_offset)?;
         let src_id = if call.is_root { tx.id } else { call.caller_id };
         self.src_id.assign(
             region,
@@ -211,16 +202,8 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
         self.call_data_offset
             .assign(region, offset, Value::known(F::from(call_data_offset)))?;
 
-        self.data_offset_lt_call_data_length.assign(
-            region,
-            offset,
-            F::from(if data_offset_within_range {
-                data_offset.as_u64()
-            } else {
-                u64::MAX
-            }),
-            F::from(call_data_length),
-        )?;
+        self.data_offset
+            .assign(region, offset, data_offset, F::from(call_data_length))?;
 
         // rw_counter increase from copy lookup is `length` memory writes + a variable
         // number of memory reads.
@@ -232,9 +215,10 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
                 // memory reads when reading from memory of caller is capped by call_data_length
                 // - data_offset.
                 min(
-                    length.low_u64(),
-                    call_data_length
-                        .checked_sub(data_offset.low_u64())
+                    length.as_u64(),
+                    u64::try_from(data_offset)
+                        .ok()
+                        .and_then(|offset| call_data_length.checked_sub(offset))
                         .unwrap_or_default(),
                 )
             };

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -11,9 +11,8 @@ use crate::{
         step::ExecutionState,
         util::{
             and,
-            common_gadget::{SameContextGadget, WordRangeGadget},
+            common_gadget::{SameContextGadget, WordByteCapGadget},
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            math_gadget::LtGadget,
             memory_gadget::BufferReaderGadget,
             not, select, CachedRegion, Cell,
         },
@@ -43,10 +42,8 @@ pub(crate) struct CallDataLoadGadget<F> {
     /// internal call.
     call_data_offset: Cell<F>,
     /// The bytes offset in calldata, from which we load a 32-bytes word. It
-    /// could be Uint64 overflow.
-    offset_word: WordRangeGadget<F, N_BYTES_U64>,
-    /// Check if offset is less than calldata length.
-    offset_lt_call_data_length: LtGadget<F, N_BYTES_U64>,
+    /// is valid if within range of Uint64 and less than call_data_length.
+    data_offset: WordByteCapGadget<F, N_BYTES_U64>,
     /// Gadget to read from tx calldata, which we validate against the word
     /// pushed to stack.
     buffer_reader: BufferReaderGadget<F, N_BYTES_WORD, N_BYTES_MEMORY_ADDRESS>,
@@ -60,39 +57,15 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let offset_word = WordRangeGadget::construct(cb);
-
-        // Reset data offset to the maximum value of Uint64 if overflow.
-        let offset = select::expr(
-            offset_word.within_range_expr(),
-            offset_word.valid_value_expr(),
-            u64::MAX.expr(),
-        );
-
-        // Pop the offset value from stack.
-        cb.stack_pop(offset_word.original_word_expr());
-
-        // Add a lookup constrain for TxId in the RW table.
         let src_id = cb.query_cell();
         let call_data_length = cb.query_cell();
         let call_data_offset = cb.query_cell();
-        let offset_lt_call_data_length =
-            LtGadget::construct(cb, offset.expr(), call_data_length.expr());
 
-        // Set source start to the minimun value of offset and call data length.
-        let src_addr = call_data_offset.expr()
-            + select::expr(
-                offset_lt_call_data_length.expr(),
-                offset,
-                call_data_length.expr(),
-            );
-        let src_addr_end = call_data_offset.expr() + call_data_length.expr();
+        let data_offset = WordByteCapGadget::construct(cb, call_data_length.expr());
+        cb.stack_pop(data_offset.original_word());
 
         cb.condition(
-            and::expr([
-                offset_word.within_range_expr(),
-                cb.curr.state.is_root.expr(),
-            ]),
+            and::expr([data_offset.within_range(), cb.curr.state.is_root.expr()]),
             |cb| {
                 cb.call_context_lookup(
                     false.expr(),
@@ -116,7 +89,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
 
         cb.condition(
             and::expr([
-                offset_word.within_range_expr(),
+                data_offset.within_range(),
                 not::expr(cb.curr.state.is_root.expr()),
             ]),
             |cb| {
@@ -141,6 +114,16 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
             },
         );
 
+        // Set source start to the minimun value of data offset and call data length.
+        let src_addr = call_data_offset.expr()
+            + select::expr(
+                data_offset.lt_cap(),
+                data_offset.valid_value(),
+                call_data_length.expr(),
+            );
+
+        let src_addr_end = call_data_offset.expr() + call_data_length.expr();
+
         let buffer_reader = BufferReaderGadget::construct(cb, src_addr.expr(), src_addr_end);
 
         let mut calldata_word: Vec<_> = (0..N_BYTES_WORD)
@@ -148,7 +131,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                 // For a root call, the call data comes from tx's data field.
                 cb.condition(
                     and::expr([
-                        offset_word.within_range_expr(),
+                        data_offset.within_range(),
                         buffer_reader.read_flag(idx),
                         cb.curr.state.is_root.expr(),
                     ]),
@@ -164,7 +147,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                 // For an internal call, the call data comes from memory.
                 cb.condition(
                     and::expr([
-                        offset_word.within_range_expr(),
+                        data_offset.within_range(),
                         buffer_reader.read_flag(idx),
                         not::expr(cb.curr.state.is_root.expr()),
                     ]),
@@ -191,7 +174,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
         let calldata_word = cb.word_rlc(calldata_word);
         cb.require_zero(
             "Stack push result must be 0 if stack pop offset is Uint64 overflow",
-            offset_word.overflow_expr() * calldata_word.expr(),
+            data_offset.overflow() * calldata_word.expr(),
         );
 
         cb.stack_push(calldata_word);
@@ -211,8 +194,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
             src_id,
             call_data_length,
             call_data_offset,
-            offset_word,
-            offset_lt_call_data_length,
+            data_offset,
             buffer_reader,
         }
     }
@@ -228,14 +210,6 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
-        let data_offset = block.rws[step.rw_indices[0]].stack_value();
-        let offset_within_range = self.offset_word.assign(region, offset, data_offset)?;
-        let data_offset = if offset_within_range {
-            data_offset.as_u64()
-        } else {
-            u64::MAX
-        };
-
         // Assign to the buffer reader gadget.
         let (src_id, call_data_offset, call_data_length) = if call.is_root {
             (tx.id, 0, tx.call_data_length as u64)
@@ -249,25 +223,23 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
         self.call_data_offset
             .assign(region, offset, Value::known(F::from(call_data_offset)))?;
 
-        self.offset_lt_call_data_length.assign(
-            region,
-            offset,
-            F::from(data_offset),
-            F::from(call_data_length),
-        )?;
+        let data_offset = block.rws[step.rw_indices[0]].stack_value();
+        let offset_within_range =
+            self.data_offset
+                .assign(region, offset, data_offset, F::from(call_data_length))?;
+
+        let data_offset = if offset_within_range {
+            data_offset.as_u64()
+        } else {
+            call_data_length
+        };
+        let src_addr_end = call_data_offset.checked_add(call_data_length).unwrap();
+        let src_addr = call_data_offset
+            .checked_add(data_offset)
+            .unwrap_or(src_addr_end)
+            .min(src_addr_end);
 
         let mut calldata_bytes = vec![0u8; N_BYTES_WORD];
-        let (src_addr, src_addr_end) = (
-            // Set source start to the minimun value of data offset and call data length.
-            call_data_offset
-                + if data_offset < call_data_length {
-                    data_offset
-                } else {
-                    call_data_length
-                },
-            call_data_offset + call_data_length,
-        );
-
         if offset_within_range {
             for (i, byte) in calldata_bytes.iter_mut().enumerate() {
                 if call.is_root {

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -188,7 +188,13 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
         // Add a lookup constraint for the 32-bytes that should have been pushed
         // to the stack.
         let calldata_word: [Expression<F>; N_BYTES_WORD] = calldata_word.try_into().unwrap();
-        cb.stack_push(cb.word_rlc(calldata_word));
+        let calldata_word = cb.word_rlc(calldata_word);
+        cb.require_zero(
+            "Stack push result must be 0 if stack pop offset is Uint64 overflow",
+            offset_word.overflow_expr() * calldata_word.expr(),
+        );
+
+        cb.stack_push(calldata_word);
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(cb.rw_counter_offset()),

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -7,9 +7,8 @@ use crate::{
         param::{N_BYTES_MEMORY_WORD_SIZE, N_BYTES_U64},
         step::ExecutionState,
         util::{
-            common_gadget::{SameContextGadget, WordByteRangeGadget},
+            common_gadget::{SameContextGadget, WordByteCapGadget},
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition},
-            math_gadget::LtGadget,
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
             not, select, CachedRegion, Cell,
         },
@@ -24,10 +23,8 @@ use super::ExecutionGadget;
 pub(crate) struct CodeCopyGadget<F> {
     same_context: SameContextGadget<F>,
     /// Holds the memory address for the offset in code from where we
-    /// read (checked with Uint64 overflow).
-    code_offset_word: WordByteRangeGadget<F, N_BYTES_U64>,
-    /// Checks if code offset is less than code size.
-    code_offset_lt_code_size: LtGadget<F, N_BYTES_U64>,
+    /// read. It is valid if within range of Uint64 and less than code_size.
+    code_offset: WordByteCapGadget<F, N_BYTES_U64>,
     /// Holds the size of the current environment's bytecode.
     code_size: Cell<F>,
     /// The code from current environment is copied to memory. To verify this
@@ -52,14 +49,15 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        // Query elements to be popped from the stack.
+        let code_size = cb.query_cell();
+
         let size = cb.query_word_rlc();
         let dst_memory_offset = cb.query_cell_phase2();
-        let code_offset_word = WordByteRangeGadget::construct(cb);
+        let code_offset = WordByteCapGadget::construct(cb, code_size.expr());
 
         // Pop items from stack.
         cb.stack_pop(dst_memory_offset.expr());
-        cb.stack_pop(code_offset_word.original_word());
+        cb.stack_pop(code_offset.original_word());
         cb.stack_pop(size.expr());
 
         // Construct memory address in the destionation (memory) to which we copy code.
@@ -69,18 +67,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         let code_hash = cb.curr.state.code_hash.clone();
 
         // Fetch the bytecode length from the bytecode table.
-        let code_size = cb.query_cell();
         cb.bytecode_length(code_hash.expr(), code_size.expr());
-
-        // Reset code offset to the maximum value of Uint64 if overflow.
-        let code_offset = select::expr(
-            code_offset_word.within_range(),
-            code_offset_word.valid_value(),
-            u64::MAX.expr(),
-        );
-
-        let code_offset_lt_code_size =
-            LtGadget::construct(cb, code_offset.expr(), code_size.expr());
 
         // Calculate the next memory size and the gas cost for this memory
         // access. This also accounts for the dynamic gas required to copy bytes to
@@ -94,17 +81,19 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
 
         let copy_rwc_inc = cb.query_cell();
         cb.condition(dst_memory_addr.has_length(), |cb| {
+            // Set source start to the minimun value of code offset and code size.
+            let src_addr = select::expr(
+                code_offset.lt_cap(),
+                code_offset.valid_value(),
+                code_size.expr(),
+            );
+
             cb.copy_table_lookup(
                 code_hash.expr(),
                 CopyDataType::Bytecode.expr(),
                 cb.curr.state.call_id.expr(),
                 CopyDataType::Memory.expr(),
-                // Set source start to the minimum value of code offset and code size.
-                select::expr(
-                    code_offset_lt_code_size.expr(),
-                    code_offset,
-                    code_size.expr(),
-                ),
+                src_addr,
                 code_size.expr(),
                 dst_memory_addr.offset(),
                 dst_memory_addr.length(),
@@ -134,8 +123,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
 
         Self {
             same_context,
-            code_offset_word,
-            code_offset_lt_code_size,
+            code_offset,
             code_size,
             dst_memory_addr,
             memory_expansion,
@@ -164,9 +152,6 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         let [dest_offset, code_offset, size] =
             [0, 1, 2].map(|i| block.rws[step.rw_indices[i]].stack_value());
 
-        // assign the code offset word.
-        let code_offset_within_range = self.code_offset_word.assign(region, offset, code_offset)?;
-
         let bytecode = block
             .bytecodes
             .get(&call.code_hash)
@@ -176,16 +161,8 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         self.code_size
             .assign(region, offset, Value::known(F::from(code_size)))?;
 
-        self.code_offset_lt_code_size.assign(
-            region,
-            offset,
-            F::from(if code_offset_within_range {
-                code_offset.as_u64()
-            } else {
-                u64::MAX
-            }),
-            F::from(code_size),
-        )?;
+        self.code_offset
+            .assign(region, offset, code_offset, F::from(code_size))?;
 
         // assign the destination memory offset.
         let memory_address = self

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -3,12 +3,11 @@ use crate::{
         param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_MEMORY_WORD_SIZE, N_BYTES_U64},
         step::ExecutionState,
         util::{
-            common_gadget::{SameContextGadget, WordByteRangeGadget},
+            common_gadget::{SameContextGadget, WordByteCapGadget},
             constraint_builder::{
                 ConstraintBuilder, ReversionInfo, StepStateTransition, Transition,
             },
             from_bytes,
-            math_gadget::LtGadget,
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
             not, select, CachedRegion, Cell, Word,
         },
@@ -28,8 +27,7 @@ pub(crate) struct ExtcodecopyGadget<F> {
     same_context: SameContextGadget<F>,
     external_address_word: Word<F>,
     memory_address: MemoryAddressGadget<F>,
-    code_offset_word: WordByteRangeGadget<F, N_BYTES_U64>,
-    code_offset_lt_code_size: LtGadget<F, N_BYTES_U64>,
+    code_offset: WordByteCapGadget<F, N_BYTES_U64>,
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
     is_warm: Cell<F>,
@@ -52,16 +50,16 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let external_address =
             from_bytes::expr(&external_address_word.cells[..N_BYTES_ACCOUNT_ADDRESS]);
 
+        let code_size = cb.query_cell();
+
         let memory_length = cb.query_word_rlc();
         let memory_offset = cb.query_cell_phase2();
-        let code_offset_word = WordByteRangeGadget::construct(cb);
+        let code_offset = WordByteCapGadget::construct(cb, code_size.expr());
 
         cb.stack_pop(external_address_word.expr());
         cb.stack_pop(memory_offset.expr());
-        cb.stack_pop(code_offset_word.original_word());
+        cb.stack_pop(code_offset.original_word());
         cb.stack_pop(memory_length.expr());
-
-        let memory_address = MemoryAddressGadget::construct(cb, memory_offset, memory_length);
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
@@ -80,23 +78,13 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             AccountFieldTag::CodeHash,
             code_hash.expr(),
         );
-        let code_size = cb.query_cell();
         // TODO: If external_address doesn't exist, we will get code_hash = 0.  With
         // this value, the bytecode_length lookup will not work, and the copy
         // from code_hash = 0 will not work. We should use EMPTY_HASH when
         // code_hash = 0.
         cb.bytecode_length(code_hash.expr(), code_size.expr());
 
-        // Reset code offset to the maximum value of Uint64 if overflow.
-        let code_offset = select::expr(
-            code_offset_word.within_range(),
-            code_offset_word.valid_value(),
-            u64::MAX.expr(),
-        );
-
-        let code_offset_lt_code_size =
-            LtGadget::construct(cb, code_offset.expr(), code_size.expr());
-
+        let memory_address = MemoryAddressGadget::construct(cb, memory_offset, memory_length);
         let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);
         let memory_copier_gas = MemoryCopierGasGadget::construct(
             cb,
@@ -112,17 +100,19 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
 
         let copy_rwc_inc = cb.query_cell();
         cb.condition(memory_address.has_length(), |cb| {
+            // Set source start to the minimun value of code offset and code size.
+            let src_addr = select::expr(
+                code_offset.lt_cap(),
+                code_offset.valid_value(),
+                code_size.expr(),
+            );
+
             cb.copy_table_lookup(
                 code_hash.expr(),
                 CopyDataType::Bytecode.expr(),
                 cb.curr.state.call_id.expr(),
                 CopyDataType::Memory.expr(),
-                // Set source start to the minimum value of code offset and code size.
-                select::expr(
-                    code_offset_lt_code_size.expr(),
-                    code_offset,
-                    code_size.expr(),
-                ),
+                src_addr,
                 code_size.expr(),
                 memory_address.offset(),
                 memory_address.length(),
@@ -152,8 +142,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             same_context,
             external_address_word,
             memory_address,
-            code_offset_word,
-            code_offset_lt_code_size,
+            code_offset,
             tx_id,
             is_warm,
             reversion_info,
@@ -183,8 +172,6 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let memory_address =
             self.memory_address
                 .assign(region, offset, memory_offset, memory_length)?;
-
-        let code_offset_within_range = self.code_offset_word.assign(region, offset, code_offset)?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(transaction.id as u64)))?;
@@ -216,16 +203,8 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         self.code_size
             .assign(region, offset, Value::known(F::from(code_size)))?;
 
-        self.code_offset_lt_code_size.assign(
-            region,
-            offset,
-            F::from(if code_offset_within_range {
-                code_offset.as_u64()
-            } else {
-                u64::MAX
-            }),
-            F::from(code_size),
-        )?;
+        self.code_offset
+            .assign(region, offset, code_offset, F::from(code_size))?;
 
         self.copy_rwc_inc.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -1108,7 +1108,7 @@ impl<F: Field, const VALID_BYTES: usize> WordByteCapGadget<F, VALID_BYTES> {
             cap
         };
 
-        self.lt_cap.assign(region, offset, value, F::from(cap))?;
+        self.lt_cap.assign(region, offset, value, cap)?;
 
         Ok(within_range)
     }

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -1124,6 +1124,10 @@ impl<F: Field> WordRangeGadget<F> {
         from_bytes::expr(&self.original.cells[..valid_bytes])
     }
 
+    pub(crate) fn overflow_expr(&self) -> Expression<F> {
+        not::expr(self.within_range_expr())
+    }
+
     pub(crate) fn within_range_expr(&self) -> Expression<F> {
         self.within_range.expr()
     }


### PR DESCRIPTION
### Description

Update according this comment https://github.com/scroll-tech/zkevm-circuits/pull/370#issuecomment-1457642939 of previous Uint64 overflow PR.

1. Constrain `CALLDATALOAD` stack push result must be `0` if stack pop offset is Uint64 overflow.
2. Fix `valid_bytes` to a const generic parameter in `WordRangeGadget`.
3. Change the parameters of Memory `copy_from` to `Word` type and update related code of `CALLDATACOPY`, `CODECOPY` and `EXTCODECOPY` in bus-mapping.
4. Rename `WordRangeGadget` to `WordByteRangeGadget` and add a new `WordByteCapGadget` (contains a WordRangeGadget and a LtGadget as cap). And update related code in zkevm-circuits.