### PR TITLE
Implement circuit for `ErrorOutOfGasSHA3` state

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -64,6 +64,7 @@ mod error_oog_dynamic_memory;
 mod error_oog_exp;
 mod error_oog_log;
 mod error_oog_memory_copy;
+mod error_oog_sha3;
 mod error_oog_sload_sstore;
 mod error_oog_static_memory;
 mod error_precompile_failed;
@@ -96,6 +97,7 @@ use error_oog_dynamic_memory::OOGDynamicMemory;
 use error_oog_exp::OOGExp;
 use error_oog_log::ErrorOOGLog;
 use error_oog_memory_copy::OOGMemoryCopy;
+use error_oog_sha3::OOGSha3;
 use error_oog_sload_sstore::OOGSloadSstore;
 use error_oog_static_memory::OOGStaticMemory;
 use error_precompile_failed::PrecompileFailed;
@@ -300,6 +302,7 @@ fn fn_gen_error_state_associated_ops(
         }
         ExecError::OutOfGas(OogError::Exp) => Some(OOGExp::gen_associated_ops),
         ExecError::OutOfGas(OogError::MemoryCopy) => Some(OOGMemoryCopy::gen_associated_ops),
+        ExecError::OutOfGas(OogError::Sha3) => Some(OOGSha3::gen_associated_ops),
         ExecError::OutOfGas(OogError::SloadSstore) => Some(OOGSloadSstore::gen_associated_ops),
         // ExecError::
         ExecError::StackOverflow => Some(ErrorSimple::gen_associated_ops),

--- a/bus-mapping/src/evm/opcodes/error_oog_sha3.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_sha3.rs
@@ -1,0 +1,38 @@
+use crate::{
+    circuit_input_builder::{CircuitInputStateRef, ExecStep},
+    error::{ExecError, OogError},
+    evm::Opcode,
+    Error,
+};
+use eth_types::{evm_types::OpcodeId, GethExecStep};
+
+/// Placeholder structure used to implement [`Opcode`] trait over it
+/// corresponding to the [`OogError::Sha3`](crate::error::OogError::Sha3).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct OOGSha3;
+
+impl Opcode for OOGSha3 {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        let geth_step = &geth_steps[0];
+        debug_assert_eq!(geth_step.op, OpcodeId::SHA3);
+
+        let mut exec_step = state.new_step(geth_step)?;
+        exec_step.error = Some(ExecError::OutOfGas(OogError::Sha3));
+
+        for i in 0..2 {
+            state.stack_read(
+                &mut exec_step,
+                geth_step.stack.nth_last_filled(i),
+                geth_step.stack.nth_last(i)?,
+            )?;
+        }
+
+        state.gen_restore_context_ops(&mut exec_step, geth_steps)?;
+        state.handle_return(geth_step)?;
+
+        Ok(vec![exec_step])
+    }
+}

--- a/eth-types/src/evm_types.rs
+++ b/eth-types/src/evm_types.rs
@@ -60,6 +60,10 @@ impl fmt::Debug for Gas {
     }
 }
 
+/// This constant ((2^32 - 1) * 32) is the highest number that can be used without overflowing the
+/// square operation of gas calculation.
+/// https://github.com/ethereum/go-ethereum/blob/e6b6a8b738069ad0579f6798ee59fde93ed13b43/core/vm/gas_table.go#L38
+pub const MAX_EXPANDED_MEMORY_ADDRESS: u64 = 0x1FFFFFFFE0;
 /// Quotient for max refund of gas used
 pub const MAX_REFUND_QUOTIENT_OF_GAS_USED: usize = 5;
 /// Gas stipend when CALL or CALLCODE is attached with value.

--- a/eth-types/src/evm_types/gas_utils.rs
+++ b/eth-types/src/evm_types/gas_utils.rs
@@ -22,9 +22,10 @@ pub fn memory_copier_gas_cost(
     curr_memory_word_size: u64,
     next_memory_word_size: u64,
     num_copy_bytes: u64,
+    per_word_copy_gas: u64,
 ) -> u64 {
     let num_words = (num_copy_bytes + 31) / 32;
-    num_words * GasCost::COPY.as_u64() +
+    num_words * per_word_copy_gas +
         // Note that opcodes with a byte size parameter of 0 will not trigger
         // memory expansion, regardless of their offset parameters.
         if num_words > 0 {

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -86,6 +86,7 @@ mod error_oog_dynamic_memory;
 mod error_oog_exp;
 mod error_oog_log;
 mod error_oog_memory_copy;
+mod error_oog_sha3;
 mod error_oog_sload_sstore;
 mod error_oog_static_memory;
 mod error_precompile_failed;
@@ -163,6 +164,7 @@ use error_oog_dynamic_memory::ErrorOOGDynamicMemoryGadget;
 use error_oog_exp::ErrorOOGExpGadget;
 use error_oog_log::ErrorOOGLogGadget;
 use error_oog_memory_copy::ErrorOOGMemoryCopyGadget;
+use error_oog_sha3::ErrorOOGSha3Gadget;
 use error_oog_sload_sstore::ErrorOOGSloadSstoreGadget;
 use error_oog_static_memory::ErrorOOGStaticMemoryGadget;
 use error_precompile_failed::ErrorPrecompileFailedGadget;
@@ -319,7 +321,7 @@ pub(crate) struct ExecutionConfig<F> {
     error_oog_log: Box<ErrorOOGLogGadget<F>>,
     error_oog_account_access:
         Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasAccountAccess }>>,
-    error_oog_sha3: Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSHA3 }>>,
+    error_oog_sha3: Box<ErrorOOGSha3Gadget<F>>,
     error_oog_create2: Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasCREATE2 }>>,
     error_code_store: Box<ErrorCodeStoreGadget<F>>,
     error_oog_self_destruct:

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -303,7 +303,7 @@ mod tests {
 
             let gas_cost = OpcodeId::PUSH32.constant_gas_cost().0 * 3
                 + opcode.constant_gas_cost().0
-                + memory_copier_gas_cost(0, memory_word_size, copy_size);
+                + memory_copier_gas_cost(0, memory_word_size, copy_size, GasCost::COPY.as_u64());
 
             Self { bytecode, gas_cost }
         }
@@ -323,7 +323,7 @@ mod tests {
 
             let mut gas_cost = OpcodeId::PUSH32.constant_gas_cost().0 * 4
                 + GasCost::COLD_ACCOUNT_ACCESS.0
-                + memory_copier_gas_cost(0, memory_word_size, copy_size);
+                + memory_copier_gas_cost(0, memory_word_size, copy_size, GasCost::COPY.as_u64());
 
             if is_warm {
                 bytecode.append(&bytecode! {
@@ -336,7 +336,12 @@ mod tests {
 
                 gas_cost += OpcodeId::PUSH32.constant_gas_cost().0 * 4
                     + GasCost::WARM_ACCESS.0
-                    + memory_copier_gas_cost(memory_word_size, memory_word_size, copy_size);
+                    + memory_copier_gas_cost(
+                        memory_word_size,
+                        memory_word_size,
+                        copy_size,
+                        GasCost::COPY.as_u64(),
+                    );
             }
 
             Self { bytecode, gas_cost }

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_sha3.rs
@@ -1,0 +1,260 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        param::{N_BYTES_GAS, N_BYTES_MEMORY_WORD_SIZE},
+        step::ExecutionState,
+        util::{
+            common_gadget::CommonErrorGadget,
+            constraint_builder::ConstraintBuilder,
+            math_gadget::LtGadget,
+            memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
+            CachedRegion, Cell,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+use eth_types::{
+    evm_types::{GasCost, OpcodeId},
+    Field,
+};
+use halo2_proofs::{circuit::Value, plonk::Error};
+
+/// Gadget to implement the corresponding out of gas error for
+/// [`OpcodeId::SHA3`].
+#[derive(Clone, Debug)]
+pub(crate) struct ErrorOOGSha3Gadget<F> {
+    opcode: Cell<F>,
+    memory_address: MemoryAddressGadget<F>,
+    memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
+    memory_copier_gas: MemoryCopierGasGadget<F, { GasCost::COPY_SHA3 }>,
+    insufficient_gas: LtGadget<F, N_BYTES_GAS>,
+    common_error_gadget: CommonErrorGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for ErrorOOGSha3Gadget<F> {
+    const NAME: &'static str = "ErrorOutOfGasSHA3";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ErrorOutOfGasSHA3;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let opcode = cb.query_cell();
+        cb.require_equal(
+            "ErrorOutOfGasSHA3 opcode must be SHA3",
+            opcode.expr(),
+            OpcodeId::SHA3.expr(),
+        );
+
+        let memory_offset = cb.query_cell_phase2();
+        let memory_size = cb.query_word_rlc();
+
+        cb.stack_pop(memory_offset.expr());
+        cb.stack_pop(memory_size.expr());
+
+        let memory_address = MemoryAddressGadget::construct(cb, memory_offset, memory_size);
+        let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);
+        let memory_copier_gas = MemoryCopierGasGadget::construct(
+            cb,
+            memory_address.length(),
+            memory_expansion.gas_cost(),
+        );
+
+        let insufficient_gas = LtGadget::construct(
+            cb,
+            cb.curr.state.gas_left.expr(),
+            OpcodeId::SHA3.constant_gas_cost().expr() + memory_copier_gas.gas_cost(),
+        );
+
+        cb.require_equal(
+            "Gas left is less than gas cost",
+            insufficient_gas.expr(),
+            1.expr(),
+        );
+
+        let common_error_gadget = CommonErrorGadget::construct(cb, opcode.expr(), 4.expr());
+
+        Self {
+            opcode,
+            memory_address,
+            memory_expansion,
+            memory_copier_gas,
+            insufficient_gas,
+            common_error_gadget,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _tx: &Transaction,
+        call: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        let opcode = step.opcode.unwrap();
+
+        // gupeng
+        println!(
+            // log::debug!(
+            "ErrorOutOfGasSHA3: gas_cost = {}, gas_left = {}",
+            step.gas_cost, step.gas_left,
+        );
+
+        let [memory_offset, memory_size] =
+            [0, 1].map(|idx| block.rws[step.rw_indices[idx]].stack_value());
+
+        self.opcode
+            .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
+        let memory_address =
+            self.memory_address
+                .assign(region, offset, memory_offset, memory_size)?;
+        let (_, memory_expansion_cost) = self.memory_expansion.assign(
+            region,
+            offset,
+            step.memory_word_size(),
+            [memory_address],
+        )?;
+        let memory_copier_gas = self.memory_copier_gas.assign(
+            region,
+            offset,
+            memory_size.as_u64(),
+            memory_expansion_cost,
+        )?;
+        self.insufficient_gas.assign_value(
+            region,
+            offset,
+            Value::known(F::from(step.gas_left)),
+            Value::known(F::from(
+                OpcodeId::SHA3.constant_gas_cost().0 + memory_copier_gas,
+            )),
+        )?;
+        self.common_error_gadget
+            .assign(region, offset, block, call, step, 4)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{evm_circuit::test::rand_bytes, test_util::CircuitTestBuilder};
+    use eth_types::{
+        bytecode, evm_types::gas_utils::memory_copier_gas_cost, Bytecode, ToWord, U256,
+    };
+    use mock::{
+        eth, test_ctx::helpers::account_0_code_account_1_no_code, TestContext, MOCK_ACCOUNTS,
+    };
+
+    #[test]
+    fn test_oog_sha3_less_than_constant_gas() {
+        let testing_data = TestingData::new(0x20, 0, OpcodeId::SHA3.constant_gas_cost().0);
+
+        test_root(&testing_data);
+        test_internal(&testing_data);
+    }
+
+    #[test]
+    fn test_oog_sha3_less_than_dynamic_gas() {
+        let testing_data = TestingData::new(
+            0x40,
+            20,
+            OpcodeId::SHA3.constant_gas_cost().0 + dynamic_gas_cost(0x40, 20),
+        );
+
+        test_root(&testing_data);
+        test_internal(&testing_data);
+    }
+
+    struct TestingData {
+        bytecode: Bytecode,
+        gas_cost: u64,
+    }
+
+    impl TestingData {
+        pub fn new(memory_offset: u64, memory_size: u64, gas_cost: u64) -> Self {
+            let bytecode = bytecode! {
+                PUSH32(memory_size)
+                PUSH32(memory_offset)
+                SHA3
+            };
+
+            let gas_cost = gas_cost + OpcodeId::PUSH32.constant_gas_cost().0 * 2;
+
+            Self { bytecode, gas_cost }
+        }
+    }
+
+    fn dynamic_gas_cost(memory_offset: u64, memory_size: u64) -> u64 {
+        let memory_word_size = (memory_offset + memory_size + 31) / 32;
+
+        memory_copier_gas_cost(
+            0,
+            memory_word_size,
+            memory_size,
+            GasCost::COPY_SHA3.as_u64(),
+        )
+    }
+
+    fn test_root(testing_data: &TestingData) {
+        let ctx = TestContext::<2, 1>::new(
+            None,
+            account_0_code_account_1_no_code(testing_data.bytecode.clone()),
+            |mut txs, accs| {
+                // Decrease expected gas cost (by 1) to trigger out of gas error.
+                txs[0]
+                    .from(accs[1].address)
+                    .to(accs[0].address)
+                    .gas((GasCost::TX.0 + testing_data.gas_cost - 1).into());
+            },
+            |block, _tx| block.number(0xcafe_u64),
+        )
+        .unwrap();
+
+        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+    }
+
+    fn test_internal(testing_data: &TestingData) {
+        let (addr_a, addr_b) = (MOCK_ACCOUNTS[0], MOCK_ACCOUNTS[1]);
+
+        // code B gets called by code A, so the call is an internal call.
+        let code_b = testing_data.bytecode.clone();
+        let gas_cost_b = testing_data.gas_cost;
+
+        // Code A calls code B.
+        let code_a = bytecode! {
+            // populate memory in A's context.
+            PUSH8(U256::from_big_endian(&rand_bytes(8)))
+            PUSH1(0x00) // offset
+            MSTORE
+            // call ADDR_B.
+            PUSH1(0x00) // retLength
+            PUSH1(0x00) // retOffset
+            PUSH32(0x00) // argsLength
+            PUSH32(0x20) // argsOffset
+            PUSH1(0x00) // value
+            PUSH32(addr_b.to_word()) // addr
+            // Decrease expected gas cost (by 1) to trigger out of gas error.
+            PUSH32(gas_cost_b - 1) // gas
+            CALL
+            STOP
+        };
+
+        let ctx = TestContext::<3, 1>::new(
+            None,
+            |accs| {
+                accs[0].address(addr_b).code(code_b);
+                accs[1].address(addr_a).code(code_a);
+                accs[2].address(MOCK_ACCOUNTS[2]).balance(eth(10));
+            },
+            |mut txs, accs| {
+                txs[0].from(accs[2].address).to(accs[1].address);
+            },
+            |block, _tx| block,
+        )
+        .unwrap();
+
+        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+    }
+}


### PR DESCRIPTION
### Description

1. Implement insufficient gas check (`gas_left < gas_cost`) for out of gas of `SHA3` in `ErrorOOGSha3Gadget`.

2. Add `MemoryExpandedAddressGadget` to support OOG when memory offset plus length is greater than `0x1FFFFFFFE0`. Reference this check in [go-ethereum memoryGasCost function](https://github.com/ethereum/go-ethereum/blob/master/core/vm/gas_table.go#L38).

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### TODO

1. Add spec Markdown doc.

2. Suppose if could use `MemoryExpandedAddressGadget` for other OOG errors in another PR.