### PR TITLE
Use code_hash instead of poseidon_code_hash

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -891,37 +891,7 @@ impl<P: JsonRpcClient> BuilderClient<P> {
         proofs: Vec<eth_types::EIP1186ProofResponse>,
         codes: HashMap<Address, Vec<u8>>,
     ) -> (StateDB, CodeDB) {
-        let mut sdb = StateDB::new();
-        for proof in proofs {
-            let mut storage = HashMap::new();
-            for storage_proof in proof.storage_proof {
-                if !storage_proof.value.is_zero() {
-                    storage.insert(storage_proof.key, storage_proof.value);
-                }
-            }
-            log::trace!(
-                "statedb set_account {:?} balance {:?}",
-                proof.address,
-                proof.balance
-            );
-            sdb.set_account(
-                &proof.address,
-                state_db::Account {
-                    nonce: proof.nonce,
-                    balance: proof.balance,
-                    storage,
-                    code_hash: proof.poseidon_code_hash,
-                    keccak_code_hash: proof.keccak_code_hash,
-                    code_size: proof.code_size,
-                },
-            )
-        }
-
-        let mut code_db = CodeDB::new();
-        for (_address, code) in codes {
-            code_db.insert(code.clone());
-        }
-        (sdb, code_db)
+        build_state_code_db(proofs, codes)
     }
 
     /// Step 5. For each step in TxExecTraces, gen the associated ops and state

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -770,7 +770,7 @@ pub fn build_state_code_db(
                 balance: proof.balance,
                 storage,
                 keccak_code_hash: proof.keccak_code_hash,
-                poseidon_code_hash: proof.poseidon_code_hash,
+                code_hash: proof.poseidon_code_hash,
                 code_size: proof.code_size,
             },
         )
@@ -910,8 +910,8 @@ impl<P: JsonRpcClient> BuilderClient<P> {
                     nonce: proof.nonce,
                     balance: proof.balance,
                     storage,
+                    code_hash: proof.poseidon_code_hash,
                     keccak_code_hash: proof.keccak_code_hash,
-                    poseidon_code_hash: proof.poseidon_code_hash,
                     code_size: proof.code_size,
                 },
             )

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -769,8 +769,8 @@ pub fn build_state_code_db(
                 nonce: proof.nonce,
                 balance: proof.balance,
                 storage,
-                keccak_code_hash: proof.keccak_code_hash,
                 code_hash: proof.poseidon_code_hash,
+                keccak_code_hash: proof.keccak_code_hash,
                 code_size: proof.code_size,
             },
         )

--- a/bus-mapping/src/circuit_input_builder/call.rs
+++ b/bus-mapping/src/circuit_input_builder/call.rs
@@ -77,7 +77,7 @@ pub struct Call {
     pub address: Address,
     /// Code Source
     pub code_source: CodeSource,
-    /// Poseidon Code Hash
+    /// Code Hash
     pub code_hash: Hash,
     /// Depth
     pub depth: usize,

--- a/bus-mapping/src/circuit_input_builder/transaction.rs
+++ b/bus-mapping/src/circuit_input_builder/transaction.rs
@@ -272,7 +272,7 @@ impl Transaction {
             if !found {
                 return Err(Error::AccountNotFound(address));
             }
-            let code_hash = account.poseidon_code_hash;
+            let code_hash = account.code_hash;
             Call {
                 call_id,
                 kind: CallKind::Call,

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -8,7 +8,6 @@ use crate::{
         TxRefundOp, RW,
     },
     state_db::CodeDB,
-    util::KECCAK_CODE_HASH_ZERO,
     Error,
 };
 use core::fmt::Debug;
@@ -501,8 +500,8 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
         state.sdb.get_account_mut(&call.address).1.storage.clear();
     }
     if state.tx.is_create()
-        && ((!callee_account.keccak_code_hash.is_zero()
-            && !callee_account.keccak_code_hash.eq(&*KECCAK_CODE_HASH_ZERO))
+        && ((!callee_account.code_hash.is_zero()
+            && !callee_account.code_hash.eq(&CodeDB::empty_code_hash()))
             || !callee_account.nonce.is_zero())
     {
         unimplemented!("deployment collision");

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -511,9 +511,9 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
         (true, _) => (call.code_hash.to_word(), false),
         (_, true) => {
             debug_assert_eq!(
-                callee_account.poseidon_code_hash, call.code_hash,
+                callee_account.code_hash, call.code_hash,
                 "callee account's code hash: {:?}, call's code hash: {:?}",
-                callee_account.poseidon_code_hash, call.code_hash
+                callee_account.code_hash, call.code_hash
             );
             (
                 call.code_hash.to_word(),
@@ -526,7 +526,7 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
         state.account_read(
             &mut exec_step,
             call.address,
-            AccountField::PoseidonCodeHash,
+            AccountField::CodeHash,
             callee_code_hash,
         );
     }
@@ -847,9 +847,9 @@ fn dummy_gen_selfdestruct_ops(
         &mut exec_step,
         AccountOp {
             address: sender,
-            field: AccountField::PoseidonCodeHash,
+            field: AccountField::CodeHash,
             value: Word::zero(),
-            value_prev: sender_account.poseidon_code_hash.to_word(),
+            value_prev: sender_account.code_hash.to_word(),
         },
     )?;
     if receiver != sender {

--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -61,7 +61,7 @@ impl Opcode for Balance {
         let exists = !account.is_empty();
         let balance = account.balance;
         let code_hash = if exists {
-            account.poseidon_code_hash
+            account.code_hash
         } else {
             H256::zero()
         };
@@ -69,7 +69,7 @@ impl Opcode for Balance {
         state.account_read(
             &mut exec_step,
             address,
-            AccountField::PoseidonCodeHash,
+            AccountField::CodeHash,
             code_hash.to_word(),
         );
         if exists {
@@ -272,7 +272,7 @@ mod balance_tests {
             operation.op(),
             &AccountOp {
                 address,
-                field: AccountField::PoseidonCodeHash,
+                field: AccountField::CodeHash,
                 value: if exists { code_hash } else { U256::zero() },
                 value_prev: if exists { code_hash } else { U256::zero() },
             }

--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -57,7 +57,6 @@ impl Opcode for Balance {
 
         // Read account balance.
         let account = state.sdb.get_account(&address).1;
-        dbg!(account, account.is_empty());
         let exists = !account.is_empty();
         let balance = account.balance;
         let code_hash = if exists {
@@ -95,7 +94,6 @@ mod balance_tests {
         mock::BlockData,
         operation::{AccountOp, CallContextOp, StackOp, RW},
         state_db::CodeDB,
-        util::hash_code,
     };
     use eth_types::{
         address, bytecode,
@@ -260,7 +258,7 @@ mod balance_tests {
         );
 
         let code_hash = if let Some(code) = account_code {
-            hash_code(&code).to_word()
+            CodeDB::hash(&code).to_word()
         } else if exists {
             CodeDB::empty_code_hash().to_word()
         } else {

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -111,7 +111,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
         state.account_read(
             &mut exec_step,
             callee_address,
-            AccountField::PoseidonCodeHash,
+            AccountField::CodeHash,
             callee_code_hash_word,
         );
 

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -129,7 +129,7 @@ mod codecopy_tests {
         circuit_input_builder::{CopyDataType, ExecState, NumberOrHash},
         mock::BlockData,
         operation::{MemoryOp, StackOp, RW},
-        util::hash_code,
+        state_db::CodeDB,
     };
 
     #[test]
@@ -216,8 +216,10 @@ mod codecopy_tests {
         let copy_events = builder.block.copy_events.clone();
         assert_eq!(copy_events.len(), 1);
         assert_eq!(copy_events[0].bytes.len(), size);
-        let code_hash = hash_code(&code.to_vec());
-        assert_eq!(copy_events[0].src_id, NumberOrHash::Hash(code_hash));
+        assert_eq!(
+            copy_events[0].src_id,
+            NumberOrHash::Hash(CodeDB::hash(&code.to_vec()))
+        );
         assert_eq!(copy_events[0].src_addr as usize, code_offset);
         assert_eq!(copy_events[0].src_addr_end as usize, code.to_vec().len());
         assert_eq!(copy_events[0].src_type, CopyDataType::Bytecode);

--- a/bus-mapping/src/evm/opcodes/error_oog_call.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_call.rs
@@ -64,7 +64,7 @@ impl Opcode for OOGCall {
 
         let (_, callee_account) = state.sdb.get_account(&call_address);
         let callee_exists = !callee_account.is_empty();
-        let callee_code_hash = callee_account.poseidon_code_hash;
+        let callee_code_hash = callee_account.code_hash;
         let callee_code_hash_word = if callee_exists {
             callee_code_hash.to_word()
         } else {
@@ -74,7 +74,7 @@ impl Opcode for OOGCall {
         state.account_read(
             &mut exec_step,
             call_address,
-            AccountField::PoseidonCodeHash,
+            AccountField::CodeHash,
             callee_code_hash_word,
         );
 

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -29,7 +29,7 @@ impl Opcode for Extcodecopy {
         let length = geth_steps[0].stack.nth_last(3)?;
 
         let (_, account) = state.sdb.get_account(&address);
-        let code_hash = account.poseidon_code_hash;
+        let code_hash = account.code_hash;
         let code = state.code(code_hash)?;
 
         let call_ctx = state.call_ctx_mut()?;
@@ -97,7 +97,7 @@ fn gen_extcodecopy_step(
     let account = state.sdb.get_account(&external_address).1;
     let exists = !account.is_empty();
     let code_hash = if exists {
-        account.poseidon_code_hash
+        account.code_hash
     } else {
         H256::zero()
     };
@@ -105,7 +105,7 @@ fn gen_extcodecopy_step(
     state.account_read(
         &mut exec_step,
         external_address,
-        AccountField::PoseidonCodeHash,
+        AccountField::CodeHash,
         code_hash.to_word(),
     );
     Ok(exec_step)
@@ -125,7 +125,7 @@ fn gen_copy_event(
     let account = state.sdb.get_account(&external_address).1;
     let exists = !account.is_empty();
     let code_hash = if exists {
-        account.poseidon_code_hash
+        account.code_hash
     } else {
         H256::zero()
     };
@@ -388,7 +388,7 @@ mod extcodecopy_tests {
                 RW::READ,
                 &AccountOp {
                     address: external_address,
-                    field: AccountField::PoseidonCodeHash,
+                    field: AccountField::CodeHash,
                     value: code_hash.to_word(),
                     value_prev: code_hash.to_word(),
                 }

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -180,7 +180,7 @@ mod extcodecopy_tests {
             AccountField, AccountOp, CallContextField, CallContextOp, MemoryOp, StackOp,
             TxAccessListAccountOp, RW,
         },
-        util::hash_code,
+        state_db::CodeDB,
     };
     use eth_types::{
         address, bytecode,
@@ -218,10 +218,10 @@ mod extcodecopy_tests {
         let bytecode_ext = Bytecode::from(code_ext.to_vec());
         // TODO: bytecode_ext = vec![] is being used to indicate an empty account.
         // Should be an optional vec and we need to add tests for EOA vs. non-EOA.
-        let code_hash = if bytecode_ext.code.is_empty() {
+        let code_hash = if code_ext.is_empty() {
             Default::default()
         } else {
-            hash_code(&code_ext.to_vec())
+            CodeDB::hash(&code_ext)
         };
 
         // Get the execution steps from the external tracer

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -83,7 +83,7 @@ impl Opcode for ReturnRevert {
                 &mut exec_step,
                 AccountOp {
                     address: state.call()?.address,
-                    field: AccountField::PoseidonCodeHash,
+                    field: AccountField::CodeHash,
                     value: code_info.poseidon_hash.to_word(),
                     value_prev: POSEIDON_CODE_HASH_ZERO.to_word(),
                 },

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -3,7 +3,8 @@ use crate::{
     circuit_input_builder::{CircuitInputStateRef, CopyDataType, CopyEvent, NumberOrHash},
     evm::opcodes::ExecStep,
     operation::{AccountField, AccountOp, CallContextField, MemoryOp, RW},
-    util::{hash_code, KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO},
+    state_db::CodeDB,
+    util::KECCAK_CODE_HASH_ZERO,
     Error,
 };
 use eth_types::{Bytecode, GethExecStep, ToWord, Word, H256};
@@ -85,7 +86,7 @@ impl Opcode for ReturnRevert {
                     address: state.call()?.address,
                     field: AccountField::CodeHash,
                     value: code_info.poseidon_hash.to_word(),
-                    value_prev: POSEIDON_CODE_HASH_ZERO.to_word(),
+                    value_prev: CodeDB::empty_code_hash().to_word(),
                 },
             )?;
             state.push_op_reversible(
@@ -231,9 +232,9 @@ fn handle_create(
 ) -> Result<AccountCodeInfo, Error> {
     let values = state.call_ctx()?.memory.0[source.offset..source.offset + source.length].to_vec();
     let keccak_hash = H256(keccak256(&values));
-    let poseidon_hash = hash_code(&values);
+    let code_hash = CodeDB::hash(&values);
     let size = values.len();
-    let dst_id = NumberOrHash::Hash(poseidon_hash);
+    let dst_id = NumberOrHash::Hash(code_hash);
     let bytes: Vec<_> = Bytecode::from(values)
         .code
         .iter()
@@ -267,7 +268,7 @@ fn handle_create(
 
     Ok(AccountCodeInfo {
         keccak_hash,
-        poseidon_hash,
+        poseidon_hash: code_hash,
         size,
     })
 }

--- a/bus-mapping/src/mock.rs
+++ b/bus-mapping/src/mock.rs
@@ -72,15 +72,15 @@ impl BlockData {
                 keccak_code_hash,
                 hex::encode(account.code.to_vec())
             );
-            let poseidon_code_hash = code_db.insert(account.code.to_vec());
+            let code_hash = code_db.insert(account.code.to_vec());
             sdb.set_account(
                 &account.address,
                 state_db::Account {
                     nonce: account.nonce,
                     balance: account.balance,
                     storage: account.storage,
+                    code_hash,
                     keccak_code_hash,
-                    poseidon_code_hash,
                     code_size: account.code.len().to_word(),
                 },
             );

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -531,10 +531,10 @@ pub enum AccountField {
     Nonce,
     /// Account Balance
     Balance,
+    /// Poseidon hash of account's code
+    CodeHash,
     /// Keccak hash of account's code
     KeccakCodeHash,
-    /// Poseidon hash of account's code
-    PoseidonCodeHash,
     /// Size of account's code, i.e. code length
     CodeSize,
 }

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     precompile::is_precompiled,
-    util::{hash_code, KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO},
+    util::{hash_code, KECCAK_CODE_HASH_ZERO},
 };
 use eth_types::{Address, Hash, Word, H256, U256};
 use lazy_static::lazy_static;
@@ -86,7 +86,7 @@ impl Account {
             nonce: Word::zero(),
             balance: Word::zero(),
             storage: HashMap::new(),
-            code_hash: *POSEIDON_CODE_HASH_ZERO,
+            code_hash: CodeDB::empty_code_hash(),
             keccak_code_hash: *KECCAK_CODE_HASH_ZERO,
             code_size: Word::zero(),
         }
@@ -98,7 +98,7 @@ impl Account {
             && self.balance.is_zero()
             //&& self.storage.is_empty()
             && self.keccak_code_hash.eq(&KECCAK_CODE_HASH_ZERO)
-            && self.code_hash.eq(&POSEIDON_CODE_HASH_ZERO)
+            && self.code_hash.eq(&CodeDB::empty_code_hash())
             && self.code_size.is_zero()
     }
 }

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -71,10 +71,10 @@ pub struct Account {
     pub balance: Word,
     /// Storage key-value map
     pub storage: HashMap<Word, Word>,
+    /// Poseidon hash of code
+    pub code_hash: Hash,
     /// Keccak hash of code
     pub keccak_code_hash: Hash,
-    /// Poseidon hash of code
-    pub poseidon_code_hash: Hash,
     /// Size of code, i.e. code length
     pub code_size: Word,
 }
@@ -86,8 +86,8 @@ impl Account {
             nonce: Word::zero(),
             balance: Word::zero(),
             storage: HashMap::new(),
+            code_hash: *POSEIDON_CODE_HASH_ZERO,
             keccak_code_hash: *KECCAK_CODE_HASH_ZERO,
-            poseidon_code_hash: *POSEIDON_CODE_HASH_ZERO,
             code_size: Word::zero(),
         }
     }
@@ -98,7 +98,7 @@ impl Account {
             && self.balance.is_zero()
             //&& self.storage.is_empty()
             && self.keccak_code_hash.eq(&KECCAK_CODE_HASH_ZERO)
-            && self.poseidon_code_hash.eq(&POSEIDON_CODE_HASH_ZERO)
+            && self.code_hash.eq(&POSEIDON_CODE_HASH_ZERO)
             && self.code_size.is_zero()
     }
 }

--- a/bus-mapping/src/util.rs
+++ b/bus-mapping/src/util.rs
@@ -19,7 +19,7 @@ pub static CHECK_MEM_STRICT: Lazy<bool> = Lazy::new(|| read_env_var("CHECK_MEM_S
 pub const POSEIDON_HASH_BYTES_IN_FIELD: usize = 31;
 
 /// Default code hash (use poseidon hash now)
-pub fn hash_code(code: &[u8]) -> Hash {
+pub(crate) fn hash_code(code: &[u8]) -> Hash {
     use poseidon_circuit::hash::{Hashable, MessageHashable, HASHABLE_DOMAIN_SPEC};
 
     let bytes_in_field = POSEIDON_HASH_BYTES_IN_FIELD;
@@ -93,5 +93,3 @@ fn code_hashing() {
 
 /// the zero keccak code hash
 pub static KECCAK_CODE_HASH_ZERO: Lazy<Hash> = Lazy::new(|| H256(keccak256([])));
-/// the zero poseidon code hash
-pub static POSEIDON_CODE_HASH_ZERO: Lazy<Hash> = Lazy::new(|| hash_code(&[]));

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,6 +4,6 @@ comment_width = 100
 imports_granularity = "Crate"
 max_width = 100
 newline_style = "Unix"
-#normalize_comments = true
+normalize_comments = true
 reorder_imports = true
 wrap_comments = true

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -87,10 +87,10 @@ fn check_post(
         }
 
         if let Some(expected_code) = &expected.code {
-            let actual_code = if actual.poseidon_code_hash.is_zero() {
+            let actual_code = if actual.code_hash.is_zero() {
                 std::borrow::Cow::Owned(Vec::new())
             } else {
-                std::borrow::Cow::Borrowed(&builder.code_db.0[&actual.poseidon_code_hash])
+                std::borrow::Cow::Borrowed(&builder.code_db.0[&actual.code_hash])
             };
             if &actual_code as &[u8] != expected_code.0 {
                 return Err(StateTestError::CodeMismatch {

--- a/zkevm-circuits/src/bytecode_circuit/circuit.rs
+++ b/zkevm-circuits/src/bytecode_circuit/circuit.rs
@@ -241,19 +241,17 @@ impl<F: Field> SubCircuitConfig<F> for BytecodeCircuitConfig<F> {
                 meta.query_advice(length, Rotation::cur()),
             );
 
-            /*
             let empty_hash = rlc::expr(
                 &EMPTY_CODE_HASH_LE.map(|v| Expression::Constant(F::from(v as u64))),
                 challenges.evm_word(),
             );
 
-                        // FIXME: poseidon
-                        cb.require_equal(
-                            "assert cur.hash == EMPTY_HASH",
-                            meta.query_advice(bytecode_table.code_hash, Rotation::cur()),
-                            empty_hash,
-                        );
-            */
+            cb.require_equal(
+                "assert cur.hash == EMPTY_HASH",
+                meta.query_advice(bytecode_table.code_hash, Rotation::cur()),
+                empty_hash,
+            );
+
             cb.gate(and::expr(vec![
                 meta.query_fixed(q_enable, Rotation::cur()),
                 or::expr(vec![

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -215,7 +215,6 @@ mod test {
             STOP
         });
 
-        // TODO: this does not actually test a non-existent account if account is None.
         let ctx = TestContext::<3, 1>::new(
             None,
             |accs| {

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -54,11 +54,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         );
         let code_hash = cb.query_cell_phase2();
         // For non-existing accounts the code_hash must be 0 in the rw_table.
-        cb.account_read(
-            address.expr(),
-            AccountFieldTag::PoseidonCodeHash,
-            code_hash.expr(),
-        );
+        cb.account_read(address.expr(), AccountFieldTag::CodeHash, code_hash.expr());
         let not_exists = IsZeroGadget::construct(cb, code_hash.expr());
         let exists = not::expr(not_exists.expr());
         let balance = cb.query_cell_phase2();

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -192,7 +192,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         // Read code_hash of callee
         let phase2_code_hash = cb.query_cell_phase2();
         let is_empty_code_hash =
-            IsEqualGadget::construct(cb, phase2_code_hash.expr(), cb.empty_poseidon_hash_rlc());
+            IsEqualGadget::construct(cb, phase2_code_hash.expr(), cb.empty_code_hash_rlc());
         let callee_not_exists = IsZeroGadget::construct(cb, phase2_code_hash.expr());
         // no_callee_code is true when the account exists and has empty
         // code hash, or when the account doesn't exist (which we encode with
@@ -652,7 +652,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             region,
             offset,
             region.word_rlc(callee_code_hash),
-            region.empty_poseidon_hash_rlc(),
+            region.empty_code_hash_rlc(),
         )?;
         self.callee_not_exists
             .assign_value(region, offset, region.word_rlc(callee_code_hash))?;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -213,7 +213,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             |cb| {
                 cb.account_read(
                     call_callee_address.expr(),
-                    AccountFieldTag::PoseidonCodeHash,
+                    AccountFieldTag::CodeHash,
                     phase2_code_hash.expr(),
                 ); // rwc_delta += 1
             },

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -141,7 +141,7 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
             cb.require_equal(
                 "poseidon hash of empty bytes",
                 poseidon_code_hash.expr(),
-                cb.empty_poseidon_hash_rlc(),
+                cb.empty_code_hash_rlc(),
             );
         });
 

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -310,50 +310,51 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
         // and code_hash. Each sequence of bytes occurs in a fixed position, so to
         // compute the RLC of the input, we only need to compute some fixed powers of
         // the randomness.
-        //     let randomness_raised_to_16 = cb.power_of_randomness()[15].clone();
-        //     let randomness_raised_to_32 = randomness_raised_to_16.square();
-        //     let randomness_raised_to_64 = randomness_raised_to_32.clone().square();
-        //     let randomness_raised_to_84 =
-        //         randomness_raised_to_64.clone() * cb.power_of_randomness()[19].clone();
-        //     cb.require_equal(
-        //         "for CREATE2, keccak input is 0xff ++ address ++ salt ++ code_hash",
-        //         keccak_input.expr(),
-        //         0xff.expr() * randomness_raised_to_84
-        //             + caller_address.expr() * randomness_raised_to_64
-        //             + salt.expr() * randomness_raised_to_32
-        //             + code_hash.expr(),
-        //     );
-        //     cb.require_equal(
-        //         "for CREATE2, keccak input length is 85",
-        //         keccak_input_length.expr(),
-        //         (1 + 20 + 32 + 32).expr(),
-        //     );
+        // let randomness_raised_to_16 = cb.power_of_randomness()[15].clone();
+        // let randomness_raised_to_32 = randomness_raised_to_16.square();
+        // let randomness_raised_to_64 = randomness_raised_to_32.clone().square();
+        // let randomness_raised_to_84 =
+        // randomness_raised_to_64.clone() * cb.power_of_randomness()[19].clone();
+        // cb.require_equal(
+        // "for CREATE2, keccak input is 0xff ++ address ++ salt ++ code_hash",
+        // keccak_input.expr(),
+        // 0xff.expr() * randomness_raised_to_84
+        // + caller_address.expr() * randomness_raised_to_64
+        // + salt.expr() * randomness_raised_to_32
+        // + code_hash.expr(),
+        // );
+        // cb.require_equal(
+        // "for CREATE2, keccak input length is 85",
+        // keccak_input_length.expr(),
+        // (1 + 20 + 32 + 32).expr(),
+        // );
         // });
 
         // cb.condition(not::expr(is_create2.expr()), |cb| {
-        //     let randomness_raised_to_20 = cb.power_of_randomness()[19].clone();
-        //     let randomness_raised_to_21 = cb.power_of_randomness()[20].clone();
-        //     cb.require_equal(
-        //         "for CREATE, keccak input is rlp([address, nonce])",
-        //         keccak_input.expr(),
-        //         nonce.rlp_rlc(cb)
-        //             + nonce.randomness_raised_to_rlp_length(cb)
-        //                 * (((0xc0.expr() + 21.expr() + nonce.rlp_length())
-        //                     * randomness_raised_to_21)
-        //                     + (0x80 + 20).expr() * randomness_raised_to_20
-        //                     + caller_address.expr()),
-        //     );
-        //     cb.require_equal(
-        //         "for CREATE, keccak input length is rlp([address, nonce]).len()",
-        //         keccak_input_length.expr(),
-        //         (1 + 1 + 20).expr() + nonce.rlp_length(),
-        //     );
+        // let randomness_raised_to_20 = cb.power_of_randomness()[19].clone();
+        // let randomness_raised_to_21 = cb.power_of_randomness()[20].clone();
+        // cb.require_equal(
+        // "for CREATE, keccak input is rlp([address, nonce])",
+        // keccak_input.expr(),
+        // nonce.rlp_rlc(cb)
+        // + nonce.randomness_raised_to_rlp_length(cb)
+        // * (((0xc0.expr() + 21.expr() + nonce.rlp_length())
+        // * randomness_raised_to_21)
+        // + (0x80 + 20).expr() * randomness_raised_to_20
+        // + caller_address.expr()),
+        // );
+        // cb.require_equal(
+        // "for CREATE, keccak input length is rlp([address, nonce]).len()",
+        // keccak_input_length.expr(),
+        // (1 + 1 + 20).expr() + nonce.rlp_length(),
+        // );
         // });
-
+        //
+        //
         // cb.keccak_table_lookup(
-        //     keccak_input.expr(),
-        //     keccak_input_length.expr(),
-        //     keccak_output.expr(),
+        // keccak_input.expr(),
+        // keccak_input_length.expr(),
+        // keccak_output.expr(),
         // );
 
         Self {

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -304,60 +304,57 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
 
         let keccak_input = cb.query_cell_phase2();
         let keccak_input_length = cb.query_cell();
-        /*
-        cb.condition(is_create2.expr(), |cb| {
-            // For CREATE2, the keccak input is the concatenation of 0xff, address, salt,
-            // and code_hash. Each sequence of bytes occurs in a fixed position, so to
-            // compute the RLC of the input, we only need to compute some fixed powers of
-            // the randomness.
-            let randomness_raised_to_16 = cb.power_of_randomness()[15].clone();
-            let randomness_raised_to_32 = randomness_raised_to_16.square();
-            let randomness_raised_to_64 = randomness_raised_to_32.clone().square();
-            let randomness_raised_to_84 =
-                randomness_raised_to_64.clone() * cb.power_of_randomness()[19].clone();
-            cb.require_equal(
-                "for CREATE2, keccak input is 0xff ++ address ++ salt ++ code_hash",
-                keccak_input.expr(),
-                0xff.expr() * randomness_raised_to_84
-                    + caller_address.expr() * randomness_raised_to_64
-                    + salt.expr() * randomness_raised_to_32
-                    + code_hash.expr(),
-            );
-            cb.require_equal(
-                "for CREATE2, keccak input length is 85",
-                keccak_input_length.expr(),
-                (1 + 20 + 32 + 32).expr(),
-            );
-        });
 
+        // cb.condition(is_create2.expr(), |cb| {
+        // For CREATE2, the keccak input is the concatenation of 0xff, address, salt,
+        // and code_hash. Each sequence of bytes occurs in a fixed position, so to
+        // compute the RLC of the input, we only need to compute some fixed powers of
+        // the randomness.
+        //     let randomness_raised_to_16 = cb.power_of_randomness()[15].clone();
+        //     let randomness_raised_to_32 = randomness_raised_to_16.square();
+        //     let randomness_raised_to_64 = randomness_raised_to_32.clone().square();
+        //     let randomness_raised_to_84 =
+        //         randomness_raised_to_64.clone() * cb.power_of_randomness()[19].clone();
+        //     cb.require_equal(
+        //         "for CREATE2, keccak input is 0xff ++ address ++ salt ++ code_hash",
+        //         keccak_input.expr(),
+        //         0xff.expr() * randomness_raised_to_84
+        //             + caller_address.expr() * randomness_raised_to_64
+        //             + salt.expr() * randomness_raised_to_32
+        //             + code_hash.expr(),
+        //     );
+        //     cb.require_equal(
+        //         "for CREATE2, keccak input length is 85",
+        //         keccak_input_length.expr(),
+        //         (1 + 20 + 32 + 32).expr(),
+        //     );
+        // });
 
-        cb.condition(not::expr(is_create2.expr()), |cb| {
-            let randomness_raised_to_20 = cb.power_of_randomness()[19].clone();
-            let randomness_raised_to_21 = cb.power_of_randomness()[20].clone();
-            cb.require_equal(
-                "for CREATE, keccak input is rlp([address, nonce])",
-                keccak_input.expr(),
-                nonce.rlp_rlc(cb)
-                    + nonce.randomness_raised_to_rlp_length(cb)
-                        * (((0xc0.expr() + 21.expr() + nonce.rlp_length())
-                            * randomness_raised_to_21)
-                            + (0x80 + 20).expr() * randomness_raised_to_20
-                            + caller_address.expr()),
-            );
-            cb.require_equal(
-                "for CREATE, keccak input length is rlp([address, nonce]).len()",
-                keccak_input_length.expr(),
-                (1 + 1 + 20).expr() + nonce.rlp_length(),
-            );
-        });
+        // cb.condition(not::expr(is_create2.expr()), |cb| {
+        //     let randomness_raised_to_20 = cb.power_of_randomness()[19].clone();
+        //     let randomness_raised_to_21 = cb.power_of_randomness()[20].clone();
+        //     cb.require_equal(
+        //         "for CREATE, keccak input is rlp([address, nonce])",
+        //         keccak_input.expr(),
+        //         nonce.rlp_rlc(cb)
+        //             + nonce.randomness_raised_to_rlp_length(cb)
+        //                 * (((0xc0.expr() + 21.expr() + nonce.rlp_length())
+        //                     * randomness_raised_to_21)
+        //                     + (0x80 + 20).expr() * randomness_raised_to_20
+        //                     + caller_address.expr()),
+        //     );
+        //     cb.require_equal(
+        //         "for CREATE, keccak input length is rlp([address, nonce]).len()",
+        //         keccak_input_length.expr(),
+        //         (1 + 1 + 20).expr() + nonce.rlp_length(),
+        //     );
+        // });
 
-
-        cb.keccak_table_lookup(
-            keccak_input.expr(),
-            keccak_input_length.expr(),
-            keccak_output.expr(),
-        );
-        */
+        // cb.keccak_table_lookup(
+        //     keccak_input.expr(),
+        //     keccak_input_length.expr(),
+        //     keccak_output.expr(),
+        // );
 
         Self {
             opcode,

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -698,43 +698,41 @@ impl<F: Field> RlpU64Gadget<F> {
     fn rlp_length(&self) -> Expression<F> {
         1.expr() + not::expr(self.is_less_than_128.expr()) * self.n_bytes_nonce()
     }
-    /*
-    fn rlp_rlc(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
-        select::expr(
-            and::expr(&[
-                self.is_less_than_128.expr(),
-                not::expr(self.most_significant_byte_is_zero.expr()),
-            ]),
-            self.value(),
-            (0x80.expr() + self.n_bytes_nonce()) * self.randomness_raised_n_bytes_nonce(cb)
-                + self.bytes.expr(),
-        )
-    }
-
-    fn randomness_raised_to_rlp_length(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
-        let powers_of_randomness = cb.power_of_randomness();
-        powers_of_randomness[0].clone()
-            * select::expr(
-                self.is_less_than_128.expr(),
-                1.expr(),
-                self.randomness_raised_n_bytes_nonce(cb),
-            )
-    }
-
-    fn randomness_raised_n_bytes_nonce(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
-        let powers_of_randomness = cb.power_of_randomness();
-        select::expr(
-            self.most_significant_byte_is_zero.expr(),
-            1.expr(),
-            sum::expr(
-                self.is_most_significant_byte
-                    .iter()
-                    .zip(powers_of_randomness)
-                    .map(|(indicator, power)| indicator.expr() * power.clone()),
-            ),
-        )
-    }
-    */
+    // fn rlp_rlc(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
+    // select::expr(
+    // and::expr(&[
+    // self.is_less_than_128.expr(),
+    // not::expr(self.most_significant_byte_is_zero.expr()),
+    // ]),
+    // self.value(),
+    // (0x80.expr() + self.n_bytes_nonce()) * self.randomness_raised_n_bytes_nonce(cb)
+    // + self.bytes.expr(),
+    // )
+    // }
+    //
+    // fn randomness_raised_to_rlp_length(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
+    // let powers_of_randomness = cb.power_of_randomness();
+    // powers_of_randomness[0].clone()
+    // select::expr(
+    // self.is_less_than_128.expr(),
+    // 1.expr(),
+    // self.randomness_raised_n_bytes_nonce(cb),
+    // )
+    // }
+    //
+    // fn randomness_raised_n_bytes_nonce(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
+    // let powers_of_randomness = cb.power_of_randomness();
+    // select::expr(
+    // self.most_significant_byte_is_zero.expr(),
+    // 1.expr(),
+    // sum::expr(
+    // self.is_most_significant_byte
+    // .iter()
+    // .zip(powers_of_randomness)
+    // .map(|(indicator, power)| indicator.expr() * power.clone()),
+    // ),
+    // )
+    // }
 }
 
 #[cfg(test)]

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -22,7 +22,7 @@ use crate::{
     table::{AccountFieldTag, CallContextFieldTag},
     util::Expr,
 };
-use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
+use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId, state_db::CodeDB};
 use eth_types::{evm_types::GasCost, Field, ToBigEndian, ToLittleEndian, ToScalar, ToWord, U256};
 use ethers_core::utils::{keccak256, rlp};
 use halo2_proofs::{
@@ -60,8 +60,8 @@ pub(crate) struct CreateGadget<F> {
 
     gas_left: ConstantDivisionGadget<F, N_BYTES_GAS>,
 
+    code_hash: Cell<F>,
     keccak_code_hash: Cell<F>,
-    poseidon_code_hash: Cell<F>,
 
     keccak_input: Cell<F>,
     keccak_input_length: Cell<F>,
@@ -115,14 +115,14 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
         let callee_is_success = cb.query_bool();
         cb.stack_push(callee_is_success.expr() * new_address_rlc);
 
+        let code_hash = cb.query_cell_phase2();
         let keccak_code_hash = cb.query_cell_phase2();
-        let poseidon_code_hash = cb.query_cell_phase2();
         cb.condition(initialization_code.has_length(), |cb| {
             // TODO(rohit): lookup to keccak table to verify keccak code hash?
             cb.copy_table_lookup(
                 cb.curr.state.call_id.expr(),
                 CopyDataType::Memory.expr(),
-                poseidon_code_hash.expr(),
+                code_hash.expr(),
                 CopyDataType::Bytecode.expr(),
                 initialization_code.offset(),
                 initialization_code.address(),
@@ -139,8 +139,8 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
                 cb.empty_keccak_hash_rlc(),
             );
             cb.require_equal(
-                "poseidon hash of empty bytes",
-                poseidon_code_hash.expr(),
+                "code hash of empty bytes",
+                code_hash.expr(),
                 cb.empty_code_hash_rlc(),
             );
         });
@@ -265,7 +265,7 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
             (CallContextFieldTag::IsRoot, false.expr()),
             (CallContextFieldTag::IsStatic, false.expr()),
             (CallContextFieldTag::IsCreate, true.expr()),
-            (CallContextFieldTag::CodeHash, poseidon_code_hash.expr()),
+            (CallContextFieldTag::CodeHash, code_hash.expr()),
             (CallContextFieldTag::Value, value.expr()),
         ] {
             cb.call_context_lookup(true.expr(), Some(callee_call_id.expr()), field_tag, value);
@@ -277,7 +277,7 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
                 call_id: To(callee_call_id.expr()),
                 is_root: To(false.expr()),
                 is_create: To(true.expr()),
-                code_hash: To(poseidon_code_hash.expr()),
+                code_hash: To(code_hash.expr()),
                 gas_left: To(callee_gas_left),
                 reversible_write_counter: To(1.expr() + transfer.reversible_w_delta()),
                 ..StepStateTransition::new_context()
@@ -376,8 +376,8 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
             memory_expansion,
             gas_left,
             callee_is_success,
+            code_hash,
             keccak_code_hash,
-            poseidon_code_hash,
             keccak_output,
             keccak_input,
             keccak_input_length,
@@ -423,12 +423,9 @@ impl<F: Field> ExecutionGadget<F> for CreateGadget<F> {
             offset,
             region.word_rlc(U256::from_big_endian(&keccak_code_hash)),
         )?;
-        let poseidon_code_hash = bus_mapping::util::hash_code(&values);
-        self.poseidon_code_hash.assign(
-            region,
-            offset,
-            region.word_rlc(poseidon_code_hash.to_word()),
-        )?;
+        let code_hash = CodeDB::hash(&values);
+        self.code_hash
+            .assign(region, offset, region.word_rlc(code_hash.to_word()))?;
 
         for (word, assignment) in [(&self.value, value), (&self.salt, salt)] {
             word.assign(region, offset, Some(assignment.to_le_bytes()))?;

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -75,7 +75,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let code_hash = cb.query_cell_phase2();
         cb.account_read(
             external_address.expr(),
-            AccountFieldTag::PoseidonCodeHash,
+            AccountFieldTag::CodeHash,
             code_hash.expr(),
         );
         // TODO: If external_address doesn't exist, we will get code_hash = 0.  With

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -18,7 +18,7 @@ use crate::{
     table::{AccountFieldTag, CallContextFieldTag},
     util::Expr,
 };
-use bus_mapping::circuit_input_builder::CopyDataType;
+use bus_mapping::{circuit_input_builder::CopyDataType, state_db::CodeDB};
 use eth_types::{evm_types::GasCost, Field, ToScalar, U256};
 use ethers_core::utils::keccak256;
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -41,7 +41,7 @@ pub(crate) struct ReturnRevertGadget<F> {
 
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
     keccak_code_hash: Cell<F>,
-    poseidon_code_hash: Cell<F>,
+    code_hash: Cell<F>,
     code_size: Cell<F>,
 
     caller_id: Cell<F>,
@@ -101,17 +101,17 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             * is_success.expr()
             * GasCost::CODE_DEPOSIT_BYTE_COST.expr()
             * range.length();
-        let (caller_id, address, reversion_info, keccak_code_hash, poseidon_code_hash, code_size) =
-            cb.condition(is_contract_deployment.clone(), |cb| {
+        let (caller_id, address, reversion_info, code_hash, keccak_code_hash, code_size) = cb
+            .condition(is_contract_deployment.clone(), |cb| {
                 // poseidon hash of code.
                 //
                 // We don't need to place any additional constraints on code_hash because the
                 // copy circuit enforces that it is the hash of the bytes in the copy lookup.
-                let poseidon_code_hash = cb.query_cell_phase2();
+                let code_hash = cb.query_cell_phase2();
                 cb.copy_table_lookup(
                     cb.curr.state.call_id.expr(),
                     CopyDataType::Memory.expr(),
-                    poseidon_code_hash.expr(),
+                    code_hash.expr(),
                     CopyDataType::Bytecode.expr(),
                     range.offset(),
                     range.address(),
@@ -143,7 +143,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                 cb.account_write(
                     address.expr(),
                     AccountFieldTag::CodeHash,
-                    poseidon_code_hash.expr(),
+                    code_hash.expr(),
                     cb.empty_code_hash_rlc(),
                     Some(&mut reversion_info),
                 );
@@ -163,8 +163,8 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                     caller_id,
                     address,
                     reversion_info,
+                    code_hash,
                     keccak_code_hash,
-                    poseidon_code_hash,
                     code_size,
                 )
             });
@@ -266,8 +266,8 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             return_data_length,
             restore_context,
             memory_expansion,
+            code_hash,
             keccak_code_hash,
-            poseidon_code_hash,
             code_size,
             address,
             caller_id,
@@ -328,11 +328,12 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             )?;
 
             // poseidon hash of code.
-            let poseidon_code_hash = bus_mapping::util::hash_code(&values);
-            self.poseidon_code_hash.assign(
+            let mut code_hash = CodeDB::hash(&values).to_fixed_bytes();
+            code_hash.reverse();
+            self.code_hash.assign(
                 region,
                 offset,
-                region.word_rlc(U256::from_big_endian(poseidon_code_hash.as_bytes())),
+                region.word_rlc(U256::from_little_endian(&code_hash)),
             )?;
 
             // code size.
@@ -354,7 +355,6 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
 
         let is_contract_deployment = call.is_create && call.is_success && !length.is_zero();
         if !call.is_root {
-            // here....
             let rw_counter_offset = 3 + if is_contract_deployment {
                 7 + length.as_u64()
             } else {

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -142,7 +142,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                 );
                 cb.account_write(
                     address.expr(),
-                    AccountFieldTag::PoseidonCodeHash,
+                    AccountFieldTag::CodeHash,
                     poseidon_code_hash.expr(),
                     cb.empty_poseidon_hash_rlc(),
                     Some(&mut reversion_info),

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -144,7 +144,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                     address.expr(),
                     AccountFieldTag::CodeHash,
                     poseidon_code_hash.expr(),
-                    cb.empty_poseidon_hash_rlc(),
+                    cb.empty_code_hash_rlc(),
                     Some(&mut reversion_info),
                 );
 

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -9,10 +9,7 @@ use crate::{
     util::{query_expression, Challenges, Expr},
     witness::{Block, ExecStep, Rw, RwMap},
 };
-use bus_mapping::{
-    state_db::CodeDB,
-    util::{KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO},
-};
+use bus_mapping::state_db::CodeDB;
 use eth_types::{Address, ToLittleEndian, ToWord, U256};
 use halo2_proofs::{
     arithmetic::FieldExt,
@@ -200,14 +197,6 @@ impl<'r, 'b, F: FieldExt> CachedRegion<'r, 'b, F> {
     }
     pub fn empty_code_hash_rlc(&self) -> Value<F> {
         self.word_rlc(CodeDB::empty_code_hash().to_word())
-    }
-
-    pub fn empty_keccak_hash_rlc(&self) -> Value<F> {
-        self.word_rlc(KECCAK_CODE_HASH_ZERO.to_word())
-    }
-
-    pub fn empty_poseidon_hash_rlc(&self) -> Value<F> {
-        self.word_rlc(POSEIDON_CODE_HASH_ZERO.to_word())
     }
 
     /// Constrains a cell to have a constant value.

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -388,7 +388,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
             |cb| {
                 cb.account_write(
                     receiver_address.clone(),
-                    AccountFieldTag::PoseidonCodeHash,
+                    AccountFieldTag::CodeHash,
                     cb.empty_poseidon_hash_rlc(),
                     0.expr(),
                     Some(reversion_info),
@@ -518,7 +518,7 @@ impl<F: Field> TransferGadget<F> {
             |cb| {
                 cb.account_write(
                     receiver_address.clone(),
-                    AccountFieldTag::PoseidonCodeHash,
+                    AccountFieldTag::CodeHash,
                     cb.empty_poseidon_hash_rlc(),
                     0.expr(),
                     Some(reversion_info),
@@ -695,7 +695,7 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         let phase2_callee_code_hash = cb.query_cell_with_type(CellType::StoragePhase2);
         cb.account_read(
             from_bytes::expr(&callee_address_word.cells[..N_BYTES_ACCOUNT_ADDRESS]),
-            AccountFieldTag::PoseidonCodeHash,
+            AccountFieldTag::CodeHash,
             phase2_callee_code_hash.expr(),
         );
         let is_empty_code_hash = IsEqualGadget::construct(

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -389,7 +389,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
                 cb.account_write(
                     receiver_address.clone(),
                     AccountFieldTag::CodeHash,
-                    cb.empty_poseidon_hash_rlc(),
+                    cb.empty_code_hash_rlc(),
                     0.expr(),
                     Some(reversion_info),
                 );
@@ -519,7 +519,7 @@ impl<F: Field> TransferGadget<F> {
                 cb.account_write(
                     receiver_address.clone(),
                     AccountFieldTag::CodeHash,
-                    cb.empty_poseidon_hash_rlc(),
+                    cb.empty_code_hash_rlc(),
                     0.expr(),
                     Some(reversion_info),
                 );
@@ -698,11 +698,8 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
             AccountFieldTag::CodeHash,
             phase2_callee_code_hash.expr(),
         );
-        let is_empty_code_hash = IsEqualGadget::construct(
-            cb,
-            phase2_callee_code_hash.expr(),
-            cb.empty_poseidon_hash_rlc(),
-        );
+        let is_empty_code_hash =
+            IsEqualGadget::construct(cb, phase2_callee_code_hash.expr(), cb.empty_code_hash_rlc());
         let callee_not_exists = IsZeroGadget::construct(cb, phase2_callee_code_hash.expr());
 
         Self {
@@ -797,7 +794,7 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
             region,
             offset,
             phase2_callee_code_hash,
-            region.empty_poseidon_hash_rlc(),
+            region.empty_code_hash_rlc(),
         )?;
         self.callee_not_exists
             .assign_value(region, offset, phase2_callee_code_hash)?;

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -523,7 +523,7 @@ impl<F: Field> TransferGadget<F> {
                     0.expr(),
                     Some(reversion_info),
                 );
-                // TODO: also write poseidon? codesize seems not need yet
+                // TODO: also write empty keccak code hash? codesize seems not need yet. write a test to verify this.
             },
         );
         // Skip transfer if value == 0

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -523,7 +523,8 @@ impl<F: Field> TransferGadget<F> {
                     0.expr(),
                     Some(reversion_info),
                 );
-                // TODO: also write empty keccak code hash? codesize seems not need yet. write a test to verify this.
+                // TODO: also write empty keccak code hash? codesize seems not need yet. write a
+                // test to verify this.
             },
         );
         // Skip transfer if value == 0

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     util::{build_tx_log_expression, Challenges, Expr},
 };
-use bus_mapping::util::{KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO};
+use bus_mapping::{state_db::EMPTY_CODE_HASH_LE, util::KECCAK_CODE_HASH_ZERO};
 use eth_types::{Field, ToLittleEndian, ToWord};
 use gadgets::util::{and, not};
 use halo2_proofs::{
@@ -469,9 +469,8 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         self.word_rlc(bytes.map(|byte| byte.expr()))
     }
 
-    pub(crate) fn empty_poseidon_hash_rlc(&self) -> Expression<F> {
-        let bytes = POSEIDON_CODE_HASH_ZERO.to_word().to_le_bytes();
-        self.word_rlc(bytes.map(|byte| byte.expr()))
+    pub(crate) fn empty_code_hash_rlc(&self) -> Expression<F> {
+        self.word_rlc((*EMPTY_CODE_HASH_LE).map(|byte| byte.expr()))
     }
 
     // Common

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -354,8 +354,7 @@ impl<F: Field> StateCircuitConfig<F> {
                     Rw::Account { field_tag, .. } => {
                         if committed_value.is_zero_vartime()
                             && value.is_zero_vartime()
-                            && matches!(field_tag, AccountFieldTag::PoseidonCodeHash)
-                        // todo fix this!!!
+                            && matches!(field_tag, AccountFieldTag::CodeHash)
                         {
                             MPTProofType::NonExistingAccountProof as u64
                         } else {

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -317,7 +317,7 @@ fn diff_1_problem_repro() {
             rw_counter: 1,
             is_write: true,
             account_address: Address::default(),
-            field_tag: AccountFieldTag::PoseidonCodeHash,
+            field_tag: AccountFieldTag::CodeHash,
             value: U256::zero(),
             value_prev: U256::zero(),
         },
@@ -325,7 +325,7 @@ fn diff_1_problem_repro() {
             rw_counter: 2,
             is_write: true,
             account_address: Address::default(),
-            field_tag: AccountFieldTag::PoseidonCodeHash,
+            field_tag: AccountFieldTag::CodeHash,
             value: U256::zero(),
             value_prev: U256::zero(),
         },
@@ -431,7 +431,7 @@ fn address_limb_mismatch() {
         rw_counter: 1,
         is_write: false,
         account_address: address!("0x000000000000000000000000000000000cafe002"),
-        field_tag: AccountFieldTag::PoseidonCodeHash,
+        field_tag: AccountFieldTag::CodeHash,
         value: U256::zero(),
         value_prev: U256::zero(),
     }];
@@ -448,7 +448,7 @@ fn address_limb_out_of_range() {
         rw_counter: 1,
         is_write: false,
         account_address: address!("0x0000000000000000000000000000000000010000"),
-        field_tag: AccountFieldTag::PoseidonCodeHash,
+        field_tag: AccountFieldTag::CodeHash,
         value: U256::zero(),
         value_prev: U256::zero(),
     }];
@@ -593,7 +593,7 @@ fn nonlexicographic_order_address() {
         rw_counter: 50,
         is_write: true,
         account_address: address!("0x1000000000000000000000000000000000000000"),
-        field_tag: AccountFieldTag::PoseidonCodeHash,
+        field_tag: AccountFieldTag::CodeHash,
         value: U256::zero(),
         value_prev: U256::zero(),
     };
@@ -601,7 +601,7 @@ fn nonlexicographic_order_address() {
         rw_counter: 30,
         is_write: true,
         account_address: address!("0x2000000000000000000000000000000000000000"),
-        field_tag: AccountFieldTag::PoseidonCodeHash,
+        field_tag: AccountFieldTag::CodeHash,
         value: U256::one(),
         value_prev: U256::zero(),
     };

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -366,8 +366,8 @@ impl From<RwTableTag> for usize {
 #[derive(Clone, Copy, Debug, EnumIter, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccountFieldTag {
     /// Variant representing the poseidon hash of an account's code.
-    PoseidonCodeHash = 0, /* we need this to match to the field tag of AccountStorage, which is
-                           * always 0 */
+    CodeHash = 0, /* we need this to match to the field tag of AccountStorage, which is
+                   * always 0 */
     /// Nonce field
     Nonce,
     /// Balance field
@@ -607,7 +607,7 @@ pub enum MPTProofType {
     /// Keccak Code hash exists
     KeccakCodeHashExists = AccountFieldTag::KeccakCodeHash as isize,
     /// Poseidon Code hash exits
-    PoseidonCodeHashExists = AccountFieldTag::PoseidonCodeHash as isize,
+    PoseidonCodeHashExists = AccountFieldTag::CodeHash as isize,
     /// Code size exists
     CodeSizeExists = AccountFieldTag::CodeSize as isize,
     /// Account does not exist
@@ -625,7 +625,7 @@ impl From<AccountFieldTag> for MPTProofType {
             AccountFieldTag::Nonce => Self::NonceMod,
             AccountFieldTag::Balance => Self::BalanceMod,
             AccountFieldTag::KeccakCodeHash => Self::KeccakCodeHashExists,
-            AccountFieldTag::PoseidonCodeHash => Self::PoseidonCodeHashExists,
+            AccountFieldTag::CodeHash => Self::PoseidonCodeHashExists,
             AccountFieldTag::NonExisting => Self::NonExistingAccountProof,
             AccountFieldTag::CodeSize => Self::CodeSizeExists,
         }

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -227,7 +227,7 @@ impl Key {
         if value_prev.is_zero() && value.is_zero() {
             match self {
                 Key::Account { address, field_tag } => {
-                    if matches!(field_tag, AccountFieldTag::PoseidonCodeHash) {
+                    if matches!(field_tag, AccountFieldTag::CodeHash) {
                         Key::Account {
                             address,
                             field_tag: AccountFieldTag::NonExisting,

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -324,7 +324,7 @@ impl Rw {
         self.account_value_pair_field_tag(AccountFieldTag::Balance)
     }
     pub fn account_codehash_pair(&self) -> (Word, Word) {
-        self.account_value_pair_field_tag(AccountFieldTag::PoseidonCodeHash)
+        self.account_value_pair_field_tag(AccountFieldTag::CodeHash)
     }
     pub fn account_nonce_pair(&self) -> (Word, Word) {
         self.account_value_pair_field_tag(AccountFieldTag::Nonce)
@@ -605,11 +605,7 @@ impl Rw {
             } => match field_tag {
                 AccountFieldTag::KeccakCodeHash
                 | AccountFieldTag::Balance
-                | AccountFieldTag::PoseidonCodeHash => {
-                    rlc::value(&value.to_le_bytes(), randomness)
-                    // TODO: PoseidonCodeHash is already a field element and
-                    // balance cannot, in practice
-                }
+                | AccountFieldTag::CodeHash => rlc::value(&value.to_le_bytes(), randomness),
                 AccountFieldTag::Nonce
                 | AccountFieldTag::NonExisting
                 | AccountFieldTag::CodeSize => value.to_scalar().unwrap(),
@@ -641,9 +637,7 @@ impl Rw {
             } => Some(match field_tag {
                 AccountFieldTag::KeccakCodeHash
                 | AccountFieldTag::Balance
-                | AccountFieldTag::PoseidonCodeHash => {
-                    rlc::value(&value_prev.to_le_bytes(), randomness)
-                }
+                | AccountFieldTag::CodeHash => rlc::value(&value_prev.to_le_bytes(), randomness),
                 AccountFieldTag::Nonce
                 | AccountFieldTag::NonExisting
                 | AccountFieldTag::CodeSize => value_prev.to_scalar().unwrap(),
@@ -746,7 +740,7 @@ impl From<&operation::OperationContainer> for RwMap {
                     field_tag: match op.op().field {
                         AccountField::Nonce => AccountFieldTag::Nonce,
                         AccountField::Balance => AccountFieldTag::Balance,
-                        AccountField::CodeHash => AccountFieldTag::PoseidonCodeHash,
+                        AccountField::CodeHash => AccountFieldTag::CodeHash,
                         AccountField::KeccakCodeHash => AccountFieldTag::KeccakCodeHash,
                         AccountField::CodeSize => AccountFieldTag::CodeSize,
                     },

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -746,8 +746,8 @@ impl From<&operation::OperationContainer> for RwMap {
                     field_tag: match op.op().field {
                         AccountField::Nonce => AccountFieldTag::Nonce,
                         AccountField::Balance => AccountFieldTag::Balance,
+                        AccountField::CodeHash => AccountFieldTag::PoseidonCodeHash,
                         AccountField::KeccakCodeHash => AccountFieldTag::KeccakCodeHash,
-                        AccountField::PoseidonCodeHash => AccountFieldTag::PoseidonCodeHash,
                         AccountField::CodeSize => AccountFieldTag::CodeSize,
                     },
                     value: op.op().value,

--- a/zktrie/src/state.rs
+++ b/zktrie/src/state.rs
@@ -142,8 +142,9 @@ impl ZktrieState {
                     Account {
                         nonce: acc_data.nonce.into(),
                         balance: acc_data.balance,
+                        code_hash: acc_data.poseidon_code_hash,
                         keccak_code_hash: acc_data.keccak_code_hash,
-                        poseidon_code_hash: acc_data.poseidon_code_hash,
+
                         code_size: acc_data.code_size.into(),
                         storage: Default::default(),
                     },

--- a/zktrie/src/state/witness.rs
+++ b/zktrie/src/state/witness.rs
@@ -61,7 +61,7 @@ impl From<&ZktrieState> for WitnessGenerator {
                     AccountData {
                         nonce: acc_data.nonce.as_u64(),
                         balance: acc_data.balance,
-                        poseidon_code_hash: acc_data.poseidon_code_hash,
+                        poseidon_code_hash: acc_data.code_hash,
                         keccak_code_hash: acc_data.keccak_code_hash,
                         code_size: acc_data.code_size.as_u64(),
                         storage_root: H256::from(storage_root),

--- a/zktrie/src/state/witness.rs
+++ b/zktrie/src/state/witness.rs
@@ -3,7 +3,7 @@ use super::{
     builder::{extend_address_to_h256, AccountData, BytesArray, CanRead, TrieProof},
     MPTProofType, ZktrieState,
 };
-use bus_mapping::util::{KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO};
+use bus_mapping::{state_db::CodeDB, util::KECCAK_CODE_HASH_ZERO};
 use eth_types::{Address, Hash, Word, H256, U256};
 use halo2_proofs::halo2curves::group::ff::PrimeField;
 use mpt_circuits::serde::{
@@ -287,7 +287,7 @@ impl WitnessGenerator {
                         old_val.to_big_endian(code_hash.as_mut_slice());
                         if H256::from(code_hash) != acc_data.poseidon_code_hash {
                             if H256::from(code_hash).is_zero()
-                                && acc_data.poseidon_code_hash == *POSEIDON_CODE_HASH_ZERO
+                                && acc_data.poseidon_code_hash == CodeDB::empty_code_hash()
                             {
                                 log::trace!("codehash 0->poseidon(nil)");
                             } else {


### PR DESCRIPTION
Doing this reduces the numbers of lines added and removed by ~100 each so maintaining the dual codehash branch will be easier.

As a general rule, code_hash should be whatever the code database is using as a key for the bytecodes.