### PR TITLE
calldata zeros assigned twice in tx table and circuit

### DIFF
--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -198,7 +198,7 @@ impl TxTable {
             txs.len(),
             max_txs
         );
-        let sum_txs_calldata = txs.iter().map(|tx| tx.call_data.len()).sum();
+        let sum_txs_calldata: usize = txs.iter().map(|tx| tx.call_data.len()).sum();
         assert!(
             sum_txs_calldata <= max_calldata,
             "sum_txs_calldata <= max_calldata: sum_txs_calldata={}, max_calldata={}",
@@ -273,15 +273,7 @@ impl TxTable {
                     calldata_assignments.extend(tx_calldata.iter());
                 }
                 // Assign Tx calldata
-                let padding_calldata = (sum_txs_calldata..max_calldata).map(|_| {
-                    [
-                        Value::known(F::zero()),
-                        Value::known(F::from(TxContextFieldTag::CallData as u64)),
-                        Value::known(F::zero()),
-                        Value::known(F::zero()),
-                    ]
-                });
-                for row in calldata_assignments.into_iter().chain(padding_calldata) {
+                for row in calldata_assignments.into_iter() {
                     assign_row(&mut region, offset, &advice_columns, &self.tag, &row, "")?;
                     offset += 1;
                 }


### PR DESCRIPTION
### Description

Calldata zeros are assigned twice in tx table and tx circuit. This will causing two different instances of tx circuit have different VKs.

### Issue Link


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



