### PR TITLE
Bug: fix to enable `gas_is_u64` for failed Calls

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -250,7 +250,7 @@ mod test {
 
     #[derive(Clone, Copy, Debug, Default)]
     struct Stack {
-        gas: u64,
+        gas: Word,
         value: Word,
         cd_offset: u64,
         cd_length: u64,
@@ -270,7 +270,7 @@ mod test {
         }
         bytecode.append(&bytecode! {
             PUSH32(address.to_word())
-            PUSH32(Word::from(stack.gas))
+            PUSH32(stack.gas)
             .write_op(opcode)
             PUSH1(0)
             PUSH1(0)
@@ -336,9 +336,9 @@ mod test {
     }
 
     #[test]
-    fn call_with_oog_root() {
+    fn test_oog_call_root() {
         let stack = Stack {
-            gas: 100,
+            gas: 100.into(),
             cd_offset: 64,
             cd_length: 320,
             rd_offset: 0,
@@ -356,9 +356,9 @@ mod test {
     }
 
     #[test]
-    fn call_with_oog_internal() {
+    fn test_oog_call_internal() {
         let caller_stack = Stack {
-            gas: 100,
+            gas: 100.into(),
             cd_offset: 64,
             cd_length: 320,
             rd_offset: 0,
@@ -366,7 +366,7 @@ mod test {
             ..Default::default()
         };
         let callee_stack = Stack {
-            gas: 21,
+            gas: 21.into(),
             cd_offset: 64,
             cd_length: 320,
             rd_offset: 0,
@@ -383,5 +383,23 @@ mod test {
             ));
             test_oog(&caller, &callee, false);
         }
+    }
+
+    #[test]
+    fn test_oog_call_with_overflow_gas() {
+        let stack = Stack {
+            gas: Word::MAX,
+            cd_offset: 64,
+            cd_length: 320,
+            rd_offset: 0,
+            rd_length: 32,
+            ..Default::default()
+        };
+        let callee = callee(bytecode! {
+            PUSH32(Word::from(0))
+            PUSH32(Word::from(0))
+            STOP
+        });
+        test_oog(&caller(OpcodeId::CALL, stack), &callee, true);
     }
 }

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -766,12 +766,12 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         if IS_SUCCESS_CALL {
             self.is_success
                 .assign(region, offset, Value::known(F::from(is_success.low_u64())))?;
-            self.gas_is_u64.assign(
-                region,
-                offset,
-                sum::value(&gas.to_le_bytes()[N_BYTES_GAS..]),
-            )?;
         }
+        self.gas_is_u64.assign(
+            region,
+            offset,
+            sum::value(&gas.to_le_bytes()[N_BYTES_GAS..]),
+        )?;
         let cd_address = self
             .cd_address
             .assign(region, offset, cd_offset, cd_length)?;


### PR DESCRIPTION
### Description

Found by and fix `testool` cases:
- ABAcalls1_d0_g0_v0
- ABAcalls2_d0_g0_v0
- ABAcalls3_d0_g0_v0
- static_ABAcalls2_d1_g0_v0
- static_ABAcalls3_d1_g0_v0
- JUMPDEST_Attack_d0_g0_v0
- static_Call1MB1024Calldepth_d1_g0_v0
- static_CallRecursiveBomb0_OOG_atMaxCallDepth_d0_g0_v0
- static_LoopCallsDepthThenRevert_d0_g0_v0

Reference [go-ethereum callGas func](https://github.com/ethereum/go-ethereum/blob/master/core/vm/gas.go#L44), the returned gas (if input is Unit64 overflow) could also cause OOG.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)