### PR TITLE
[don't-merge] set gas to `const_gas - 1` and print `gas_cost = const_gas`

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -234,7 +234,7 @@ mod tests {
     ];
 
     const TESTING_DST_OFFSET_COPY_SIZE_PAIRS: &[(u64, u64)] =
-        &[(0x20, 0) /* , (0x40, 20), (0x2000, 0x200) */];
+        &[/* (0x20, 0) , (0x40, 20), */ (0x2000, 0x200)];
 
     #[test]
     fn test_oog_memory_copy_for_common_opcodes() {

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -153,11 +153,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
         let opcode = step.opcode.unwrap();
         let is_extcodecopy = usize::from(opcode == OpcodeId::EXTCODECOPY);
 
-        log::debug!(
+        println!(
+            // log::debug!(
             "ErrorOutOfGasMemoryCopy: opcode = {}, gas_left = {}, gas_cost = {}",
-            opcode,
-            step.gas_left,
-            step.gas_cost,
+            opcode, step.gas_left, step.gas_cost,
         );
 
         let (is_warm, external_address) = if is_extcodecopy == 1 {
@@ -230,12 +229,12 @@ mod tests {
 
     const TESTING_COMMON_OPCODES: &[OpcodeId] = &[
         OpcodeId::CALLDATACOPY,
-        OpcodeId::CODECOPY,
-        OpcodeId::RETURNDATACOPY,
+        // OpcodeId::CODECOPY,
+        // OpcodeId::RETURNDATACOPY,
     ];
 
     const TESTING_DST_OFFSET_COPY_SIZE_PAIRS: &[(u64, u64)] =
-        &[(0x20, 0), (0x40, 20), (0x2000, 0x200)];
+        &[(0x20, 0) /* , (0x40, 20), (0x2000, 0x200) */];
 
     #[test]
     fn test_oog_memory_copy_for_common_opcodes() {
@@ -246,7 +245,7 @@ mod tests {
             let testing_data = TestingData::new_for_common_opcode(*opcode, *dst_offset, *copy_size);
 
             test_root(&testing_data);
-            test_internal(&testing_data);
+            // test_internal(&testing_data);
         }
     }
 
@@ -279,9 +278,9 @@ mod tests {
 
             let memory_word_size = (dst_offset + copy_size + 31) / 32;
 
-            let gas_cost = OpcodeId::PUSH32.constant_gas_cost().0 * 3
-                + opcode.constant_gas_cost().0
-                + memory_copier_gas_cost(0, memory_word_size, copy_size);
+            let gas_cost =
+                OpcodeId::PUSH32.constant_gas_cost().0 * 3 + opcode.constant_gas_cost().0;
+            // + memory_copier_gas_cost(0, memory_word_size, copy_size);
 
             Self { bytecode, gas_cost }
         }


### PR DESCRIPTION
Just share to test.

Could run and output via:
```
cargo test -- --nocapture test_oog_memory_copy_for_common_opcodes
```