### PR TITLE
fix: codehash equality or codehash zero

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -207,18 +207,20 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         let salt = array_init::array_init(|_| cb.query_byte());
 
         #[cfg(not(feature = "poseidon-codehash"))]
-        cb.require_equal(
-            "codehash",
-            cb.word_rlc::<N_BYTES_WORD>(
+        {
+            let word_rlc = cb.word_rlc::<N_BYTES_WORD>(
                 keccak_code_hash
                     .iter()
                     .map(Expr::expr)
                     .collect::<Vec<_>>()
                     .try_into()
                     .unwrap(),
-            ),
-            code_hash_rlc.expr(),
-        );
+            );
+            cb.require_zero(
+                "keccak_code_hash == 0 or keccak_code_hash == code_hash",
+                word_rlc.expr() * (word_rlc.expr() - code_hash_rlc.expr()),
+            );
+        }
 
         Self {
             caller_address,
@@ -249,11 +251,13 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         self.nonce.assign(region, offset, caller_nonce)?;
 
         #[cfg(feature = "poseidon-codehash")]
-        if code_hash.is_some() || keccak_code_hash.is_some() {
+        if code_hash.is_some() && keccak_code_hash.is_some() {
             debug_assert_ne!(code_hash, keccak_code_hash);
         }
         #[cfg(not(feature = "poseidon-codehash"))]
-        debug_assert_eq!(code_hash, keccak_code_hash);
+        if code_hash.is_some() && keccak_code_hash.is_some() {
+            debug_assert_eq!(code_hash, keccak_code_hash);
+        }
 
         for (c, v) in self.keccak_code_hash.iter().zip(
             keccak_code_hash
@@ -399,7 +403,9 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
 #[cfg(test)]
 mod test {
     use super::{super::test_util::*, ContractCreateGadget};
+    use bus_mapping::state_db::CodeDB;
     use eth_types::{Field, ToAddress, ToLittleEndian, ToWord, Word};
+    use ethers_core::utils::keccak256;
     use gadgets::util::{not, Expr};
     use halo2_proofs::halo2curves::bn256::Fr;
 
@@ -472,10 +478,10 @@ mod test {
             let caller_address = witnesses[0].to_address();
             let caller_nonce = witnesses[1].as_u64();
             let input_len = witnesses[2].as_u64();
-            let (salt, init_code_hash) = if IS_CREATE2 {
-                (Some(witnesses[5]), Some(witnesses[6]))
+            let (salt, init_code_keccak_hash, init_code_hash) = if IS_CREATE2 {
+                (Some(witnesses[5]), Some(witnesses[6]), Some(witnesses[7]))
             } else {
-                (None, None)
+                (None, None, None)
             };
 
             self.create_gadget.assign(
@@ -483,8 +489,8 @@ mod test {
                 offset,
                 caller_address,
                 caller_nonce,
+                init_code_keccak_hash,
                 init_code_hash,
-                None,
                 salt,
             )?;
             self.input_len_expected
@@ -495,7 +501,7 @@ mod test {
                 }
                 for (c, v) in self.create2_input_rlc_expected.iter().zip(
                     [
-                        witnesses[6].to_le_bytes().as_ref(), // 32-byte init code hash
+                        witnesses[6].to_le_bytes().as_ref(), // 32-byte init code's keccak hash
                         witnesses[5].to_le_bytes().as_ref(), // 32-byte salt
                         witnesses[4].to_le_bytes()[0..20].as_ref(), // 20-byte address
                         witnesses[3].to_le_bytes()[0..1].as_ref(), // 0xff
@@ -555,8 +561,6 @@ mod test {
                     Word::from(caller_nonce),
                     rlp_len,
                     rlp_word,
-                    Word::default(),
-                    Word::default(),
                 ],
                 true
             );
@@ -567,7 +571,9 @@ mod test {
     fn create2_address() {
         let caller_address = mock::MOCK_ACCOUNTS[0];
         let salt = Word::from(0xbeefcafedeadu64);
-        let code_hash = Word::from(0xdeadcafeu64);
+        let code = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let code_hash = Word::from(CodeDB::hash(&code).to_fixed_bytes());
+        let keccak_code_hash = Word::from(keccak256(&code));
         try_test!(
             ContractCreateGadgetContainer<Fr, true>,
             vec![
@@ -577,6 +583,7 @@ mod test {
                 Word::from(0xffu64),
                 caller_address.to_word(),
                 salt,
+                keccak_code_hash,
                 code_hash,
             ],
             true


### PR DESCRIPTION
### Description

`ContractCreateGadget` failed when `scroll` feature was disabled (i.e. codehash == keccak codehash).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update