### PR TITLE
Implement circuit for `ErrorGasUintOverflow` state

### DIFF
--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     circuit_input_builder::access::gen_state_access_trace,
-    error::{ExecError, InsufficientBalanceError},
+    error::{ExecError, InsufficientBalanceError, OogError},
     geth_errors::{
         GETH_ERR_GAS_UINT_OVERFLOW, GETH_ERR_OUT_OF_GAS, GETH_ERR_STACK_OVERFLOW,
         GETH_ERR_STACK_UNDERFLOW,
@@ -1411,7 +1411,7 @@ fn tracer_err_gas_uint_overflow() {
     let mut builder = CircuitInputBuilderTx::new(&block, step);
     assert_eq!(
         builder.state_ref().get_step_err(step, next_step).unwrap(),
-        Some(ExecError::GasUintOverflow)
+        Some(ExecError::OutOfGas(OogError::StaticMemoryExpansion))
     );
 }
 

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -143,17 +143,12 @@ pub enum ExecError {
     /// For CALL, CALLCODE, DELEGATECALL, STATICCALL
     PrecompileFailed,
     /// ..
-    GasUintOverflow,
-    /// ..
     NonceUintOverflow,
 }
 
 // TODO: Move to impl block.
 pub(crate) fn get_step_reported_error(op: &OpcodeId, error: &str) -> ExecError {
-    if error == GETH_ERR_GAS_UINT_OVERFLOW {
-        return ExecError::GasUintOverflow;
-    }
-    if error == GETH_ERR_OUT_OF_GAS {
+    if [GETH_ERR_OUT_OF_GAS, GETH_ERR_GAS_UINT_OVERFLOW].contains(&error) {
         // NOTE: We report a GasUintOverflow error as an OutOfGas error
         let oog_err = match op {
             OpcodeId::MLOAD | OpcodeId::MSTORE | OpcodeId::MSTORE8 => {

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -337,7 +337,6 @@ fn fn_gen_error_state_associated_ops(
             OpcodeId::CREATE2 => Some(StackOnlyOpcode::<4, 1>::gen_associated_ops),
             _ => unreachable!(),
         },
-        ExecError::GasUintOverflow => Some(StackOnlyOpcode::<0, 0, true>::gen_associated_ops),
         ExecError::InvalidCreationCode => Some(ErrorCreationCode::gen_associated_ops),
         // more future errors place here
         _ => {

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -15,6 +15,9 @@ pub(crate) use block::MockBlock;
 pub use test_ctx::TestContext;
 pub use transaction::{AddrOrWallet, MockTransaction, CORRECT_MOCK_TXS};
 
+/// Mock block gas limit
+pub const MOCK_BLOCK_GAS_LIMIT: u64 = 10_000_000_000_000_000;
+
 lazy_static! {
     /// Mock 1 ETH
     pub static ref MOCK_1_ETH: Word = eth(1);

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -340,7 +340,6 @@ pub(crate) struct ExecutionConfig<F> {
     error_invalid_creation_code: Box<ErrorInvalidCreationCodeGadget<F>>,
     error_precompile_failed: Box<ErrorPrecompileFailedGadget<F>>,
     error_return_data_out_of_bound: Box<ErrorReturnDataOutOfBoundGadget<F>>,
-    error_gas_uint_overflow: Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorGasUintOverflow }>>,
 }
 
 impl<F: Field> ExecutionConfig<F> {
@@ -603,7 +602,6 @@ impl<F: Field> ExecutionConfig<F> {
             error_invalid_creation_code: configure_gadget!(),
             error_return_data_out_of_bound: configure_gadget!(),
             error_precompile_failed: configure_gadget!(),
-            error_gas_uint_overflow: configure_gadget!(),
             // step and presets
             step: step_curr,
             height_map,
@@ -1447,9 +1445,6 @@ impl<F: Field> ExecutionConfig<F> {
             }
             ExecutionState::ErrorPrecompileFailed => {
                 assign_exec_step!(self.error_precompile_failed)
-            }
-            ExecutionState::ErrorGasUintOverflow => {
-                assign_exec_step!(self.error_gas_uint_overflow)
             }
         }
 

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -9,7 +9,10 @@ use crate::{
                 ConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
-            memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryAddressGadget, MemoryCopierGasGadget,
+                MemoryExpansionGadget,
+            },
             not, select, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -13,6 +13,7 @@ use crate::{
             math_gadget::{
                 ConstantDivisionGadget, IsZeroGadget, LtGadget, LtWordGadget, MinMaxGadget,
             },
+            memory_gadget::{CommonMemoryAddressGadget, MemoryAddressGadget},
             not, or, select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
@@ -43,7 +44,7 @@ pub(crate) struct CallOpGadget<F> {
     current_caller_address: Cell<F>,
     is_static: Cell<F>,
     depth: Cell<F>,
-    call: CommonCallGadget<F, true>,
+    call: CommonCallGadget<F, MemoryAddressGadget<F>, true>,
     current_value: Word<F>,
     is_warm: Cell<F>,
     is_warm_prev: Cell<F>,
@@ -99,13 +100,14 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             )
         });
 
-        let call_gadget = CommonCallGadget::construct(
-            cb,
-            is_call.expr(),
-            is_callcode.expr(),
-            is_delegatecall.expr(),
-            is_staticcall.expr(),
-        );
+        let call_gadget: CommonCallGadget<F, MemoryAddressGadget<F>, true> =
+            CommonCallGadget::construct(
+                cb,
+                is_call.expr(),
+                is_callcode.expr(),
+                is_delegatecall.expr(),
+                is_staticcall.expr(),
+            );
         cb.condition(not::expr(is_call.expr() + is_callcode.expr()), |cb| {
             cb.require_zero(
                 "for non call/call code, value is zero",

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -9,7 +9,10 @@ use crate::{
         util::{
             common_gadget::{SameContextGadget, WordByteCapGadget},
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition},
-            memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryAddressGadget, MemoryCopierGasGadget,
+                MemoryExpansionGadget,
+            },
             not, select, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -15,7 +15,9 @@ use crate::{
             math_gadget::{
                 ConstantDivisionGadget, ContractCreateGadget, IsZeroGadget, LtWordGadget,
             },
-            memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget},
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryAddressGadget, MemoryExpansionGadget,
+            },
             not, select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/execution/error_code_store.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_code_store.rs
@@ -4,8 +4,11 @@ use crate::{
         param::{N_BYTES_GAS, N_BYTES_U64},
         step::ExecutionState,
         util::{
-            common_gadget::CommonErrorGadget, constraint_builder::ConstraintBuilder,
-            math_gadget::LtGadget, memory_gadget::MemoryAddressGadget, CachedRegion, Cell,
+            common_gadget::CommonErrorGadget,
+            constraint_builder::ConstraintBuilder,
+            math_gadget::LtGadget,
+            memory_gadget::{CommonMemoryAddressGadget, MemoryAddressGadget},
+            CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
@@ -3,8 +3,11 @@ use crate::{
         execution::ExecutionGadget,
         step::ExecutionState,
         util::{
-            common_gadget::CommonErrorGadget, constraint_builder::ConstraintBuilder,
-            math_gadget::IsEqualGadget, memory_gadget::MemoryAddressGadget, CachedRegion, Cell,
+            common_gadget::CommonErrorGadget,
+            constraint_builder::ConstraintBuilder,
+            math_gadget::IsEqualGadget,
+            memory_gadget::{CommonMemoryAddressGadget, MemoryAddressGadget},
+            CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -7,7 +7,8 @@ use crate::{
             common_gadget::{CommonCallGadget, CommonErrorGadget},
             constraint_builder::ConstraintBuilder,
             math_gadget::{IsZeroGadget, LtGadget},
-            CachedRegion, Cell,
+            memory_gadget::MemoryExpandedAddressGadget,
+            or, CachedRegion, Cell,
         },
     },
     table::CallContextFieldTag,
@@ -30,8 +31,8 @@ pub(crate) struct ErrorOOGCallGadget<F> {
     is_staticcall: IsZeroGadget<F>,
     tx_id: Cell<F>,
     is_static: Cell<F>,
-    call: CommonCallGadget<F, false>,
     is_warm: Cell<F>,
+    call: CommonCallGadget<F, MemoryExpandedAddressGadget<F>, false>,
     insufficient_gas: LtGadget<F, N_BYTES_GAS>,
     common_error_gadget: CommonErrorGadget<F>,
 }
@@ -54,13 +55,14 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let is_static = cb.call_context(None, CallContextFieldTag::IsStatic);
 
-        let call_gadget = CommonCallGadget::construct(
-            cb,
-            is_call.expr(),
-            is_callcode.expr(),
-            is_delegatecall.expr(),
-            is_staticcall.expr(),
-        );
+        let call_gadget: CommonCallGadget<F, MemoryExpandedAddressGadget<F>, false> =
+            CommonCallGadget::construct(
+                cb,
+                is_call.expr(),
+                is_callcode.expr(),
+                is_delegatecall.expr(),
+                is_staticcall.expr(),
+            );
 
         // Add callee to access list
         let is_warm = cb.query_bool();
@@ -82,9 +84,14 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
 
         // Check if the amount of gas available is less than the amount of gas required
         let insufficient_gas = LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);
+
         cb.require_equal(
-            "gas left is less than gas required",
-            insufficient_gas.expr(),
+            "Either Memory address is overflow or gas left is less than cost",
+            or::expr([
+                call_gadget.cd_address.overflow(),
+                call_gadget.rd_address.overflow(),
+                insufficient_gas.expr(),
+            ]),
             1.expr(),
         );
 
@@ -104,8 +111,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             is_staticcall,
             tx_id,
             is_static,
-            call: call_gadget,
             is_warm,
+            call: call_gadget,
             insufficient_gas,
             common_error_gadget,
         }
@@ -400,5 +407,47 @@ mod test {
             STOP
         });
         test_oog(&caller(OpcodeId::CALL, stack), &callee, true);
+    }
+
+    #[test]
+    fn test_oog_call_max_expanded_address() {
+        // 0xffffffff1 + 0xffffffff0 = 0x1fffffffe1
+        // > MAX_EXPANDED_MEMORY_ADDRESS (0x1fffffffe0)
+        let stack = Stack {
+            gas: Word::MAX,
+            cd_offset: 0xffffffff1,
+            cd_length: 0xffffffff0,
+            rd_offset: 0xffffffff1,
+            rd_length: 0xffffffff0,
+            ..Default::default()
+        };
+        let callee = callee(bytecode! {
+            PUSH32(Word::from(0))
+            PUSH32(Word::from(0))
+            STOP
+        });
+        for opcode in TEST_CALL_OPCODES {
+            test_oog(&caller(*opcode, stack), &callee, true);
+        }
+    }
+
+    #[test]
+    fn test_oog_call_max_u64_address() {
+        let stack = Stack {
+            gas: Word::MAX,
+            cd_offset: u64::MAX,
+            cd_length: u64::MAX,
+            rd_offset: u64::MAX,
+            rd_length: u64::MAX,
+            ..Default::default()
+        };
+        let callee = callee(bytecode! {
+            PUSH32(Word::from(0))
+            PUSH32(Word::from(0))
+            STOP
+        });
+        for opcode in TEST_CALL_OPCODES {
+            test_oog(&caller(*opcode, stack), &callee, true);
+        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
@@ -7,8 +7,10 @@ use crate::{
             common_gadget::CommonErrorGadget,
             constraint_builder::ConstraintBuilder,
             math_gadget::LtGadget,
-            memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget},
-            CachedRegion, Cell,
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryExpandedAddressGadget, MemoryExpansionGadget,
+            },
+            or, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -25,7 +27,7 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 pub(crate) struct ErrorOOGLogGadget<F> {
     opcode: Cell<F>,
     // memory address
-    memory_address: MemoryAddressGadget<F>,
+    memory_address: MemoryExpandedAddressGadget<F>,
     is_static_call: Cell<F>,
     is_opcode_logn: LtGadget<F, 1>,
     // constrain gas left is less than gas cost
@@ -41,12 +43,12 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
-        let mstart = cb.query_cell_phase2();
-        let msize = cb.query_word_rlc();
+
+        let memory_address = MemoryExpandedAddressGadget::construct_self(cb);
 
         // Pop mstart_address, msize from stack
-        cb.stack_pop(mstart.expr());
-        cb.stack_pop(msize.expr());
+        cb.stack_pop(memory_address.offset_rlc());
+        cb.stack_pop(memory_address.length_rlc());
 
         // constrain not in static call
         let is_static_call = cb.call_context(None, CallContextFieldTag::IsStatic);
@@ -60,9 +62,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
             1.expr(),
         );
 
-        // check memory
-        let memory_address = MemoryAddressGadget::construct(cb, mstart, msize);
-
         // Calculate the next memory size and the gas cost for this memory
         // access
         let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);
@@ -75,9 +74,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
         // Check if the amount of gas available is less than the amount of gas
         // required
         let insufficient_gas = LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);
+
         cb.require_equal(
-            "gas left is less than gas required ",
-            insufficient_gas.expr(),
+            "Memory address is overflow or gas left is less than cost",
+            or::expr([memory_address.overflow(), insufficient_gas.expr()]),
             1.expr(),
         );
 
@@ -130,7 +130,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
 
         let gas_cost = GasCost::LOG.as_u64()
             + GasCost::LOG.as_u64() * topic_count
-            + 8 * msize.low_u64()
+            + 8 * MemoryExpandedAddressGadget::<F>::length_value(memory_start, msize)
             + memory_expansion_cost;
         // Gas insufficient check
         self.insufficient_gas
@@ -144,33 +144,69 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
 #[cfg(test)]
 mod test {
     use crate::test_util::CircuitTestBuilder;
-
     use bus_mapping::evm::OpcodeId;
     use eth_types::{
-        self, address, bytecode, bytecode::Bytecode, evm_types::GasCost, geth_types::Account,
-        Address, ToWord, Word,
+        address, bytecode, bytecode::Bytecode, evm_types::GasCost, geth_types::Account, Address,
+        ToWord, Transaction, Word, U256,
     };
-
     use mock::{
         eth, gwei, test_ctx::helpers::account_0_code_account_1_no_code, TestContext, MOCK_ACCOUNTS,
     };
 
-    fn gas(call_data: &[u8]) -> Word {
-        Word::from(
-            GasCost::TX.as_u64()
-                + 2 * OpcodeId::PUSH32.constant_gas_cost().as_u64()
-                + call_data
-                    .iter()
-                    .map(|&x| if x == 0 { 4 } else { 16 })
-                    .sum::<u64>(),
-        )
+    #[test]
+    fn test_oog_log_root_simple() {
+        test_root(100.into(), 0.into());
     }
 
-    fn test_oog_log(tx: eth_types::Transaction) {
+    #[test]
+    fn test_oog_log_internal_simple() {
+        let bytecode = bytecode! {
+            PUSH32(Word::from(0))
+            PUSH32(Word::from(10))
+            PUSH32(Word::from(224))
+            PUSH32(Word::from(1025))
+            PUSH32(Word::from(5089))
+            LOG2
+            STOP
+        };
+        let callee = callee(bytecode);
+        test_internal(caller(), callee);
+    }
+
+    #[test]
+    fn test_oog_log_max_expanded_address() {
+        // 0xffffffff1 + 0xffffffff0 = 0x1fffffffe1
+        // > MAX_EXPANDED_MEMORY_ADDRESS (0x1fffffffe0)
+        test_root(0xffffffff1_u64.into(), 0xffffffff0_u64.into());
+    }
+
+    #[test]
+    fn test_oog_log_max_u64_address() {
+        test_root(u64::MAX.into(), u64::MAX.into());
+    }
+
+    #[test]
+    fn test_oog_log_max_word_address() {
+        test_root(U256::MAX, U256::MAX);
+    }
+
+    #[derive(Clone, Copy, Debug, Default)]
+    struct Stack {
+        gas: u64,
+        value: Word,
+        cd_offset: u64,
+        cd_length: u64,
+        rd_offset: u64,
+        rd_length: u64,
+    }
+
+    fn test_root(offset: U256, size: U256) {
+        let tx = mock_tx(eth(1), gwei(2), vec![]);
+
         let code = bytecode! {
                 PUSH1(0)
-                PUSH1(0)
-                PUSH1(100)
+                PUSH32(size)
+                PUSH32(offset)
                 LOG0
         };
 
@@ -184,7 +220,7 @@ mod test {
                     .from(tx.from)
                     .gas_price(tx.gas_price.unwrap())
                     .gas(tx.gas + 5)
-                    .input(tx.input)
+                    .input(tx.input.clone())
                     .value(tx.value);
             },
             |block, _tx| block.number(0xcafeu64),
@@ -194,34 +230,35 @@ mod test {
         CircuitTestBuilder::new_from_test_ctx(ctx).run();
     }
 
-    fn mock_tx(value: Word, gas_price: Word, calldata: Vec<u8>) -> eth_types::Transaction {
-        let from = MOCK_ACCOUNTS[1];
-        let to = MOCK_ACCOUNTS[0];
-        eth_types::Transaction {
-            from,
-            to: Some(to),
-            value,
-            gas: gas(&calldata),
-            gas_price: Some(gas_price),
-            input: calldata.into(),
-            ..Default::default()
-        }
-    }
+    fn test_internal(caller: Account, callee: Account) {
+        let ctx = TestContext::<3, 1>::new(
+            None,
+            |accs| {
+                accs[0]
+                    .address(address!("0x000000000000000000000000000000000000cafe"))
+                    .balance(Word::from(10u64.pow(19)));
+                accs[1]
+                    .address(caller.address)
+                    .code(caller.code)
+                    .nonce(caller.nonce)
+                    .balance(caller.balance);
+                accs[2]
+                    .address(callee.address)
+                    .code(callee.code)
+                    .nonce(callee.nonce)
+                    .balance(callee.balance);
+            },
+            |mut txs, accs| {
+                txs[0]
+                    .from(accs[0].address)
+                    .to(accs[1].address)
+                    .gas(24000.into());
+            },
+            |block, _tx| block.number(0xcafeu64),
+        )
+        .unwrap();
 
-    #[test]
-    // test oog log in root call
-    fn test_oog_log_root() {
-        test_oog_log(mock_tx(eth(1), gwei(2), vec![]));
-    }
-
-    #[derive(Clone, Copy, Debug, Default)]
-    struct Stack {
-        gas: u64,
-        value: Word,
-        cd_offset: u64,
-        cd_length: u64,
-        rd_offset: u64,
-        rd_length: u64,
+        CircuitTestBuilder::new_from_test_ctx(ctx).run();
     }
 
     fn caller() -> Account {
@@ -263,37 +300,6 @@ mod test {
         }
     }
 
-    fn oog_log_internal_call(caller: Account, callee: Account) {
-        let ctx = TestContext::<3, 1>::new(
-            None,
-            |accs| {
-                accs[0]
-                    .address(address!("0x000000000000000000000000000000000000cafe"))
-                    .balance(Word::from(10u64.pow(19)));
-                accs[1]
-                    .address(caller.address)
-                    .code(caller.code)
-                    .nonce(caller.nonce)
-                    .balance(caller.balance);
-                accs[2]
-                    .address(callee.address)
-                    .code(callee.code)
-                    .nonce(callee.nonce)
-                    .balance(callee.balance);
-            },
-            |mut txs, accs| {
-                txs[0]
-                    .from(accs[0].address)
-                    .to(accs[1].address)
-                    .gas(24000.into());
-            },
-            |block, _tx| block.number(0xcafeu64),
-        )
-        .unwrap();
-
-        CircuitTestBuilder::new_from_test_ctx(ctx).run();
-    }
-
     fn callee(code: Bytecode) -> Account {
         let code = code.to_vec();
         let is_empty = code.is_empty();
@@ -306,19 +312,28 @@ mod test {
         }
     }
 
-    #[test]
-    // test oog log in internal call
-    fn test_oog_log_internal() {
-        let bytecode = bytecode! {
-            PUSH32(Word::from(0))
-            PUSH32(Word::from(10))
-            PUSH32(Word::from(224))
-            PUSH32(Word::from(1025))
-            PUSH32(Word::from(5089))
-            LOG2
-            STOP
-        };
-        let callee = callee(bytecode);
-        oog_log_internal_call(caller(), callee);
+    fn gas(call_data: &[u8]) -> Word {
+        Word::from(
+            GasCost::TX.as_u64()
+                + 2 * OpcodeId::PUSH32.constant_gas_cost().as_u64()
+                + call_data
+                    .iter()
+                    .map(|&x| if x == 0 { 4 } else { 16 })
+                    .sum::<u64>(),
+        )
+    }
+
+    fn mock_tx(value: Word, gas_price: Word, calldata: Vec<u8>) -> Transaction {
+        let from = MOCK_ACCOUNTS[1];
+        let to = MOCK_ACCOUNTS[0];
+        Transaction {
+            from,
+            to: Some(to),
+            value,
+            gas: gas(&calldata),
+            gas_price: Some(gas_price),
+            input: calldata.into(),
+            ..Default::default()
+        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
@@ -3,8 +3,10 @@ use crate::{
         execution::ExecutionGadget,
         step::ExecutionState,
         util::{
-            constraint_builder::ConstraintBuilder, math_gadget::IsZeroGadget,
-            memory_gadget::MemoryAddressGadget, CachedRegion, Cell, Word,
+            constraint_builder::ConstraintBuilder,
+            math_gadget::IsZeroGadget,
+            memory_gadget::{CommonMemoryAddressGadget, MemoryAddressGadget},
+            CachedRegion, Cell, Word,
         },
     },
     util::Expr,

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -8,7 +8,10 @@ use crate::{
                 ConstraintBuilder, ReversionInfo, StepStateTransition, Transition,
             },
             from_bytes,
-            memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryAddressGadget, MemoryCopierGasGadget,
+                MemoryExpansionGadget,
+            },
             not, select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -9,7 +9,9 @@ use crate::{
                 ConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
-            memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget},
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryAddressGadget, MemoryExpansionGadget,
+            },
             not, sum, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -10,7 +10,9 @@ use crate::{
                 Transition::{Delta, To},
             },
             math_gadget::{IsZeroGadget, MinMaxGadget},
-            memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget},
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryAddressGadget, MemoryExpansionGadget,
+            },
             not, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -11,7 +11,10 @@ use crate::{
             },
             from_bytes,
             math_gadget::RangeCheckGadget,
-            memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
+            memory_gadget::{
+                CommonMemoryAddressGadget, MemoryAddressGadget, MemoryCopierGasGadget,
+                MemoryExpansionGadget,
+            },
             CachedRegion, Cell, MemoryAddress,
         },
         witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -9,7 +9,10 @@ use crate::evm_circuit::{
     util::{
         common_gadget::SameContextGadget,
         constraint_builder::{ConstraintBuilder, StepStateTransition, Transition},
-        memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
+        memory_gadget::{
+            CommonMemoryAddressGadget, MemoryAddressGadget, MemoryCopierGasGadget,
+            MemoryExpansionGadget,
+        },
         rlc, CachedRegion, Cell, Word,
     },
     witness::{Block, Call, ExecStep, Transaction},

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -110,7 +110,6 @@ pub enum ExecutionState {
     ErrorOutOfGasSloadSstore,
     ErrorOutOfGasCREATE2,
     ErrorOutOfGasSELFDESTRUCT,
-    ErrorGasUintOverflow,
 }
 
 impl Default for ExecutionState {
@@ -145,7 +144,6 @@ impl ExecutionState {
                 | Self::ErrorInvalidCreationCode
                 | Self::ErrorInvalidJump
                 | Self::ErrorReturnDataOutOfBound
-                | Self::ErrorGasUintOverflow
                 | Self::ErrorOutOfGasConstant
                 | Self::ErrorOutOfGasStaticMemoryExpansion
                 | Self::ErrorOutOfGasDynamicMemoryExpansion

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -3,13 +3,14 @@ use crate::{
     evm_circuit::{
         param::{N_BYTES_GAS, N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE, N_BYTES_U64},
         util::{
-            common_gadget::WordByteRangeGadget,
+            and,
             constraint_builder::ConstraintBuilder,
             from_bytes,
             math_gadget::{
-                ConstantDivisionGadget, IsZeroGadget, LtGadget, MinMaxGadget, RangeCheckGadget,
+                AddWordsGadget, ConstantDivisionGadget, IsZeroGadget, LtGadget, MinMaxGadget,
+                RangeCheckGadget,
             },
-            not, select, sum, Cell, CellType, MemoryAddress,
+            not, or, select, sum, Cell, CellType, MemoryAddress,
         },
     },
     util::Expr,
@@ -20,6 +21,7 @@ use eth_types::{
     Field, ToLittleEndian, U256,
 };
 use halo2_proofs::{
+    arithmetic::FieldExt,
     circuit::Value,
     plonk::{Error, Expression},
 };
@@ -63,6 +65,32 @@ pub(crate) mod address_high {
     }
 }
 
+/// Memory address trait to adapt for right and Uint overflow cases.
+pub(crate) trait CommonMemoryAddressGadget<F: FieldExt> {
+    fn construct_self(cb: &mut ConstraintBuilder<F>) -> Self;
+
+    /// Return the memory address (offset + length).
+    fn assign(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        memory_offset: U256,
+        memory_length: U256,
+    ) -> Result<u64, Error>;
+
+    /// Return original word of memory offset.
+    fn offset_rlc(&self) -> Expression<F>;
+
+    /// Return original word of memory length.
+    fn length_rlc(&self) -> Expression<F>;
+
+    /// Return valid memory length of Uint64.
+    fn length(&self) -> Expression<F>;
+
+    /// Return valid memory offset plus length.
+    fn address(&self) -> Expression<F>;
+}
+
 /// Convert the dynamic memory offset and length from random linear combination
 /// to integer. It handles the "no expansion" feature by setting the
 /// `memory_offset_bytes` to zero when `memory_length` is zero. In this case,
@@ -75,43 +103,14 @@ pub(crate) struct MemoryAddressGadget<F> {
     memory_length_is_zero: IsZeroGadget<F>,
 }
 
-impl<F: Field> MemoryAddressGadget<F> {
-    pub(crate) fn construct(
-        cb: &mut ConstraintBuilder<F>,
-        memory_offset: Cell<F>,
-        memory_length: MemoryAddress<F>,
-    ) -> Self {
-        debug_assert_eq!(
-            CellType::StoragePhase2,
-            cb.curr.cell_manager.columns()[memory_offset.cell_column_index].cell_type
-        );
-        let memory_length_is_zero = IsZeroGadget::construct(cb, sum::expr(&memory_length.cells));
-        let memory_offset_bytes = cb.query_word_rlc();
-
-        let has_length = 1.expr() - memory_length_is_zero.expr();
-        cb.condition(has_length, |cb| {
-            cb.require_equal(
-                "Offset decomposition into 5 bytes",
-                memory_offset_bytes.expr(),
-                memory_offset.expr(),
-            );
-        });
-
-        Self {
-            memory_offset,
-            memory_offset_bytes,
-            memory_length,
-            memory_length_is_zero,
-        }
-    }
-
-    pub(crate) fn construct_2(cb: &mut ConstraintBuilder<F>) -> Self {
+impl<F: Field> CommonMemoryAddressGadget<F> for MemoryAddressGadget<F> {
+    fn construct_self(cb: &mut ConstraintBuilder<F>) -> Self {
         let offset = cb.query_cell_phase2();
         let length = cb.query_word_rlc();
         Self::construct(cb, offset, length)
     }
 
-    pub(crate) fn assign(
+    fn assign(
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
@@ -155,6 +154,53 @@ impl<F: Field> MemoryAddressGadget<F> {
         })
     }
 
+    fn offset_rlc(&self) -> Expression<F> {
+        self.memory_offset.expr()
+    }
+
+    fn length_rlc(&self) -> Expression<F> {
+        self.memory_length.expr()
+    }
+
+    fn length(&self) -> Expression<F> {
+        from_bytes::expr(&self.memory_length.cells)
+    }
+
+    fn address(&self) -> Expression<F> {
+        self.offset() + self.length()
+    }
+}
+
+impl<F: Field> MemoryAddressGadget<F> {
+    pub(crate) fn construct(
+        cb: &mut ConstraintBuilder<F>,
+        memory_offset: Cell<F>,
+        memory_length: MemoryAddress<F>,
+    ) -> Self {
+        debug_assert_eq!(
+            CellType::StoragePhase2,
+            cb.curr.cell_manager.columns()[memory_offset.cell_column_index].cell_type
+        );
+        let memory_length_is_zero = IsZeroGadget::construct(cb, sum::expr(&memory_length.cells));
+        let memory_offset_bytes = cb.query_word_rlc();
+
+        let has_length = 1.expr() - memory_length_is_zero.expr();
+        cb.condition(has_length, |cb| {
+            cb.require_equal(
+                "Offset decomposition into 5 bytes",
+                memory_offset_bytes.expr(),
+                memory_offset.expr(),
+            );
+        });
+
+        Self {
+            memory_offset,
+            memory_offset_bytes,
+            memory_length,
+            memory_length_is_zero,
+        }
+    }
+
     pub(crate) fn has_length(&self) -> Expression<F> {
         1.expr() - self.memory_length_is_zero.expr()
     }
@@ -162,139 +208,160 @@ impl<F: Field> MemoryAddressGadget<F> {
     pub(crate) fn offset(&self) -> Expression<F> {
         self.has_length() * from_bytes::expr(&self.memory_offset_bytes.cells)
     }
-
-    pub(crate) fn offset_rlc(&self) -> Expression<F> {
-        self.memory_offset.expr()
-    }
-
-    pub(crate) fn length_rlc(&self) -> Expression<F> {
-        self.memory_length.expr()
-    }
-
-    pub(crate) fn length(&self) -> Expression<F> {
-        from_bytes::expr(&self.memory_length.cells)
-    }
-
-    pub(crate) fn address(&self) -> Expression<F> {
-        self.offset() + self.length()
-    }
 }
 
-/// Convert the dynamic memory offset and length from random linear combination to Uint64. It is
-/// mainly used for memory expanded address in error execution states except Uint64 overflow. It
-/// also checks with MAX_EXPANDED_MEMORY_ADDRESS for out of gas, and the returned expanded address
-/// should be within the range of N_BYTES_MEMORY_WORD_SIZE which is constrained in other memory
-/// gadgets (as MemoryWordSizeGadget).
+/// Check if memory offset plus length is within range or Uint overflow.
+/// The sum of memory offset and length should also be less than or equal to
+/// `0x1FFFFFFFE0` (which is less than `u64::MAX - 31`).
+/// Reference go-ethereum code as:
+/// . [calcMemSize64WithUint](https://github.com/ethereum/go-ethereum/blob/db18293c32f6dc5d6886e5e68ab8bfd12e33cad6/core/vm/common.go#L37)
+/// . [memoryGasCost](https://github.com/ethereum/go-ethereum/blob/db18293c32f6dc5d6886e5e68ab8bfd12e33cad6/core/vm/gas_table.go#L38)
+/// . [toWordSize](https://github.com/ethereum/go-ethereum/blob/db18293c32f6dc5d6886e5e68ab8bfd12e33cad6/core/vm/common.go#L67)
 #[derive(Clone, Debug)]
 pub(crate) struct MemoryExpandedAddressGadget<F> {
-    offset: WordByteRangeGadget<F, N_BYTES_U64>,
-    length: WordByteRangeGadget<F, N_BYTES_U64>,
     length_is_zero: IsZeroGadget<F>,
-    // Offset plus length may be overflow for Uint64.
-    address_within_range: LtGadget<F, { N_BYTES_U64 + 1 }>,
+    offset_length_sum: AddWordsGadget<F, 2, false>,
+    sum_lt_cap: LtGadget<F, N_BYTES_U64>,
+    sum_within_u64: IsZeroGadget<F>,
 }
 
-impl<F: Field> MemoryExpandedAddressGadget<F> {
-    pub(crate) fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
-        let offset = WordByteRangeGadget::construct(cb);
-        let length = WordByteRangeGadget::construct(cb);
+impl<F: Field> CommonMemoryAddressGadget<F> for MemoryExpandedAddressGadget<F> {
+    fn construct_self(cb: &mut ConstraintBuilder<F>) -> Self {
+        let offset = cb.query_word_rlc();
+        let length = cb.query_word_rlc();
+        let sum = cb.query_word_rlc();
 
-        cb.require_zero("Memory length cannot be Uint64 overflow", length.overflow());
-        let length_is_zero = IsZeroGadget::construct(cb, length.valid_value());
-
-        cb.condition(not::expr(length_is_zero.expr()), |cb| {
-            cb.require_zero(
-                "Memory offset cannot be Uint64 overflow if length is non-zero",
-                offset.overflow(),
-            );
-        });
-
-        let address = select::expr(
-            length_is_zero.expr(),
-            0.expr(),
-            offset.valid_value() + length.valid_value(),
+        let sum_lt_cap = LtGadget::construct(
+            cb,
+            from_bytes::expr(&sum.cells[..N_BYTES_U64]),
+            (MAX_EXPANDED_MEMORY_ADDRESS + 1).expr(),
         );
-        let address_within_range =
-            LtGadget::construct(cb, address, (MAX_EXPANDED_MEMORY_ADDRESS + 1).expr());
+
+        let sum_overflow_hi = sum::expr(&sum.cells[N_BYTES_U64..]);
+        let sum_within_u64 = IsZeroGadget::construct(cb, sum_overflow_hi);
+
+        let length_is_zero = IsZeroGadget::construct(cb, sum::expr(&length.cells));
+        let offset_length_sum = AddWordsGadget::construct(cb, [offset, length], sum);
 
         Self {
-            offset,
-            length,
             length_is_zero,
-            address_within_range,
+            offset_length_sum,
+            sum_lt_cap,
+            sum_within_u64,
         }
     }
 
-    pub(crate) fn assign(
+    fn assign(
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         memory_offset: U256,
         memory_length: U256,
     ) -> Result<u64, Error> {
-        self.offset.assign(region, offset, memory_offset)?;
-        self.length.assign(region, offset, memory_length)?;
-
-        let memory_offset = memory_offset.low_u64();
-        let memory_length = memory_length.low_u64();
+        let length_bytes = memory_length
+            .to_le_bytes()
+            .iter()
+            .fold(0, |acc, val| acc + u64::from(*val));
         self.length_is_zero
-            .assign(region, offset, memory_length.into())?;
+            .assign(region, offset, F::from(length_bytes))?;
 
-        // Address should be within 9 (N_BYTES_U64 + 1) bytes.
-        let address = if memory_length == 0 {
-            0
-        } else {
-            u128::from(memory_offset) + u128::from(memory_length)
-        };
-        let address_cap = u128::from(MAX_EXPANDED_MEMORY_ADDRESS + 1);
-        self.address_within_range.assign(
+        let (sum, sum_word_overflow) = memory_offset.overflowing_add(memory_length);
+        self.offset_length_sum
+            .assign(region, offset, [memory_offset, memory_length], sum)?;
+
+        self.sum_lt_cap.assign(
             region,
             offset,
-            F::from_u128(address),
-            F::from_u128(address_cap),
+            F::from(sum.low_u64()),
+            F::from(MAX_EXPANDED_MEMORY_ADDRESS + 1),
         )?;
 
-        // Return MAX_EXPANDED_MEMORY_ADDRESS if address overflow.
-        Ok(if address < address_cap {
-            address.try_into().unwrap()
+        let sum_overflow_hi_bytes = sum.to_le_bytes()[N_BYTES_U64..]
+            .iter()
+            .fold(0, |acc, val| acc + u64::from(*val));
+        self.sum_within_u64
+            .assign(region, offset, F::from(sum_overflow_hi_bytes))?;
+
+        let address = if length_bytes == 0
+            || sum_overflow_hi_bytes != 0
+            || sum_word_overflow
+            || sum.low_u64() > MAX_EXPANDED_MEMORY_ADDRESS
+        {
+            0
         } else {
-            MAX_EXPANDED_MEMORY_ADDRESS
-        })
+            sum.low_u64()
+        };
+
+        Ok(address)
     }
 
-    /// Return word of memory offset.
-    pub(crate) fn offset_rlc(&self) -> Expression<F> {
-        self.offset.original_word()
+    fn offset_rlc(&self) -> Expression<F> {
+        let addends = self.offset_length_sum.addends();
+        addends[0].expr()
     }
 
-    /// Return word of memory length.
-    pub(crate) fn length_rlc(&self) -> Expression<F> {
-        self.length.original_word()
+    fn length_rlc(&self) -> Expression<F> {
+        let addends = self.offset_length_sum.addends();
+        addends[1].expr()
     }
 
-    /// Return Uint64 of memory length.
-    pub(crate) fn length(&self) -> Expression<F> {
-        self.length.valid_value()
-    }
-
-    /// Return expanded address if within range, otherwise return MAX_EXPANDED_MEMORY_ADDRESS.
-    pub(crate) fn address(&self) -> Expression<F> {
-        let address = select::expr(
-            self.length_is_zero.expr(),
-            0.expr(),
-            self.offset.valid_value() + self.length.valid_value(),
-        );
-
+    fn length(&self) -> Expression<F> {
+        let addends = self.offset_length_sum.addends();
         select::expr(
-            self.address_within_range.expr(),
-            address,
-            MAX_EXPANDED_MEMORY_ADDRESS.expr(),
+            self.within_range(),
+            from_bytes::expr(&addends[1].cells[..N_BYTES_U64]),
+            0.expr(),
         )
     }
 
-    /// Check if expanded address is greater than MAX_EXPANDED_MEMORY_ADDRESS.
-    pub(crate) fn address_overflow(&self) -> Expression<F> {
-        not::expr(self.address_within_range.expr())
+    /// Return expanded address if within range, otherwise return 0.
+    fn address(&self) -> Expression<F> {
+        select::expr(
+            self.length_is_zero.expr(),
+            0.expr(),
+            select::expr(
+                self.within_range(),
+                from_bytes::expr(&self.offset_length_sum.sum().cells[..N_BYTES_U64]),
+                0.expr(),
+            ),
+        )
+    }
+}
+
+impl<F: Field> MemoryExpandedAddressGadget<F> {
+    /// Return the valid length value corresponding to function `length`
+    /// (which returns an Expression).
+    pub(crate) fn length_value(memory_offset: U256, memory_length: U256) -> u64 {
+        if memory_length.is_zero() {
+            return 0;
+        }
+
+        memory_offset
+            .checked_add(memory_length)
+            .map_or(0, |address| {
+                if address > MAX_EXPANDED_MEMORY_ADDRESS.into() {
+                    0
+                } else {
+                    memory_length.as_u64()
+                }
+            })
+    }
+
+    /// Check if overflow.
+    pub(crate) fn overflow(&self) -> Expression<F> {
+        not::expr(self.within_range())
+    }
+
+    /// Check if within range.
+    pub(crate) fn within_range(&self) -> Expression<F> {
+        or::expr([
+            self.length_is_zero.expr(),
+            and::expr([
+                self.sum_lt_cap.expr(),
+                self.sum_within_u64.expr(),
+                not::expr(self.offset_length_sum.carry().as_ref().unwrap()),
+            ]),
+        ])
     }
 }
 

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -80,7 +80,6 @@ impl From<&ExecError> for ExecutionState {
                 ExecutionState::ErrorCodeStore
             }
             ExecError::PrecompileFailed => ExecutionState::ErrorPrecompileFailed,
-            ExecError::GasUintOverflow => ExecutionState::ErrorGasUintOverflow,
             ExecError::OutOfGas(oog_error) => match oog_error {
                 OogError::Constant => ExecutionState::ErrorOutOfGasConstant,
                 OogError::StaticMemoryExpansion => {


### PR DESCRIPTION
### Description

1. Delete execution state `ErrorGasUintOverflow` and update to handle it as OOG errors.

2. Add a trait `CommonMemoryAddressGadget`, and implement it for struct `MemoryAddressGadget` and `MemoryExpandedAddressGadget`.

3. Fix `CommonCallGadget` use `MemoryAddressGadget` for successful cases (otherwise an error of `no enough cell bytes` occurred), and `MemoryExpandedAddressGadget` for OOG-call state.

4. Update `MemoryExpandedAddressGadget` to handle Uint overflow cases of memory address (offset and length).

5. Replace `MemoryAddressGadget` with `MemoryExpandedAddressGadget` in all OOG errors, and check OOG as either gas Uint overflow or insufficient gas cost.


### Type of change

- [X] New feature (non-breaking change which adds functionality)