### PR TITLE
Salt field popped from stack should be RLC with EVM word input

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -100,7 +100,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         cb.stack_pop(init_code.offset_rlc());
         cb.stack_pop(init_code.length_rlc());
         cb.condition(IS_CREATE2.expr(), |cb| {
-            cb.stack_pop(create.salt_keccak_rlc());
+            cb.stack_pop(create.salt_word_rlc(cb));
         });
 
         cb.stack_push(callee_is_success.expr() * new_address_rlc);

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -607,7 +607,7 @@ mod test {
             bytecode.write_op(OpcodeId::MSTORE);
         }
         bytecode.append(&bytecode! {
-            PUSH3(0x12) // salt
+            PUSH3(0x123456) // salt
             PUSH1(initializer.len()) // length
             PUSH1(0) // offset
             PUSH1(0) // value

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -191,7 +191,7 @@ pub struct ContractCreateGadget<F, const IS_CREATE2: bool> {
     /// appropriate RLC wherever needed.
     code_hash: [Cell<F>; N_BYTES_WORD],
     /// Random salt for CREATE2.
-    salt: RandomLinearCombination<F, N_BYTES_WORD>,
+    salt: [Cell<F>; N_BYTES_WORD],
 }
 
 impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
@@ -200,7 +200,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         let caller_address = cb.query_keccak_rlc();
         let nonce = RlpU64Gadget::construct(cb);
         let code_hash = array_init::array_init(|_| cb.query_byte());
-        let salt = cb.query_keccak_rlc();
+        let salt = array_init::array_init(|_| cb.query_byte());
 
         Self {
             caller_address,
@@ -227,15 +227,17 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
 
         self.nonce.assign(region, offset, caller_nonce)?;
 
-        self.salt.assign(
-            region,
-            offset,
-            Some(salt.map(|v| v.to_le_bytes()).unwrap_or_default()),
-        )?;
         for (c, v) in self
             .code_hash
             .iter()
             .zip(code_hash.map(|v| v.to_le_bytes()).unwrap_or_default())
+        {
+            c.assign(region, offset, Value::known(F::from(v as u64)))?;
+        }
+        for (c, v) in self
+            .salt
+            .iter()
+            .zip(salt.map(|v| v.to_le_bytes()).unwrap_or_default())
         {
             c.assign(region, offset, Value::known(F::from(v as u64)))?;
         }
@@ -277,9 +279,28 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         )
     }
 
+    /// Salt EVM word RLC.
+    pub(crate) fn salt_word_rlc(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
+        cb.word_rlc::<N_BYTES_WORD>(
+            self.salt
+                .iter()
+                .map(Expr::expr)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        )
+    }
+
     /// Salt keccak RLC.
-    pub(crate) fn salt_keccak_rlc(&self) -> Expression<F> {
-        self.salt.expr()
+    pub(crate) fn salt_keccak_rlc(&self, cb: &ConstraintBuilder<F>) -> Expression<F> {
+        cb.keccak_rlc::<N_BYTES_WORD>(
+            self.salt
+                .iter()
+                .map(Expr::expr)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        )
     }
 
     /// Caller address' RLC value.
@@ -323,7 +344,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
             let challenge_power_84 = challenge_power_64.clone() * challenge_power_20;
             (0xff.expr() * challenge_power_84)
                 + (self.caller_address_rlc() * challenge_power_64)
-                + (self.salt_keccak_rlc() * challenge_power_32)
+                + (self.salt_keccak_rlc(cb) * challenge_power_32)
                 + self.code_hash_keccak_rlc(cb)
         } else {
             // RLC(RLP([caller_address, caller_nonce]))


### PR DESCRIPTION
### Description

`salt` field that is popped from stack, was incorrectly RLC'd with keccak input (instead of EVM word input).

### Issue Link

Part 1 of:
https://github.com/scroll-tech/zkevm-circuits/issues/440

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
