### PR TITLE
Insufficient caller balance (CREATE/CREATE2)

### DIFF
--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     circuit_input_builder::access::gen_state_access_trace,
-    error::ExecError,
+    error::{ExecError, InsufficientBalanceError},
     geth_errors::{
         GETH_ERR_GAS_UINT_OVERFLOW, GETH_ERR_OUT_OF_GAS, GETH_ERR_STACK_OVERFLOW,
         GETH_ERR_STACK_UNDERFLOW,
@@ -289,7 +289,9 @@ fn tracer_err_insufficient_balance() {
     let mut builder = CircuitInputBuilderTx::new(&block, step);
     assert_eq!(
         builder.state_ref().get_step_err(step, next_step).unwrap(),
-        Some(ExecError::InsufficientBalance)
+        Some(ExecError::InsufficientBalance(
+            InsufficientBalanceError::Call
+        ))
     );
 }
 

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -98,6 +98,17 @@ pub enum OogError {
     SelfDestruct,
 }
 
+/// Insufficient balance errors by opcode/state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InsufficientBalanceError {
+    /// Insufficient balance during CALL/CALLCODE opcode.
+    Call,
+    /// Insufficient balance during CREATE opcode.
+    Create,
+    /// Insufficient balance during CREATE2 opcode.
+    Create2,
+}
+
 /// EVM Execution Error
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExecError {
@@ -114,8 +125,8 @@ pub enum ExecError {
     WriteProtection,
     /// For CALL, CALLCODE, DELEGATECALL, STATICCALL
     Depth,
-    /// For CALL, CALLCODE
-    InsufficientBalance,
+    /// For CALL, CALLCODE, CREATE, CREATE2
+    InsufficientBalance(InsufficientBalanceError),
     /// For CREATE, CREATE2
     ContractAddressCollision,
     /// contract must not begin with 0xef due to EIP #3541 EVM Object Format

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -202,6 +202,12 @@ impl StateDB {
         self.dirty_storage.insert((*addr, *key), *value);
     }
 
+    /// Get balance of account with the given address.
+    pub fn get_balance(&self, addr: &Address) -> Word {
+        let (_, account) = self.get_account(addr);
+        account.balance
+    }
+
     /// Get nonce of account with `addr`.
     pub fn get_nonce(&self, addr: &Address) -> u64 {
         let (_, account) = self.get_account(addr);

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -332,8 +332,6 @@ pub(crate) struct ExecutionConfig<F> {
     error_code_store: Box<ErrorCodeStoreGadget<F>>,
     error_oog_self_destruct:
         Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSELFDESTRUCT }>>,
-    error_insufficient_balance:
-        Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorInsufficientBalance }>>,
     error_nonce_uint_overflow:
         Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorNonceUintOverflow }>>,
     error_invalid_jump: Box<ErrorInvalidJumpGadget<F>>,
@@ -597,7 +595,6 @@ impl<F: Field> ExecutionConfig<F> {
             error_oog_create2: configure_gadget!(),
             error_oog_self_destruct: configure_gadget!(),
             error_code_store: configure_gadget!(),
-            error_insufficient_balance: configure_gadget!(),
             error_invalid_jump: configure_gadget!(),
             error_invalid_opcode: configure_gadget!(),
             error_write_protection: configure_gadget!(),
@@ -1423,10 +1420,6 @@ impl<F: Field> ExecutionConfig<F> {
             }
             ExecutionState::ErrorStack => {
                 assign_exec_step!(self.error_stack)
-            }
-
-            ExecutionState::ErrorInsufficientBalance => {
-                assign_exec_step!(self.error_insufficient_balance)
             }
             ExecutionState::ErrorInvalidJump => {
                 assign_exec_step!(self.error_invalid_jump)

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -645,6 +645,7 @@ mod test {
 
     fn creater_bytecode(
         initialization_bytecode: Bytecode,
+        value: Word,
         is_create2: bool,
         is_persistent: bool,
     ) -> Bytecode {
@@ -660,7 +661,7 @@ mod test {
         code.append(&bytecode! {
             PUSH1(initialization_bytes.len()) // size
             PUSH1(32 - initialization_bytes.len()) // length
-            PUSH2(23414) // value
+            PUSH2(value) // value
         });
         code.write_op(if is_create2 {
             OpcodeId::CREATE2
@@ -739,7 +740,7 @@ mod test {
             .cartesian_product(&[true, false])
         {
             let init_code = initialization_bytecode(*is_success);
-            let root_code = creater_bytecode(init_code, *is_create2, *is_persistent);
+            let root_code = creater_bytecode(init_code, 23414.into(), *is_create2, *is_persistent);
             let caller = Account {
                 address: *CALLER_ADDRESS,
                 code: root_code.into(),
@@ -756,7 +757,8 @@ mod test {
         for nonce in [0, 1, 127, 128, 255, 256, 0x10000, u64::MAX - 1] {
             let caller = Account {
                 address: *CALLER_ADDRESS,
-                code: creater_bytecode(initialization_bytecode(true), false, true).into(),
+                code: creater_bytecode(initialization_bytecode(true), 23414.into(), false, true)
+                    .into(),
                 nonce: nonce.into(),
                 balance: eth(10),
                 ..Default::default()
@@ -770,7 +772,7 @@ mod test {
         for is_create2 in [true, false] {
             let caller = Account {
                 address: *CALLER_ADDRESS,
-                code: creater_bytecode(vec![].into(), is_create2, true).into(),
+                code: creater_bytecode(vec![].into(), 23414.into(), is_create2, true).into(),
                 nonce: 10.into(),
                 balance: eth(10),
                 ..Default::default()
@@ -815,5 +817,21 @@ mod test {
             ..Default::default()
         };
         run_test_circuits(test_context(caller));
+    }
+
+    #[test]
+    fn test_create_insufficient_balance() {
+        let value = 23414.into();
+        for is_create2 in [true, false] {
+            let caller = Account {
+                address: mock::MOCK_ACCOUNTS[0],
+                nonce: 1.into(),
+                code: creater_bytecode(initialization_bytecode(false), value, is_create2, true)
+                    .into(),
+                balance: value - 1,
+                ..Default::default()
+            };
+            run_test_circuits(test_context(caller));
+        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -539,8 +539,10 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             .assign_value(region, offset, code_hash_previous_rlc)?;
         let is_address_collision = !code_hash_previous.0.is_zero();
 
+        let mut rw_offset = 0;
         if !is_address_collision && !is_insufficient_balance {
             let [caller_balance_pair, callee_balance_pair] = if !value.is_zero() {
+                rw_offset += 2;
                 [15, 16].map(|i| {
                     block.rws[step.rw_indices[i + usize::from(is_create2) + copy_rw_increase]]
                         .account_balance_pair()
@@ -587,7 +589,8 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             Value::known(if is_address_collision || is_insufficient_balance {
                 F::zero()
             } else {
-                block.rws[step.rw_indices[25 + usize::from(is_create2) + copy_rw_increase]]
+                block.rws
+                    [step.rw_indices[23 + rw_offset + usize::from(is_create2) + copy_rw_increase]]
                     .call_context_value()
                     .to_scalar()
                     .unwrap()

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -90,7 +90,6 @@ pub enum ExecutionState {
     ErrorStack,
     ErrorWriteProtection,
     ErrorDepth,
-    ErrorInsufficientBalance,
     ErrorNonceUintOverflow,
     ErrorContractAddressCollision,
     ErrorInvalidCreationCode,
@@ -142,7 +141,6 @@ impl ExecutionState {
                 | Self::ErrorStack
                 | Self::ErrorWriteProtection
                 | Self::ErrorDepth
-                | Self::ErrorInsufficientBalance
                 | Self::ErrorContractAddressCollision
                 | Self::ErrorInvalidCreationCode
                 | Self::ErrorInvalidJump

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -1,6 +1,6 @@
 use bus_mapping::{
     circuit_input_builder,
-    error::{ExecError, OogError},
+    error::{ExecError, InsufficientBalanceError, OogError},
     evm::OpcodeId,
     operation,
 };
@@ -66,7 +66,11 @@ impl From<&ExecError> for ExecutionState {
             ExecError::StackOverflow | ExecError::StackUnderflow => ExecutionState::ErrorStack,
             ExecError::WriteProtection => ExecutionState::ErrorWriteProtection,
             ExecError::Depth => ExecutionState::ErrorDepth,
-            ExecError::InsufficientBalance => ExecutionState::ErrorInsufficientBalance,
+            ExecError::InsufficientBalance(insuff_balance_err) => match insuff_balance_err {
+                InsufficientBalanceError::Call => ExecutionState::CALL_OP,
+                InsufficientBalanceError::Create => ExecutionState::CREATE,
+                InsufficientBalanceError::Create2 => ExecutionState::CREATE2,
+            },
             ExecError::ContractAddressCollision => ExecutionState::CREATE,
             ExecError::NonceUintOverflow => ExecutionState::ErrorNonceUintOverflow,
             ExecError::InvalidCreationCode => ExecutionState::ErrorInvalidCreationCode,


### PR DESCRIPTION
### Description

Handle the erroneous case of "Insufficient caller balance" for the opcodes `CREATE`/`CREATE2`.

### Issue Link

Closes #354 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
