### PR TITLE
Separate `BlockHash` assignments for scroll and non-scroll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test-light: ## Run light tests
 	@cargo test --release --all --exclude integration-tests --exclude circuit-benchmarks
 
 test-heavy: ## Run heavy tests serially to avoid OOM
-	@cargo test --release --all --exclude integration-tests --exclude circuit-benchmarks serial_ -- --ignored --test-threads 1
+	@cargo test --release --features scroll --all --exclude integration-tests --exclude circuit-benchmarks serial_ # -- --test-threads 1
 
 test: test-light test-heavy ## Run tests for all the workspace members
 

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,13 @@ fmt: ## Check whether the code is formated correctly
 	@cargo check --all-features
 	@cargo fmt --all -- --check
 
-test: ## Run tests for all the workspace members
-	# Run light tests
+test-light: ## Run light tests
 	@cargo test --release --all --exclude integration-tests --exclude circuit-benchmarks
-	# Run heavy tests serially to avoid OOM
+
+test-heavy: ## Run heavy tests serially to avoid OOM
 	@cargo test --release --all --exclude integration-tests --exclude circuit-benchmarks serial_ -- --ignored --test-threads 1
+
+test: test-light test-heavy ## Run tests for all the workspace members
 
 test_doc: ## Test the docs
 	@cargo test --release --all --all-features --doc

--- a/eth-types/src/evm_types.rs
+++ b/eth-types/src/evm_types.rs
@@ -62,7 +62,7 @@ impl fmt::Debug for Gas {
 
 /// This constant ((2^32 - 1) * 32) is the highest number that can be used without overflowing the
 /// square operation of gas calculation.
-/// https://github.com/ethereum/go-ethereum/blob/e6b6a8b738069ad0579f6798ee59fde93ed13b43/core/vm/gas_table.go#L38
+/// <https://github.com/ethereum/go-ethereum/blob/e6b6a8b738069ad0579f6798ee59fde93ed13b43/core/vm/gas_table.go#L38>
 pub const MAX_EXPANDED_MEMORY_ADDRESS: u64 = 0x1FFFFFFFE0;
 /// Quotient for max refund of gas used
 pub const MAX_REFUND_QUOTIENT_OF_GAS_USED: usize = 5;

--- a/mock/src/test_ctx.rs
+++ b/mock/src/test_ctx.rs
@@ -3,7 +3,7 @@
 use crate::{eth, MockAccount, MockBlock, MockTransaction};
 use eth_types::{
     geth_types::{Account, BlockConstants, GethData},
-    Block, Bytecode, Error, GethExecTrace, Transaction, Word,
+    BigEndianHash, Block, Bytecode, Error, GethExecTrace, Transaction, Word, H256,
 };
 use external_tracer::{trace, TraceConfig};
 use helpers::*;
@@ -155,6 +155,11 @@ impl<const NACC: usize, const NTX: usize> TestContext<NACC, NTX> {
 
         // Build Block modifiers
         let mut block = MockBlock::default();
+        let parent_hash = history_hashes
+            .as_ref()
+            .and_then(|hashes| hashes.last().copied())
+            .unwrap_or_default();
+        block.parent_hash(H256::from_uint(&parent_hash));
         block.transactions.extend_from_slice(&transactions);
         func_block(&mut block, transactions).build();
 

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -271,6 +271,7 @@ pub fn run_test(
         gas_limit: trace_config.block_constants.gas_limit,
         base_fee_per_gas: Some(trace_config.block_constants.base_fee),
         transactions,
+        parent_hash: st.env.previous_hash,
         ..eth_types::Block::default()
     };
 

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -138,7 +138,7 @@ use balance::BalanceGadget;
 use begin_tx::BeginTxGadget;
 use bitwise::BitwiseGadget;
 use block_ctx::{BlockCtxU160Gadget, BlockCtxU256Gadget, BlockCtxU64Gadget};
-// use blockhash::BlockHashGadget;
+use blockhash::BlockHashGadget;
 use byte::ByteGadget;
 use calldatacopy::CallDataCopyGadget;
 use calldataload::CallDataLoadGadget;
@@ -306,7 +306,7 @@ pub(crate) struct ExecutionConfig<F> {
     sstore_gadget: Box<SstoreGadget<F>>,
     stop_gadget: Box<StopGadget<F>>,
     swap_gadget: Box<SwapGadget<F>>,
-    blockhash_gadget: Box<DummyGadget<F, 1, 1, { ExecutionState::BLOCKHASH }>>,
+    blockhash_gadget: Box<BlockHashGadget<F>>,
     block_ctx_u64_gadget: Box<BlockCtxU64Gadget<F>>,
     block_ctx_u160_gadget: Box<BlockCtxU160Gadget<F>>,
     block_ctx_u256_gadget: Box<BlockCtxU256Gadget<F>>,

--- a/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
@@ -14,16 +14,12 @@ use crate::{
     },
     table::BlockContextFieldTag,
     util::Expr,
+    witness::NUM_PREV_BLOCK_ALLOWED,
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian, ToScalar};
 use gadgets::util::not;
 use halo2_proofs::{circuit::Value, plonk::Error};
-
-#[cfg(feature = "scroll")]
-const NUM_PREV_BLOCK_ALLOWED: u64 = 2;
-#[cfg(not(feature = "scroll"))]
-const NUM_PREV_BLOCK_ALLOWED: u64 = 257;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BlockHashGadget<F> {
@@ -56,7 +52,7 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
         let diff_lt = LtGadget::construct(
             cb,
             current_block_number.expr(),
-            NUM_PREV_BLOCK_ALLOWED.expr() + block_number.valid_value(),
+            (NUM_PREV_BLOCK_ALLOWED + 1).expr() + block_number.valid_value(),
         );
 
         let is_valid = and::expr([block_number.lt_cap(), diff_lt.expr()]);
@@ -134,7 +130,7 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
             region,
             offset,
             current_block_number,
-            block_number + F::from(NUM_PREV_BLOCK_ALLOWED),
+            block_number + F::from(NUM_PREV_BLOCK_ALLOWED + 1),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1460,16 +1460,9 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_INNER_
 
 #[cfg(test)]
 mod pi_circuit_test {
+
     use super::*;
-    use crate::witness::block_convert;
-    use bus_mapping::mock::BlockData;
-    use eth_types::{bytecode, geth_types::GethData};
-    use halo2_proofs::{
-        dev::{MockProver, VerifyFailure},
-        halo2curves::bn256::Fr,
-    };
-    use mock::{TestContext, MOCK_CHAIN_ID, MOCK_DIFFICULTY};
-    use pretty_assertions::assert_eq;
+    use halo2_proofs::dev::{MockProver, VerifyFailure};
     // use rand_chacha::ChaCha20Rng;
     // use rand::SeedableRng;
 
@@ -1507,9 +1500,21 @@ mod pi_circuit_test {
     //     assert_eq!(run::<Fr, MAX_TXS, MAX_CALLDATA>(k, public_data), Ok(()));
     // }
 
+    #[cfg(feature = "scroll")]
     #[test]
     fn test_simple_pi() {
+        use mock::test_ctx::helpers::tx_from_1_to_0;
         use std::env::set_var;
+
+        use crate::witness::block_convert;
+        use bus_mapping::mock::BlockData;
+        use eth_types::{bytecode, geth_types::GethData};
+        use halo2_proofs::halo2curves::bn256::Fr;
+        use mock::{
+            test_ctx::helpers::account_0_code_account_1_no_code, TestContext, MOCK_CHAIN_ID,
+            MOCK_DIFFICULTY,
+        };
+        use pretty_assertions::assert_eq;
 
         const MAX_TXS: usize = 4;
         const MAX_CALLDATA: usize = 20;
@@ -1522,9 +1527,15 @@ mod pi_circuit_test {
         set_var("CHAIN_ID", hex::encode(chain_id_be_bytes));
         set_var("DIFFICULTY", hex::encode(difficulty_be_bytes));
 
-        let test_ctx = TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode! {
+        let bytecode = bytecode! {
             STOP
-        })
+        };
+        let test_ctx = TestContext::<2, 1>::new(
+            Some(vec![Word::zero()]),
+            account_0_code_account_1_no_code(bytecode),
+            tx_from_1_to_0,
+            |block, _txs| block.number(0xcafeu64),
+        )
         .unwrap();
         let block: GethData = test_ctx.into();
         let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1502,7 +1502,7 @@ mod pi_circuit_test {
 
     #[cfg(feature = "scroll")]
     #[test]
-    fn test_simple_pi() {
+    fn serial_test_simple_pi() {
         use mock::test_ctx::helpers::tx_from_1_to_0;
         use std::env::set_var;
 

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -39,7 +39,6 @@ use crate::table::BlockContextFieldTag::{
     Timestamp,
 };
 use gadgets::binary_number::{BinaryNumberChip, BinaryNumberConfig};
-use halo2_proofs::circuit::{Cell, RegionIndex};
 #[cfg(any(feature = "test", test, feature = "test-circuits"))]
 use halo2_proofs::{circuit::SimpleFloorPlanner, plonk::Circuit};
 use itertools::Itertools;
@@ -898,6 +897,7 @@ impl<F: Field> PiCircuitConfig<F> {
         }
         #[cfg(feature = "reject-eip2718")]
         for (i, tx_hash_cell) in tx_copy_cells.into_iter().enumerate() {
+            use halo2_proofs::circuit::{Cell, RegionIndex};
             region.constrain_equal(
                 tx_hash_cell.cell(),
                 Cell {
@@ -1507,7 +1507,6 @@ mod pi_circuit_test {
     //     assert_eq!(run::<Fr, MAX_TXS, MAX_CALLDATA>(k, public_data), Ok(()));
     // }
 
-    #[cfg(feature = "scroll")]
     #[test]
     fn test_simple_pi() {
         use std::env::set_var;

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1507,6 +1507,7 @@ mod pi_circuit_test {
     //     assert_eq!(run::<Fr, MAX_TXS, MAX_CALLDATA>(k, public_data), Ok(()));
     // }
 
+    #[cfg(feature = "scroll")]
     #[test]
     fn test_simple_pi() {
         use std::env::set_var;

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -611,6 +611,7 @@ impl<
     ) -> Result<(u32, Self, Vec<Vec<F>>, CircuitInputBuilder), bus_mapping::Error> {
         let block_data =
             BlockData::new_from_geth_data_with_params(geth_data.clone(), circuits_params);
+
         let mut builder = block_data.new_circuit_input_builder();
         builder
             .handle_block(&geth_data.eth_block, &geth_data.geth_traces)
@@ -740,7 +741,7 @@ pub(crate) mod super_circuit_tests {
 
         let tx_input = callee_bytecode(true, 300, 20).code();
         let mut block: GethData = TestContext::<2, 1>::new(
-            None,
+            Some(vec![Word::zero()]),
             |accs| {
                 accs[0].address(addr_a).balance(eth(10));
             },
@@ -774,7 +775,7 @@ pub(crate) mod super_circuit_tests {
         wallets.insert(wallet_a.address(), wallet_a);
 
         let mut block: GethData = TestContext::<2, 1>::new(
-            None,
+            Some(vec![Word::zero()]),
             |accs| {
                 accs[0]
                     .address(addr_b)
@@ -815,7 +816,7 @@ pub(crate) mod super_circuit_tests {
         wallets.insert(wallet_a.address(), wallet_a);
 
         let mut block: GethData = TestContext::<2, 2>::new(
-            None,
+            Some(vec![Word::zero()]),
             |accs| {
                 accs[0]
                     .address(addr_b)

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -846,7 +846,7 @@ pub(crate) mod super_circuit_tests {
 
     // High memory usage test.  Run in serial with:
     // `cargo test [...] serial_ -- --ignored --test-threads 1`
-    #[ignore]
+    #[cfg(feature = "scroll")]
     #[test]
     fn serial_test_super_circuit_1tx_1max_tx() {
         let block = block_1tx();
@@ -869,7 +869,7 @@ pub(crate) mod super_circuit_tests {
             circuits_params,
         );
     }
-    #[ignore]
+    #[cfg(feature = "scroll")]
     #[test]
     fn serial_test_super_circuit_1tx_deploy_2max_tx() {
         let block = block_1tx_deploy();
@@ -895,7 +895,7 @@ pub(crate) mod super_circuit_tests {
         );
     }
 
-    #[ignore]
+    #[cfg(feature = "scroll")]
     #[test]
     fn serial_test_super_circuit_1tx_2max_tx() {
         let block = block_1tx();
@@ -918,7 +918,7 @@ pub(crate) mod super_circuit_tests {
             circuits_params,
         );
     }
-    #[ignore]
+    #[cfg(feature = "scroll")]
     #[test]
     fn serial_test_super_circuit_2tx_4max_tx() {
         let block = block_2tx();
@@ -943,7 +943,7 @@ pub(crate) mod super_circuit_tests {
             circuits_params,
         );
     }
-    #[ignore]
+    #[cfg(feature = "scroll")]
     #[test]
     fn serial_test_super_circuit_2tx_2max_tx() {
         let block = block_2tx();

--- a/zkevm-circuits/src/witness.rs
+++ b/zkevm-circuits/src/witness.rs
@@ -3,7 +3,10 @@
 //! used to generate witnesses for circuits.
 
 mod block;
-pub use block::{block_apply_mpt_state, block_convert, Block, BlockContext, BlockContexts};
+pub use block::{
+    block_apply_mpt_state, block_convert, Block, BlockContext, BlockContexts,
+    NUM_PREV_BLOCK_ALLOWED,
+};
 mod bytecode;
 pub use bytecode::Bytecode;
 mod call;

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -20,8 +20,10 @@ use super::{
 };
 use crate::util::{Challenges, DEFAULT_RAND};
 
+/// max range of prev blocks allowed inside BLOCKHASH opcode
 #[cfg(feature = "scroll")]
 pub const NUM_PREV_BLOCK_ALLOWED: u64 = 1;
+/// max range of prev blocks allowed inside BLOCKHASH opcode
 #[cfg(not(feature = "scroll"))]
 pub const NUM_PREV_BLOCK_ALLOWED: u64 = 256;
 
@@ -263,14 +265,13 @@ impl BlockContext {
         .concat()
     }
 
-    #[cfg(not(feature = "scroll"))]
     fn block_hash_assignments<F: Field>(&self, randomness: Value<F>) -> Vec<[Value<F>; 3]> {
         use eth_types::ToWord;
 
         let len_history = std::cmp::min(self.history_hashes.len(), NUM_PREV_BLOCK_ALLOWED as usize);
         let history_hashes = &self.history_hashes[0..len_history];
 
-        self.history_hashes
+        history_hashes
             .iter()
             .enumerate()
             .map(|(idx, hash)| {

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -204,6 +204,62 @@ impl BlockContext {
     ) -> Vec<[Value<F>; 3]> {
         let current_block_number = self.number.to_scalar().unwrap();
         let randomness = challenges.evm_word();
+        [
+            vec![
+                [
+                    Value::known(F::from(BlockContextFieldTag::Coinbase as u64)),
+                    Value::known(current_block_number),
+                    Value::known(self.coinbase.to_scalar().unwrap()),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::Timestamp as u64)),
+                    Value::known(current_block_number),
+                    Value::known(self.timestamp.to_scalar().unwrap()),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::Number as u64)),
+                    Value::known(current_block_number),
+                    Value::known(current_block_number),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::Difficulty as u64)),
+                    Value::known(current_block_number),
+                    randomness.map(|rand| rlc::value(&self.difficulty.to_le_bytes(), rand)),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::GasLimit as u64)),
+                    Value::known(current_block_number),
+                    Value::known(F::from(self.gas_limit)),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::BaseFee as u64)),
+                    Value::known(current_block_number),
+                    randomness
+                        .map(|randomness| rlc::value(&self.base_fee.to_le_bytes(), randomness)),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::ChainId as u64)),
+                    Value::known(current_block_number),
+                    randomness.map(|rand| rlc::value(&self.chain_id.to_le_bytes(), rand)),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::NumTxs as u64)),
+                    Value::known(current_block_number),
+                    Value::known(F::from(num_txs as u64)),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::CumNumTxs as u64)),
+                    Value::known(current_block_number),
+                    Value::known(F::from(cum_num_txs as u64)),
+                ],
+            ],
+            self.block_hash_assignments(randomness),
+        ]
+        .concat()
+    }
+
+    #[cfg(feature = "scroll")]
+    fn block_hash_assignments<F: Field>(&self, randomness: Value<F>) -> Vec<[Value<F>; 3]> {
         let parent_block_num = if self.number.as_u64() < 1 {
             0
         } else {
@@ -216,59 +272,33 @@ impl BlockContext {
                 .into_iter()
                 .fold(F::zero(), |acc, byte| acc * rand + F::from(byte as u64))
         });
-        [vec![
-            [
-                Value::known(F::from(BlockContextFieldTag::Coinbase as u64)),
-                Value::known(current_block_number),
-                Value::known(self.coinbase.to_scalar().unwrap()),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::Timestamp as u64)),
-                Value::known(current_block_number),
-                Value::known(self.timestamp.to_scalar().unwrap()),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::Number as u64)),
-                Value::known(current_block_number),
-                Value::known(current_block_number),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::Difficulty as u64)),
-                Value::known(current_block_number),
-                randomness.map(|rand| rlc::value(&self.difficulty.to_le_bytes(), rand)),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::GasLimit as u64)),
-                Value::known(current_block_number),
-                Value::known(F::from(self.gas_limit)),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::BaseFee as u64)),
-                Value::known(current_block_number),
-                randomness.map(|randomness| rlc::value(&self.base_fee.to_le_bytes(), randomness)),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::ChainId as u64)),
-                Value::known(current_block_number),
-                randomness.map(|rand| rlc::value(&self.chain_id.to_le_bytes(), rand)),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::NumTxs as u64)),
-                Value::known(current_block_number),
-                Value::known(F::from(num_txs as u64)),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::CumNumTxs as u64)),
-                Value::known(current_block_number),
-                Value::known(F::from(cum_num_txs as u64)),
-            ],
-            [
-                Value::known(F::from(BlockContextFieldTag::BlockHash as u64)),
-                Value::known(parent_block_num.to_scalar().unwrap()),
-                parent_hash_rlc,
-            ],
+        vec![[
+            Value::known(F::from(BlockContextFieldTag::BlockHash as u64)),
+            Value::known(parent_block_num.to_scalar().unwrap()),
+            parent_hash_rlc,
         ]]
-        .concat()
+    }
+
+    #[cfg(not(feature = "scroll"))]
+    fn block_hash_assignments<F: Field>(&self, randomness: Value<F>) -> Vec<[Value<F>; 3]> {
+        let len_history = self.history_hashes.len();
+        self.history_hashes
+            .iter()
+            .enumerate()
+            .map(|(idx, hash)| {
+                [
+                    Value::known(F::from(BlockContextFieldTag::BlockHash as u64)),
+                    Value::known(
+                        self.number
+                            .checked_sub((len_history - idx).into())
+                            .unwrap_or_default()
+                            .to_scalar()
+                            .unwrap(),
+                    ),
+                    randomness.map(|randomness| rlc::value(&hash.to_le_bytes(), randomness)),
+                ]
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
### Description

1. Enable `BlockHashGadget`.

2. Separate `BlockHash` assignments to function `block_hash_assignments`. It is guarded with feature for scroll and non-scroll. Reference [this upstream code](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/witness/block.rs#L201) for non-scroll.

3. Restrict test case `test_simple_pi` with feature scroll.

### Issue Link

Close https://github.com/scroll-tech/zkevm-circuits/issues/415

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)