### PR TITLE
add invalid creation code circuit

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -58,6 +58,7 @@ mod swap;
 
 mod error_codestore;
 mod error_contract_address_collision;
+mod error_invalid_creation_code;
 mod error_invalid_jump;
 mod error_oog_call;
 mod error_oog_dynamic_memory;
@@ -90,6 +91,7 @@ use create::Create;
 use dup::Dup;
 use error_codestore::ErrorCodeStore;
 use error_contract_address_collision::ContractAddressCollision;
+use error_invalid_creation_code::ErrorCreationCode;
 use error_invalid_jump::InvalidJump;
 use error_oog_call::OOGCall;
 use error_oog_dynamic_memory::OOGDynamicMemory;
@@ -327,6 +329,7 @@ fn fn_gen_error_state_associated_ops(
             _ => unreachable!(),
         },
         ExecError::GasUintOverflow => Some(ErrorSimple::gen_associated_ops),
+        ExecError::InvalidCreationCode => Some(ErrorCreationCode::gen_associated_ops),
         // more future errors place here
         _ => {
             evm_unimplemented!("TODO: error state {:?} not implemented", error);

--- a/bus-mapping/src/evm/opcodes/error_invalid_creation_code.rs
+++ b/bus-mapping/src/evm/opcodes/error_invalid_creation_code.rs
@@ -1,0 +1,66 @@
+use crate::{
+    circuit_input_builder::{CircuitInputStateRef, ExecStep},
+    error::ExecError,
+    evm::Opcode,
+    operation::CallContextField,
+    Error,
+};
+use eth_types::{GethExecStep, U256};
+
+#[derive(Debug, Copy, Clone)]
+pub struct ErrorCreationCode;
+
+impl Opcode for ErrorCreationCode {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        let geth_step = &geth_steps[0];
+        let mut exec_step = state.new_step(geth_step)?;
+
+        exec_step.error = Some(ExecError::InvalidCreationCode);
+
+        let offset = geth_step.stack.nth_last(0)?;
+        let length = geth_step.stack.nth_last(1)?;
+        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), offset)?;
+        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(1), length)?;
+
+        // in create context
+        let call = state.call()?;
+        let call_id = call.call_id;
+        let is_success = call.is_success;
+
+        // create context check
+        assert!(call.is_create());
+
+        assert!(length > U256::zero());
+
+        // read first byte and assert it is 0xef
+        let byte = state.call_ctx()?.memory.0[offset.as_usize()];
+        assert!(byte == 0xef);
+
+        state.memory_read(&mut exec_step, offset.try_into()?, byte)?;
+
+        // common error handling
+        state.call_context_read(
+            &mut exec_step,
+            call_id,
+            CallContextField::IsSuccess,
+            (is_success as u64).into(),
+        );
+
+        state.call_context_read(
+            &mut exec_step,
+            call_id,
+            CallContextField::RwCounterEndOfReversion,
+            0u64.into(),
+        );
+
+        // refer to return_revert Case C
+        state.handle_restore_context(geth_steps, &mut exec_step)?;
+
+        // state.gen_restore_context_ops(&mut exec_step, geth_steps)?;
+        state.handle_return(geth_step)?;
+        Ok(vec![exec_step])
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -78,6 +78,7 @@ mod end_block;
 mod end_inner_block;
 mod end_tx;
 mod error_code_store;
+mod error_invalid_creation_code;
 mod error_invalid_jump;
 mod error_invalid_opcode;
 mod error_oog_call;
@@ -155,6 +156,7 @@ use end_block::EndBlockGadget;
 use end_inner_block::EndInnerBlockGadget;
 use end_tx::EndTxGadget;
 use error_code_store::ErrorCodeStoreGadget;
+use error_invalid_creation_code::ErrorInvalidCreationCodeGadget;
 use error_invalid_jump::ErrorInvalidJumpGadget;
 use error_invalid_opcode::ErrorInvalidOpcodeGadget;
 use error_oog_call::ErrorOOGCallGadget;
@@ -333,8 +335,7 @@ pub(crate) struct ExecutionConfig<F> {
     error_depth: Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorDepth }>>,
     error_contract_address_collision:
         Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorContractAddressCollision }>>,
-    error_invalid_creation_code:
-        Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorInvalidCreationCode }>>,
+    error_invalid_creation_code: Box<ErrorInvalidCreationCodeGadget<F>>,
     error_precompile_failed: Box<ErrorPrecompileFailedGadget<F>>,
     error_return_data_out_of_bound: Box<ErrorReturnDataOutOfBoundGadget<F>>,
     error_gas_uint_overflow: Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorGasUintOverflow }>>,

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
@@ -1,0 +1,250 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        util::{
+            common_gadget::CommonErrorGadget, constraint_builder::ConstraintBuilder,
+            math_gadget::IsEqualGadget, memory_gadget::MemoryAddressGadget, CachedRegion, Cell,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+
+use eth_types::Field;
+use halo2_proofs::{circuit::Value, plonk::Error};
+
+/// Gadget for code store oog and max code size exceed
+#[derive(Clone, Debug)]
+pub(crate) struct ErrorInvalidCreationCodeGadget<F> {
+    opcode: Cell<F>,
+    memory_address: MemoryAddressGadget<F>,
+    first_byte: Cell<F>,
+    is_first_byte_invalid: IsEqualGadget<F>,
+    common_error_gadget: CommonErrorGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for ErrorInvalidCreationCodeGadget<F> {
+    const NAME: &'static str = "ErrorInvalidCreationCode";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ErrorInvalidCreationCode;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let opcode = cb.query_cell();
+        let first_byte = cb.query_cell();
+
+        let offset = cb.query_cell_phase2();
+        let length = cb.query_word_rlc();
+
+        cb.stack_pop(offset.expr());
+        cb.stack_pop(length.expr());
+        cb.require_true("is_create is true", cb.curr.state.is_create.expr());
+
+        let memory_address = MemoryAddressGadget::construct(cb, offset, length);
+        // TODO: lookup memory for first byte
+        cb.memory_lookup(0.expr(), memory_address.offset(), first_byte.expr(), None);
+
+        // constrain first byte is 0xef
+        let is_first_byte_invalid = IsEqualGadget::construct(cb, first_byte.expr(), 0xef.expr());
+
+        cb.require_true(
+            "is_first_byte_invalid is true",
+            is_first_byte_invalid.expr(),
+        );
+
+        let common_error_gadget = CommonErrorGadget::construct_with_lastcallee_return_data(
+            cb,
+            opcode.expr(),
+            5.expr(),
+            memory_address.offset(),
+            memory_address.length(),
+        );
+
+        Self {
+            opcode,
+            first_byte,
+            is_first_byte_invalid,
+            memory_address,
+            common_error_gadget,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _tx: &Transaction,
+        call: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        let opcode = step.opcode.unwrap();
+        self.opcode
+            .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
+
+        let [memory_offset, length] = [0, 1].map(|i| block.rws[step.rw_indices[i]].stack_value());
+        self.memory_address
+            .assign(region, offset, memory_offset, length)?;
+
+        let byte = block.rws[step.rw_indices[2]].memory_value();
+
+        self.first_byte
+            .assign(region, offset, Value::known(F::from(byte as u64)))?;
+        self.is_first_byte_invalid.assign(
+            region,
+            offset,
+            F::from(byte as u64),
+            F::from(0xef_u64),
+        )?;
+
+        self.common_error_gadget
+            .assign(region, offset, block, call, step, 5)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bus_mapping::circuit_input_builder::CircuitsParams;
+    use eth_types::{
+        address, bytecode, evm_types::OpcodeId, geth_types::Account, Address, Bytecode, Word,
+    };
+
+    use lazy_static::lazy_static;
+    use mock::{eth, TestContext, MOCK_ACCOUNTS};
+
+    use crate::test_util::CircuitTestBuilder;
+
+    const CALLEE_ADDRESS: Address = Address::repeat_byte(0xff);
+    lazy_static! {
+        static ref CALLER_ADDRESS: Address = address!("0x00bbccddee000000000000000000000000002400");
+    }
+
+    const MAXCODESIZE: u64 = 0x6000u64;
+
+    fn run_test_circuits(ctx: TestContext<2, 1>) {
+        CircuitTestBuilder::new_from_test_ctx(ctx)
+            .params(CircuitsParams {
+                max_rws: 4500,
+                ..Default::default()
+            })
+            .run();
+    }
+
+    fn initialization_bytecode() -> Bytecode {
+        let memory_bytes = [0xef; 10];
+        let memory_value = Word::from_big_endian(&memory_bytes);
+
+        let mut code = bytecode! {
+            PUSH10(memory_value)
+            PUSH32(0)
+            MSTORE
+            PUSH2( 5 ) // length to copy
+            PUSH2(32u64 - u64::try_from(memory_bytes.len()).unwrap()) // offset
+            //PUSH2(0x00) // offset
+
+        };
+        code.write_op(OpcodeId::RETURN);
+
+        code
+    }
+
+    fn creator_bytecode(initialization_bytecode: Bytecode, is_create2: bool) -> Bytecode {
+        let initialization_bytes = initialization_bytecode.code();
+        let mut code = Bytecode::default();
+
+        // construct maxcodesize + 1 memory bytes
+        let code_creator: Vec<u8> = initialization_bytes
+            .to_vec()
+            .iter()
+            .cloned()
+            .chain(0u8..((32 - initialization_bytes.len() % 32) as u8))
+            .collect();
+        for (index, word) in code_creator.chunks(32).enumerate() {
+            code.push(32, Word::from_big_endian(word));
+            code.push(32, Word::from(index * 32));
+            code.write_op(OpcodeId::MSTORE);
+        }
+
+        if is_create2 {
+            code.append(&bytecode! {PUSH1(45)}); // salt;
+        }
+        code.append(&bytecode! {
+            PUSH32(initialization_bytes.len()) // size
+            PUSH2(0x00) // offset
+            PUSH2(23414) // value
+        });
+        code.write_op(if is_create2 {
+            OpcodeId::CREATE2
+        } else {
+            OpcodeId::CREATE
+        });
+        code.append(&bytecode! {
+            PUSH1(0)
+            PUSH1(0)
+            RETURN
+        });
+
+        code
+    }
+
+    fn test_context(caller: Account) -> TestContext<2, 1> {
+        TestContext::new(
+            None,
+            |accs| {
+                accs[0]
+                    .address(address!("0x000000000000000000000000000000000000cafe"))
+                    .balance(eth(10));
+                accs[1].account(&caller);
+            },
+            |mut txs, accs| {
+                txs[0]
+                    .from(accs[0].address)
+                    .to(accs[1].address)
+                    .gas(103800u64.into());
+            },
+            |block, _| block,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_invalid_creation_code() {
+        for is_create2 in [false, true] {
+            let initialization_code = initialization_bytecode();
+            let root_code = creator_bytecode(initialization_code, is_create2);
+            let caller = Account {
+                address: *CALLER_ADDRESS,
+                code: root_code.into(),
+                nonce: Word::one(),
+                balance: eth(10),
+                ..Default::default()
+            };
+            run_test_circuits(test_context(caller));
+        }
+    }
+
+    // TODO: add tx deploy case for invalid creation code.
+    #[test]
+    fn test_tx_deploy_invalid_creation_code() {
+        let code = initialization_bytecode();
+
+        let ctx = TestContext::<1, 1>::new(
+            None,
+            |accs| {
+                accs[0].address(MOCK_ACCOUNTS[0]).balance(eth(20));
+            },
+            |mut txs, _accs| {
+                txs[0]
+                    .from(MOCK_ACCOUNTS[0])
+                    .gas(53446u64.into())
+                    .value(eth(2))
+                    .input(code.into());
+            },
+            |block, _tx| block.number(0xcafeu64),
+        )
+        .unwrap();
+
+        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
@@ -41,7 +41,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidCreationCodeGadget<F> {
         cb.require_true("is_create is true", cb.curr.state.is_create.expr());
 
         let memory_address = MemoryAddressGadget::construct(cb, offset, length);
-        // TODO: lookup memory for first byte
+        // lookup memory for first byte
         cb.memory_lookup(0.expr(), memory_address.offset(), first_byte.expr(), None);
 
         // constrain first byte is 0xef
@@ -224,7 +224,7 @@ mod test {
         }
     }
 
-    // TODO: add tx deploy case for invalid creation code.
+    // add tx deploy case for invalid creation code.
     #[test]
     fn test_tx_deploy_invalid_creation_code() {
         let code = initialization_bytecode();


### PR DESCRIPTION
### Description

circuit for invalid creation code error in create
### Issue Link

issue #1291 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Rationale

Get first byte of code to store , check it is 0xef

This PR contains:
- buss mapping: at the return opcode in create, get the first byte .
- add circuit & test 
- add tx deploy trace test .
