### PR TITLE
Copy circuit degree fix

### DIFF
--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -249,25 +249,6 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             cb.gate(meta.query_fixed(q_enable, Rotation::cur()))
         });
 
-        meta.create_gate("Last Step (check value accumulator) RlcAcc", |meta| {
-            let mut cb = BaseConstraintBuilder::default();
-
-            cb.require_equal(
-                "value_acc == rlc_acc on the last row",
-                meta.query_advice(value_acc, Rotation::next()),
-                meta.query_advice(rlc_acc, Rotation::next()),
-            );
-
-            cb.gate(and::expr([
-                meta.query_fixed(q_enable, Rotation::cur()),
-                meta.query_advice(is_last, Rotation::next()),
-                and::expr([
-                    tag.value_equals(CopyDataType::Memory, Rotation::cur())(meta),
-                    tag.value_equals(CopyDataType::Bytecode, Rotation::next())(meta),
-                ]),
-            ]))
-        });
-
         meta.create_gate(
             "Last Step (check value accumulator) Memory => Bytecode",
             |meta| {
@@ -282,10 +263,29 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 cb.gate(and::expr([
                     meta.query_fixed(q_enable, Rotation::cur()),
                     meta.query_advice(is_last, Rotation::next()),
-                    tag.value_equals(CopyDataType::RlcAcc, Rotation::next())(meta),
+                    and::expr([
+                        tag.value_equals(CopyDataType::Memory, Rotation::cur())(meta),
+                        tag.value_equals(CopyDataType::Bytecode, Rotation::next())(meta),
+                    ]),
                 ]))
             },
         );
+
+        meta.create_gate("Last Step (check value accumulator) RlcAcc", |meta| {
+            let mut cb = BaseConstraintBuilder::default();
+
+            cb.require_equal(
+                "value_acc == rlc_acc on the last row",
+                meta.query_advice(value_acc, Rotation::next()),
+                meta.query_advice(rlc_acc, Rotation::next()),
+            );
+
+            cb.gate(and::expr([
+                meta.query_fixed(q_enable, Rotation::cur()),
+                meta.query_advice(is_last, Rotation::next()),
+                tag.value_equals(CopyDataType::RlcAcc, Rotation::next())(meta),
+            ]))
+        });
 
         meta.create_gate("verify step (q_step == 1)", |meta| {
             let mut cb = BaseConstraintBuilder::default();


### PR DESCRIPTION
### Description

Fix degree of copy circuit from 12 to 9.

### Issue Link

#443 additions changed the degree of copy circuit from 9 to 12. This PR corrects the constraints so the degree is back to 9.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update