### PR TITLE
Bug: fix for `JUMPI` successful run case with zero `condition` and overflow `destination`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,5 @@
 rustflags = ["-C", "link-args=-framework CoreFoundation -framework Security"]
 [net]
 git-fetch-with-cli = true
+[env]
+RUST_MIN_STACK = "16777216"


### PR DESCRIPTION
### Description

Fix `testool` case `jumpi_d19(not-jump-hyperspace)_g0_v0`.

Reference [go-ethereum opJumpi function](https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L550), the `destination` is not checked with Uint64 overflow if `condition` is zero.

TODO: may need to update with refactor PR https://github.com/scroll-tech/zkevm-circuits/pull/380.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

Could test with `testool` case `jumpi_d19(not-jump-hyperspace)_g0_v0`.
And add a new unit-test case `jumpi_gadget_with_zero_cond_and_overflow_dest`.