### PR TITLE
[Fix] Witness generator in zktrie touch non-existed address unexpectly

### DIFF
--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -72,7 +72,7 @@ impl MptUpdates {
         self.proof_types = Vec::new();
 
         for (key, update) in &mut self.updates {
-            log::trace!("apply update {:?} {:?}", key, update);
+            log::trace!("apply update {:?} {:#?}", key, update);
             let proof_tip = state::as_proof_type(update.proof_type() as i32);
             let smt_trace = wit_gen.handle_new_state(
                 proof_tip,
@@ -111,6 +111,7 @@ impl MptUpdates {
                 root_pair2.0,
                 root_pair2.1
             );
+            wit_gen.dump();
         }
     }
 

--- a/zktrie/src/state/builder.rs
+++ b/zktrie/src/state/builder.rs
@@ -6,6 +6,7 @@ use std::{
     io::{Error, ErrorKind, Read},
 };
 
+use bus_mapping::util::{KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO};
 use halo2_proofs::{
     arithmetic::FieldExt,
     halo2curves::{bn256::Fr, group::ff::PrimeField},
@@ -59,7 +60,7 @@ const NODE_TYPE_MIDDLE: u8 = 0;
 const NODE_TYPE_LEAF: u8 = 1;
 const NODE_TYPE_EMPTY: u8 = 2;
 
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub(crate) struct AccountData {
     pub nonce: u64,
     pub balance: U256,
@@ -80,6 +81,19 @@ pub(crate) trait CanRead: Sized {
     fn parse_leaf(data: &[u8]) -> Result<Self, Error> {
         // notice the first 33 bytes has been read external
         Self::try_parse(&data[33..])
+    }
+}
+
+impl Default for AccountData {
+    fn default() -> Self {
+        Self {
+            nonce: 0,
+            balance: Default::default(),
+            code_size: 0,
+            storage_root: Default::default(),
+            keccak_code_hash: *KECCAK_CODE_HASH_ZERO,
+            poseidon_code_hash: *POSEIDON_CODE_HASH_ZERO,
+        }
     }
 }
 

--- a/zktrie/src/state/witness.rs
+++ b/zktrie/src/state/witness.rs
@@ -56,8 +56,14 @@ impl From<&ZktrieState> for WitnessGenerator {
                     existed,
                     "expected to be consistented between records in sdb and account root"
                 );
+                (*addr, acc_data, storage_root)
+            })
+            // filter out the account data which is empty can provide update applying some
+            // convenient
+            .filter(|(_, acc_data, _)| !acc_data.is_empty())
+            .map(|(addr, acc_data, storage_root)| {
                 (
-                    *addr,
+                    addr,
                     AccountData {
                         nonce: acc_data.nonce.as_u64(),
                         balance: acc_data.balance,
@@ -74,7 +80,10 @@ impl From<&ZktrieState> for WitnessGenerator {
             .accounts
             .iter()
             .map(|(addr, storage_root)| (*addr, state.zk_db.borrow_mut().new_trie(storage_root)))
-            .filter(|(_, storage_root)| storage_root.is_some())
+            .filter(|(addr, storage_root)| {
+                log::warn!("can not create zktrie for storage in account {addr:?}");
+                storage_root.is_some()
+            })
             .map(|(addr, storage_root)| (addr, storage_root.expect("None has been filtered")))
             .collect();
 
@@ -213,10 +222,11 @@ impl WitnessGenerator {
                 log::warn!("invalid update {:?}", rs);
             }
             self.accounts.insert(address, account_data_after);
-        } else {
+        } else if account_data_before.is_some() {
+            log::warn!("trace update try delete account {address:?} trie while we have no SELFDESTRUCT yet");
             self.trie.delete(address.as_bytes());
             self.accounts.remove(&address);
-        }
+        } // no touch for non-exist proof
 
         let proofs = self.trie.prove(address.as_bytes()).unwrap();
         let account_path_after = decode_proof_for_mpt_path(address_key, proofs).unwrap();
@@ -311,7 +321,22 @@ impl WitnessGenerator {
                         );
                         acc_data.code_size = new_val.as_u64();
                     }
-                    MPTProofType::AccountDoesNotExist => (),
+                    MPTProofType::AccountDoesNotExist => {
+                        // for proof NotExist, the account_before must be empty
+                        assert!(
+                            acc_data.balance.is_zero(),
+                            "not-exist proof on existed account balance: {address}"
+                        );
+                        assert_eq!(
+                            0, acc_data.nonce,
+                            "not-exist proof on existed account nonce: {address}"
+                        );
+                        assert!(
+                            acc_data.storage_root.is_zero(),
+                            "not-exist proof on existed account storage: {address}"
+                        );
+                        return None;
+                    }
                     _ => unreachable!("invalid proof type: {:?}", proof_type),
                 }
                 Some(acc_data)

--- a/zktrie/src/state/witness.rs
+++ b/zktrie/src/state/witness.rs
@@ -80,10 +80,9 @@ impl From<&ZktrieState> for WitnessGenerator {
             .accounts
             .iter()
             .map(|(addr, storage_root)| (*addr, state.zk_db.borrow_mut().new_trie(storage_root)))
-            .filter(|(addr, storage_root)| {
-                log::warn!("can not create zktrie for storage in account {addr:?}");
-                storage_root.is_some()
-            })
+            // if an account has no storage slot being touched in execution, they do not need
+            // storage trie and would be filter out here
+            .filter(|(addr, storage_root)| storage_root.is_some())
             .map(|(addr, storage_root)| (addr, storage_root.expect("None has been filtered")))
             .collect();
 

--- a/zktrie/src/state/witness.rs
+++ b/zktrie/src/state/witness.rs
@@ -82,7 +82,7 @@ impl From<&ZktrieState> for WitnessGenerator {
             .map(|(addr, storage_root)| (*addr, state.zk_db.borrow_mut().new_trie(storage_root)))
             // if an account has no storage slot being touched in execution, they do not need
             // storage trie and would be filter out here
-            .filter(|(addr, storage_root)| storage_root.is_some())
+            .filter(|(_, storage_root)| storage_root.is_some())
             .map(|(addr, storage_root)| (addr, storage_root.expect("None has been filtered")))
             .collect();
 


### PR DESCRIPTION
This PR fixed an issue when witness generator in zktrie handle an 'non-existed' proof, it touch (created) the account unexectedly.