### PR TITLE
Bug: fix to truncate memory offset of Word to Uint64 when memory length is zero

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -685,10 +685,17 @@ pub fn get_create_init_code<'a>(
     call_ctx: &'a CallContext,
     step: &GethExecStep,
 ) -> Result<&'a [u8], Error> {
-    let offset = step.stack.nth_last(1)?;
-    let length = step.stack.nth_last(2)?;
-    Ok(&call_ctx.memory.0
-        [offset.low_u64() as usize..(offset.low_u64() + length.low_u64()) as usize])
+    let offset = step.stack.nth_last(1)?.low_u64() as usize;
+    let length = step.stack.nth_last(2)?.as_usize();
+
+    let mem_len = call_ctx.memory.0.len();
+    if offset >= mem_len {
+        return Ok(&[]);
+    }
+
+    let offset_end = offset.checked_add(length).unwrap_or(mem_len);
+
+    Ok(&call_ctx.memory.0[offset..offset_end])
 }
 
 /// Retrieve the memory offset and length of call.

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -102,7 +102,7 @@ fn gen_copy_event(
     let call_data_offset = state.call()?.call_data_offset;
     let call_data_length = state.call()?.call_data_length;
 
-    // Get low Uint64 for memory offset.
+    // Get low Uint64 of offset.
     // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/instructions.go#L299
     let dst_addr = memory_offset.low_u64();
     let src_addr_end = call_data_offset.checked_add(call_data_length).unwrap();

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -103,7 +103,6 @@ fn gen_copy_event(
     let call_data_length = state.call()?.call_data_length;
 
     // Get low Uint64 of offset.
-    // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/instructions.go#L299
     let dst_addr = memory_offset.low_u64();
     let src_addr_end = call_data_offset.checked_add(call_data_length).unwrap();
 

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -102,7 +102,9 @@ fn gen_copy_event(
     let call_data_offset = state.call()?.call_data_offset;
     let call_data_length = state.call()?.call_data_length;
 
-    let dst_addr = memory_offset.as_u64();
+    // Get low Uint64 for memory offset.
+    // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/instructions.go#L299
+    let dst_addr = memory_offset.low_u64();
     let src_addr_end = call_data_offset.checked_add(call_data_length).unwrap();
 
     // Reset offset to call_data_length if overflow, and set source start to the

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -78,7 +78,9 @@ fn gen_copy_event(
     let bytecode: Bytecode = state.code(code_hash)?.into();
     let code_size = bytecode.code.len() as u64;
 
-    let dst_addr = dst_offset.as_u64();
+    // Get low Uint64 of offset.
+    // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/instructions.go#L367
+    let dst_addr = dst_offset.low_u64();
     let src_addr_end = code_size;
 
     // Reset offset to Uint64 maximum value if overflow, and set source start to the

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -79,7 +79,6 @@ fn gen_copy_event(
     let code_size = bytecode.code.len() as u64;
 
     // Get low Uint64 of offset.
-    // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/instructions.go#L367
     let dst_addr = dst_offset.low_u64();
     let src_addr_end = code_size;
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -20,7 +20,8 @@ impl<const IS_CREATE2: bool> Opcode for Create<IS_CREATE2> {
         let geth_step = &geth_steps[0];
         let mut exec_step = state.new_step(geth_step)?;
 
-        let offset = geth_step.stack.nth_last(1)?.as_usize();
+        // Get low Uint64 of offset.
+        let offset = geth_step.stack.nth_last(1)?.low_u64() as usize;
         let length = geth_step.stack.nth_last(2)?.as_usize();
 
         if length != 0 {

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -135,7 +135,8 @@ fn gen_copy_event(
     };
     let code_size = bytecode.code.len() as u64;
 
-    let dst_addr = dst_offset.as_u64();
+    // Get low Uint64 of offset.
+    let dst_addr = dst_offset.low_u64();
     let src_addr_end = code_size;
 
     // Reset offset to Uint64 maximum value if overflow, and set source start to the

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -43,7 +43,8 @@ impl Opcode for ReturnRevert {
             call.is_success.to_word(),
         );
 
-        let offset = offset.as_usize();
+        // Get low Uint64 of offset.
+        let offset = offset.low_u64() as usize;
         let length = length.as_usize();
 
         // Case A in the spec.

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -121,7 +121,8 @@ fn gen_copy_event(
     state: &mut CircuitInputStateRef,
     geth_step: &GethExecStep,
 ) -> Result<CopyEvent, Error> {
-    let dst_addr = geth_step.stack.nth_last(0)?.as_u64();
+    // Get low Uint64 of offset.
+    let dst_addr = geth_step.stack.nth_last(0)?.low_u64();
     let data_offset = geth_step.stack.nth_last(1)?.as_u64();
     let length = geth_step.stack.nth_last(2)?.as_u64();
 

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -40,7 +40,7 @@ impl Opcode for Sha3 {
         let memory = state
             .call_ctx()?
             .memory
-            .read_chunk(offset.as_usize().into(), size.as_usize().into());
+            .read_chunk(offset.low_u64().into(), size.as_usize().into());
 
         // keccak-256 hash of the given data in memory.
         let sha3 = keccak256(&memory);
@@ -65,8 +65,8 @@ impl Opcode for Sha3 {
         state.push_copy(
             &mut exec_step,
             CopyEvent {
-                src_addr: offset.as_u64(),
-                src_addr_end: offset.as_u64() + size.as_u64(),
+                src_addr: offset.low_u64(),
+                src_addr_end: offset.low_u64().checked_add(size.as_u64()).unwrap_or(u64::MAX),
                 src_type: CopyDataType::Memory,
                 src_id: NumberOrHash::Number(call_id),
                 dst_addr: 0,

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -66,7 +66,10 @@ impl Opcode for Sha3 {
             &mut exec_step,
             CopyEvent {
                 src_addr: offset.low_u64(),
-                src_addr_end: offset.low_u64().checked_add(size.as_u64()).unwrap_or(u64::MAX),
+                src_addr_end: offset
+                    .low_u64()
+                    .checked_add(size.as_u64())
+                    .unwrap_or(u64::MAX),
                 src_type: CopyDataType::Memory,
                 src_id: NumberOrHash::Number(call_id),
                 dst_addr: 0,

--- a/eth-types/src/evm_types/memory.rs
+++ b/eth-types/src/evm_types/memory.rs
@@ -332,7 +332,8 @@ impl Memory {
         // Reference go-ethereum `opCallDataCopy` function for defails.
         // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/instructions.go#L299
 
-        // `length` should be checked for overflow during gas cost calculation. Otherwise should return an out of gas error previously.
+        // `length` should be checked for overflow during gas cost calculation.
+        // Otherwise should return an out of gas error previously.
         let length = length.as_usize();
         if length != 0 {
             // `dst_offset` should be within range if length is non-zero.

--- a/eth-types/src/evm_types/memory.rs
+++ b/eth-types/src/evm_types/memory.rs
@@ -332,10 +332,11 @@ impl Memory {
         // Reference go-ethereum `opCallDataCopy` function for defails.
         // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/instructions.go#L299
 
-        // Both `dst_offset` and `length` should be checked for overflow during gas cost
-        // calculation. Otherwise should return an out of gas error previously.
+        // `length` should be checked for overflow during gas cost calculation. Otherwise should return an out of gas error previously.
         let length = length.as_usize();
         if length != 0 {
+            // `dst_offset` should be within range if length is non-zero.
+            // https://github.com/ethereum/go-ethereum/blob/bb4ac2d396de254898a5f44b1ea2086bfe5bd193/core/vm/common.go#L37
             let dst_offset = dst_offset.as_u64();
 
             // Reset data offset to the maximum value of Uint64 if overflow.

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -260,9 +260,9 @@ mod test {
 
     fn test_ok_root(
         call_data_length: usize,
-        memory_offset: usize,
         length: usize,
         data_offset: Word,
+        memory_offset: Word,
     ) {
         let bytecode = bytecode! {
             PUSH32(length)
@@ -299,9 +299,9 @@ mod test {
     fn test_ok_internal(
         call_data_offset: usize,
         call_data_length: usize,
-        dst_offset: usize,
         length: usize,
         data_offset: Word,
+        dst_offset: Word,
     ) {
         let (addr_a, addr_b) = (mock::MOCK_ACCOUNTS[0], mock::MOCK_ACCOUNTS[1]);
 
@@ -354,31 +354,37 @@ mod test {
 
     #[test]
     fn calldatacopy_gadget_simple() {
-        test_ok_root(0x40, 0x40, 10, 0x00.into());
-        test_ok_internal(0x40, 0x40, 0xA0, 10, 0x10.into());
+        test_ok_root(0x40, 10, 0x00.into(), 0x40.into());
+        test_ok_internal(0x40, 0x40, 10, 0x10.into(), 0xA0.into());
     }
 
     #[test]
     fn calldatacopy_gadget_large() {
-        test_ok_root(0x204, 0x103, 0x101, 0x102.into());
-        test_ok_internal(0x30, 0x204, 0x103, 0x101, 0x102.into());
+        test_ok_root(0x204, 0x101, 0x102.into(), 0x103.into());
+        test_ok_internal(0x30, 0x204, 0x101, 0x102.into(), 0x103.into());
     }
 
     #[test]
     fn calldatacopy_gadget_out_of_bound() {
-        test_ok_root(0x40, 0x40, 40, 0x20.into());
-        test_ok_internal(0x40, 0x20, 0xA0, 10, 0x28.into());
+        test_ok_root(0x40, 40, 0x20.into(), 0x40.into());
+        test_ok_internal(0x40, 0x20, 10, 0x28.into(), 0xA0.into());
     }
 
     #[test]
     fn calldatacopy_gadget_zero_length() {
-        test_ok_root(0x40, 0x40, 0, 0x00.into());
-        test_ok_internal(0x40, 0x40, 0xA0, 0, 0x10.into());
+        test_ok_root(0x40, 0, 0x00.into(), 0x40.into());
+        test_ok_internal(0x40, 0x40, 0, 0x10.into(), 0xA0.into());
     }
 
     #[test]
     fn calldatacopy_gadget_data_offset_overflow() {
-        test_ok_root(0x40, 0x40, 0, Word::MAX);
-        test_ok_internal(0x40, 0x40, 0xA0, 0, Word::MAX);
+        test_ok_root(0x40, 10, Word::MAX, 0x40.into());
+        test_ok_internal(0x40, 0x40, 10, Word::MAX, 0xA0.into());
+    }
+
+    #[test]
+    fn calldatacopy_gadget_overflow_memory_offset_and_zero_length() {
+        test_ok_root(0x40, 0, 0x40.into(), Word::MAX);
+        test_ok_internal(0x40, 0x40, 0, 0x10.into(), Word::MAX);
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -879,31 +879,31 @@ mod test {
             },
             // With memory expansion
             Stack {
-                cd_offset: 64,
+                cd_offset: 64.into(),
                 cd_length: 320,
-                rd_offset: 0,
+                rd_offset: Word::zero(),
                 rd_length: 32,
                 ..Default::default()
             },
             Stack {
-                cd_offset: 0,
+                cd_offset: Word::zero(),
                 cd_length: 32,
-                rd_offset: 64,
+                rd_offset: 64.into(),
                 rd_length: 320,
                 ..Default::default()
             },
             Stack {
-                cd_offset: 0xFFFFFF,
+                cd_offset: 0xFFFFFF.into(),
                 cd_length: 0,
-                rd_offset: 0xFFFFFF,
+                rd_offset: 0xFFFFFF.into(),
                 rd_length: 0,
                 ..Default::default()
             },
             // With memory expansion and value
             Stack {
-                cd_offset: 64,
+                cd_offset: 64.into(),
                 cd_length: 320,
-                rd_offset: 0,
+                rd_offset: 0.into(),
                 rd_length: 32,
                 value: Word::from(10).pow(18.into()),
                 ..Default::default()
@@ -921,13 +921,28 @@ mod test {
             });
     }
 
+    #[test]
+    fn callop_with_overflow_offset_and_zero_length() {
+        let stack = Stack {
+            cd_offset: Word::MAX,
+            cd_length: 0,
+            rd_offset: Word::MAX,
+            rd_length: 0,
+            ..Default::default()
+        };
+
+        TEST_CALL_OPCODES
+            .iter()
+            .for_each(|opcode| test_ok(caller(opcode, stack, true), callee(bytecode! {})));
+    }
+
     #[derive(Clone, Copy, Debug, Default)]
     struct Stack {
         gas: u64,
         value: Word,
-        cd_offset: u64,
+        cd_offset: Word,
         cd_length: u64,
-        rd_offset: u64,
+        rd_offset: Word,
         rd_length: u64,
     }
 
@@ -954,9 +969,9 @@ mod test {
         // Call twice for testing both cold and warm access
         let mut bytecode = bytecode! {
             PUSH32(Word::from(stack.rd_length))
-            PUSH32(Word::from(stack.rd_offset))
+            PUSH32(stack.rd_offset)
             PUSH32(Word::from(stack.cd_length))
-            PUSH32(Word::from(stack.cd_offset))
+            PUSH32(stack.cd_offset)
         };
         if is_call_or_callcode {
             bytecode.push(32, stack.value);
@@ -966,9 +981,9 @@ mod test {
             PUSH32(Word::from(stack.gas))
             .write_op(*opcode)
             PUSH32(Word::from(stack.rd_length))
-            PUSH32(Word::from(stack.rd_offset))
+            PUSH32(stack.rd_offset)
             PUSH32(Word::from(stack.cd_length))
-            PUSH32(Word::from(stack.cd_offset))
+            PUSH32(stack.cd_offset)
         });
         if is_call_or_callcode {
             bytecode.push(32, stack.value);
@@ -996,9 +1011,9 @@ mod test {
 
         let mut bytecode = bytecode! {
             PUSH32(Word::from(stack.rd_length))
-            PUSH32(Word::from(stack.rd_offset))
+            PUSH32(stack.rd_offset)
             PUSH32(Word::from(stack.cd_length))
-            PUSH32(Word::from(stack.cd_offset))
+            PUSH32(stack.cd_offset)
         };
         if is_call_or_callcode {
             bytecode.push(32, stack.value);

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -922,7 +922,7 @@ mod test {
     }
 
     #[test]
-    fn callop_with_overflow_offset_and_zero_length() {
+    fn callop_overflow_offset_and_zero_length() {
         let stack = Stack {
             cd_offset: Word::MAX,
             cd_length: 0,

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -198,7 +198,7 @@ mod tests {
     use eth_types::{bytecode, Word};
     use mock::TestContext;
 
-    fn test_ok(code_offset: Word, memory_offset: usize, size: usize, large: bool) {
+    fn test_ok(code_offset: Word, memory_offset: Word, size: usize, large: bool) {
         let mut code = bytecode! {};
         if large {
             for _ in 0..size {
@@ -208,7 +208,7 @@ mod tests {
         let tail = bytecode! {
             PUSH32(Word::from(size))
             PUSH32(code_offset)
-            PUSH32(Word::from(memory_offset))
+            PUSH32(memory_offset)
             CODECOPY
             STOP
         };
@@ -222,18 +222,23 @@ mod tests {
 
     #[test]
     fn codecopy_gadget_simple() {
-        test_ok(0x00.into(), 0x00, 0x20, false);
-        test_ok(0x30.into(), 0x20, 0x30, false);
-        test_ok(0x20.into(), 0x10, 0x42, false);
+        test_ok(0x00.into(), 0x00.into(), 0x20, false);
+        test_ok(0x30.into(), 0x20.into(), 0x30, false);
+        test_ok(0x20.into(), 0x10.into(), 0x42, false);
     }
 
     #[test]
     fn codecopy_gadget_large() {
-        test_ok(0x102.into(), 0x103, 0x101, true);
+        test_ok(0x102.into(), 0x103.into(), 0x101, true);
     }
 
     #[test]
     fn codecopy_gadget_code_offset_overflow() {
-        test_ok(Word::MAX, 0x103, 0x101, true);
+        test_ok(Word::MAX, 0x103.into(), 0x101, true);
+    }
+
+    #[test]
+    fn codecopy_gadget_overflow_memory_offset_and_zero_size() {
+        test_ok(0x102.into(), Word::MAX, 0, false);
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -870,4 +870,28 @@ mod test {
             run_test_circuits(test_context(caller));
         }
     }
+
+    #[test]
+    fn test_create_overflow_offset_and_zero_size() {
+        for is_create2 in [true, false] {
+            let mut bytecode = bytecode! {
+                PUSH1(0) // size
+                PUSH32(Word::MAX) // offset
+                PUSH2(23414) // value
+            };
+            bytecode.write_op(if is_create2 {
+                OpcodeId::CREATE2
+            } else {
+                OpcodeId::CREATE
+            });
+            let caller = Account {
+                address: *CALLER_ADDRESS,
+                code: bytecode.into(),
+                nonce: 10.into(),
+                balance: eth(10),
+                ..Default::default()
+            };
+            run_test_circuits(test_context(caller));
+        }
+    }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -252,7 +252,7 @@ mod test {
     fn test_ok(
         external_account: Option<Account>,
         code_offset: Word,
-        memory_offset: usize,
+        memory_offset: Word,
         length: usize,
         is_warm: bool,
     ) {
@@ -312,8 +312,8 @@ mod test {
 
     #[test]
     fn extcodecopy_empty_account() {
-        test_ok(None, 0x00.into(), 0x00, 0x36, true); // warm account
-        test_ok(None, 0x00.into(), 0x00, 0x36, false); // cold account
+        test_ok(None, Word::zero(), Word::zero(), 0x36, true); // warm account
+        test_ok(None, Word::zero(), Word::zero(), 0x36, false); // cold account
     }
 
     #[test]
@@ -324,8 +324,8 @@ mod test {
                 code: Bytes::from([10, 40]),
                 ..Default::default()
             }),
-            0x00.into(),
-            0x00,
+            Word::zero(),
+            Word::zero(),
             0x36,
             true,
         ); // warm account
@@ -336,8 +336,8 @@ mod test {
                 code: Bytes::from([10, 40]),
                 ..Default::default()
             }),
-            0x00.into(),
-            0x00,
+            Word::zero(),
+            Word::zero(),
             0x36,
             false,
         ); // cold account
@@ -351,8 +351,8 @@ mod test {
                 code: Bytes::from(rand_bytes_array::<256>()),
                 ..Default::default()
             }),
-            0x00.into(),
-            0x00,
+            Word::zero(),
+            Word::zero(),
             0x36,
             true,
         );
@@ -362,8 +362,8 @@ mod test {
                 code: Bytes::from(rand_bytes_array::<256>()),
                 ..Default::default()
             }),
-            0x00.into(),
-            0x00,
+            Word::zero(),
+            Word::zero(),
             0x36,
             false,
         );
@@ -378,7 +378,7 @@ mod test {
                 ..Default::default()
             }),
             0x20.into(),
-            0x00,
+            Word::zero(),
             0x104,
             true,
         );
@@ -389,7 +389,7 @@ mod test {
                 ..Default::default()
             }),
             0x20.into(),
-            0x00,
+            Word::zero(),
             0x104,
             false,
         );
@@ -404,7 +404,7 @@ mod test {
                 ..Default::default()
             }),
             Word::MAX,
-            0x00,
+            Word::zero(),
             0x36,
             true,
         );
@@ -415,9 +415,35 @@ mod test {
                 ..Default::default()
             }),
             Word::MAX,
-            0x00,
+            Word::zero(),
             0x36,
             false,
+        );
+    }
+
+    #[test]
+    fn extcodecopy_overflow_memory_offset_and_zero_length() {
+        test_ok(
+            Some(Account {
+                address: *EXTERNAL_ADDRESS,
+                code: Bytes::from(rand_bytes_array::<256>()),
+                ..Default::default()
+            }),
+            0x20.into(),
+            Word::MAX,
+            0,
+            true,
+        );
+        test_ok(
+            Some(Account {
+                address: *EXTERNAL_ADDRESS,
+                code: Bytes::from(rand_bytes_array::<256>()),
+                ..Default::default()
+            }),
+            0x20.into(),
+            Word::MAX,
+            0,
+            true,
         );
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -276,9 +276,9 @@ mod test {
     fn test_ok_internal(
         return_data_offset: usize,
         return_data_size: usize,
-        dest_offset: usize,
-        offset: usize,
         size: usize,
+        offset: usize,
+        dest_offset: Word,
     ) {
         let (addr_a, addr_b) = (mock::MOCK_ACCOUNTS[0], mock::MOCK_ACCOUNTS[1]);
 
@@ -340,51 +340,56 @@ mod test {
 
     #[test]
     fn returndatacopy_gadget_do_nothing() {
-        test_ok_internal(0x00, 0x02, 0x10, 0x00, 0x00);
+        test_ok_internal(0, 2, 0, 0, 0x10.into());
     }
 
     #[test]
     fn returndatacopy_gadget_simple() {
-        test_ok_internal(0x00, 0x02, 0x10, 0x00, 0x02);
+        test_ok_internal(0, 2, 2, 0, 0x10.into());
     }
 
     #[test]
     fn returndatacopy_gadget_large() {
-        test_ok_internal(0x00, 0x20, 0x20, 0x00, 0x20);
+        test_ok_internal(0, 0x20, 0x20, 0, 0x20.into());
     }
 
     #[test]
     fn returndatacopy_gadget_large_partial() {
-        test_ok_internal(0x00, 0x20, 0x20, 0x10, 0x10);
+        test_ok_internal(0, 0x20, 0x10, 0x10, 0x20.into());
     }
 
     #[test]
     fn returndatacopy_gadget_zero_length() {
-        test_ok_internal(0x00, 0x00, 0x20, 0x00, 0x00);
+        test_ok_internal(0, 0, 0, 0, 0x20.into());
     }
 
     #[test]
     fn returndatacopy_gadget_long_length() {
         // rlc value matters only if length > 255, i.e., size.cells.len() > 1
-        test_ok_internal(0x00, 0x200, 0x20, 0x00, 0x150);
+        test_ok_internal(0, 0x200, 0x150, 0, 0x20.into());
     }
 
     #[test]
     fn returndatacopy_gadget_big_offset() {
         // rlc value matters only if length > 255, i.e., size.cells.len() > 1
-        test_ok_internal(0x200, 0x200, 0x200, 0x00, 0x150);
+        test_ok_internal(0x200, 0x200, 0x150, 0, 0x200.into());
+    }
+
+    #[test]
+    fn returndatacopy_gadget_overflow_offset_and_zero_length() {
+        test_ok_internal(0, 0x20, 0, 0x20, Word::MAX);
     }
 
     // TODO: Add negative cases for out-of-bound and out-of-gas
     // #[test]
     // #[should_panic]
     // fn returndatacopy_gadget_out_of_bound() {
-    //     test_ok_internal(0x00, 0x10, 0x20, 0x10, 0x10);
+    //     test_ok_internal(0, 0x10, 0x10, 0x10, 0x20.into());
     // }
 
     // #[test]
     // #[should_panic]
     // fn returndatacopy_gadget_out_of_gas() {
-    //     test_ok_internal(0x00, 0x10, 0x2000000, 0x00, 0x10);
+    //     test_ok_internal(0, 0x10, 0x10, 0, 0x2000000.into());
     // }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -164,6 +164,7 @@ mod tests {
         circuit_input_builder::CircuitsParams,
         evm::{gen_sha3_code, MemoryKind},
     };
+    use eth_types::{bytecode, Word};
     use mock::TestContext;
 
     fn test_ok(offset: usize, size: usize, mem_kind: MemoryKind) {
@@ -197,5 +198,19 @@ mod tests {
         test_ok(0x202, 0x303, MemoryKind::LessThanSize);
         test_ok(0x303, 0x404, MemoryKind::EqualToSize);
         test_ok(0x404, 0x505, MemoryKind::MoreThanSize);
+    }
+
+    #[test]
+    fn sha3_gadget_overflow_offset_and_zero_size() {
+        let bytecode = bytecode! {
+            PUSH1(0)
+            PUSH32(Word::MAX)
+            SHA3
+        };
+
+        CircuitTestBuilder::new_from_test_ctx(
+            TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
+        )
+        .run();
     }
 }


### PR DESCRIPTION
### Description

Reference [go-ethereum calcMemSize64WithUint function](https://github.com/ethereum/go-ethereum/blob/master/core/vm/common.go#L38), memory offset is ignored to check Uint64 overflow if length is zero.

it is also called by [calcMemSize64](https://github.com/ethereum/go-ethereum/blob/master/core/vm/common.go#L31). And both are widely used in [memory_table.go](https://github.com/ethereum/go-ethereum/blob/master/core/vm/memory_table.go) (as `memorySize` in [jump_table.go](https://github.com/ethereum/go-ethereum/blob/master/core/vm/jump_table.go)).

For `CALLCODE`, memory offset is truncate to Uint64 directly in [opCallCode](https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L715).

Review and fix the all related opcodes in  [memory_table.go](https://github.com/ethereum/go-ethereum/blob/master/core/vm/memory_table.go).

### Issue Link

Related upstream issue https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1301

### TODO

Should we also need to constrain memory length is zero when memory offset is overflow in circuit?

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

1. Fix `testool` case `randomStatetest85_d0_g0_v0`.
2. Add test cases of overflow memory offset and zero length for related opcodes.