### PR TITLE
[Fix] code hash do not use rlc in 'poseidon-codehash' feature

### DIFF
--- a/zkevm-circuits/src/bytecode_circuit/circuit.rs
+++ b/zkevm-circuits/src/bytecode_circuit/circuit.rs
@@ -4,8 +4,8 @@ use crate::{
     util::{get_push_size, Challenges, Expr, SubCircuit, SubCircuitConfig},
     witness,
 };
-use bus_mapping::state_db::EMPTY_CODE_HASH_LE;
-use eth_types::{Field, ToLittleEndian};
+use bus_mapping::{state_db::EMPTY_CODE_HASH_LE, util::POSEIDON_CODE_HASH_ZERO};
+use eth_types::{Field, ToLittleEndian, ToScalar, ToWord};
 use gadgets::is_zero::{IsZeroChip, IsZeroConfig, IsZeroInstruction};
 use halo2_proofs::{
     circuit::{Layouter, Region, Value},
@@ -241,10 +241,14 @@ impl<F: Field> SubCircuitConfig<F> for BytecodeCircuitConfig<F> {
                 meta.query_advice(length, Rotation::cur()),
             );
 
-            let empty_hash = rlc::expr(
-                &EMPTY_CODE_HASH_LE.map(|v| Expression::Constant(F::from(v as u64))),
-                challenges.evm_word(),
-            );
+            let empty_hash = if cfg!(feature = "poseidon-codehash") {
+                Expression::Constant(POSEIDON_CODE_HASH_ZERO.to_word().to_scalar().unwrap())
+            } else {
+                rlc::expr(
+                    &EMPTY_CODE_HASH_LE.map(|v| Expression::Constant(F::from(v as u64))),
+                    challenges.evm_word(),
+                )
+            };
 
             cb.require_equal(
                 "assert cur.hash == EMPTY_HASH",
@@ -457,9 +461,13 @@ impl<F: Field> BytecodeCircuitConfig<F> {
             last_row_offset
         );
 
-        let empty_hash = challenges
-            .evm_word()
-            .map(|challenge| rlc::value(EMPTY_CODE_HASH_LE.as_ref(), challenge));
+        let empty_hash = challenges.evm_word().map(|challenge| {
+            if cfg!(feature = "poseidon-codehash") {
+                POSEIDON_CODE_HASH_ZERO.to_word().to_scalar().unwrap()
+            } else {
+                rlc::value(EMPTY_CODE_HASH_LE.as_ref(), challenge)
+            }
+        });
 
         let mut is_first_time = true;
         layouter.assign_region(
@@ -529,9 +537,13 @@ impl<F: Field> BytecodeCircuitConfig<F> {
 
         // Code hash with challenge is calculated only using the first row of the
         // bytecode (header row), the rest of the code_hash in other rows are ignored.
-        let code_hash = challenges
-            .evm_word()
-            .map(|challenge| rlc::value(&bytecode.rows[0].code_hash.to_le_bytes(), challenge));
+        let code_hash = challenges.evm_word().map(|challenge| {
+            if cfg!(feature = "poseidon-codehash") {
+                bytecode.rows[0].code_hash.to_scalar().unwrap()
+            } else {
+                rlc::value(&bytecode.rows[0].code_hash.to_le_bytes(), challenge)
+            }
+        });
 
         for (idx, row) in bytecode.rows.iter().enumerate() {
             if fail_fast && *offset > last_row_offset {
@@ -891,11 +903,9 @@ impl<F: Field> Circuit<F> for BytecodeCircuit<F> {
             &challenges,
         )?;
         #[cfg(feature = "poseidon-codehash")]
-        config.poseidon_table.dev_load(
-            &mut layouter,
-            self.bytecodes.iter().map(|b| &b.bytes),
-            &challenges,
-        )?;
+        config
+            .poseidon_table
+            .dev_load(&mut layouter, self.bytecodes.iter().map(|b| &b.bytes))?;
         self.synthesize_sub(&config, &challenges, &mut layouter)?;
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -128,9 +128,9 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
 
         let code_hash = block.rws[step.rw_indices[5]].account_value_pair().0;
         self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
+            .assign(region, offset, region.code_hash(code_hash))?;
         self.not_exists
-            .assign_value(region, offset, region.word_rlc(code_hash))?;
+            .assign_value(region, offset, region.code_hash(code_hash))?;
         let balance = if code_hash.is_zero() {
             eth_types::Word::zero()
         } else {

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -648,7 +648,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             tx_fee,
         )?;
         self.phase2_code_hash
-            .assign(region, offset, region.word_rlc(callee_code_hash))?;
+            .assign(region, offset, region.code_hash(callee_code_hash))?;
         let untrimmed_contract_addr = {
             let mut stream = RlpStream::new();
             stream.begin_list(2);
@@ -668,11 +668,11 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         self.is_empty_code_hash.assign_value(
             region,
             offset,
-            region.word_rlc(callee_code_hash),
+            region.code_hash(callee_code_hash),
             region.empty_code_hash_rlc(),
         )?;
         self.callee_not_exists
-            .assign_value(region, offset, region.word_rlc(callee_code_hash))?;
+            .assign_value(region, offset, region.code_hash(callee_code_hash))?;
 
         let untrimmed_contract_addr = {
             let mut stream = ethers_core::utils::rlp::RlpStream::new();

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -692,7 +692,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             rd_offset,
             rd_length,
             step.memory_word_size(),
-            region.word_rlc(callee_code_hash),
+            region.code_hash(callee_code_hash),
         )?;
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -532,7 +532,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         let code_hash_previous = block.rws
             [step.rw_indices[13 + usize::from(is_create2) + copy_rw_increase]]
             .account_codehash_pair();
-        let code_hash_previous_rlc = region.word_rlc(code_hash_previous.0);
+        let code_hash_previous_rlc = region.code_hash(code_hash_previous.0);
         self.code_hash_previous
             .assign(region, offset, code_hash_previous_rlc)?;
         self.not_address_collision
@@ -634,7 +634,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         self.keccak_code_hash.assign(
             region,
             offset,
-            region.word_rlc(U256::from_big_endian(&keccak_code_hash)),
+            region.code_hash(U256::from_big_endian(&keccak_code_hash)),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -164,7 +164,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             rd_offset,
             rd_length,
             step.memory_word_size(),
-            region.word_rlc(callee_code_hash),
+            region.code_hash(callee_code_hash),
         )?;
 
         self.opcode

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -188,7 +188,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
 
         let code_hash = block.rws[step.rw_indices[8]].account_value_pair().0;
         self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
+            .assign(region, offset, region.code_hash(code_hash))?;
 
         let code_size = if code_hash.is_zero() {
             0

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -112,7 +112,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
 
         let code_hash = block.rws[step.rw_indices[5]].account_value_pair().0;
         self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
+            .assign(region, offset, region.code_hash(code_hash))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -141,9 +141,9 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
 
         let code_hash = block.rws[step.rw_indices[5]].account_value_pair().0;
         self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
+            .assign(region, offset, region.code_hash(code_hash))?;
         self.not_exists
-            .assign_value(region, offset, region.word_rlc(code_hash))?;
+            .assign_value(region, offset, region.code_hash(code_hash))?;
 
         let rw_offset = 6;
         #[cfg(feature = "scroll")]

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -353,7 +353,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             self.code_hash.assign(
                 region,
                 offset,
-                region.word_rlc(U256::from_little_endian(&code_hash)),
+                region.code_hash(U256::from_little_endian(&code_hash)),
             )?;
 
             // code size.

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -590,7 +590,7 @@ impl<F: FieldExt> Step<F> {
             .assign(region, offset, Value::known(F::from(step.block_num)))?;
         self.state
             .code_hash
-            .assign(region, offset, region.word_rlc(call.code_hash))?;
+            .assign(region, offset, region.code_hash(call.code_hash))?;
         self.state.program_counter.assign(
             region,
             offset,

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -196,6 +196,19 @@ impl<'r, 'b, F: FieldExt> CachedRegion<'r, 'b, F> {
             .map(|r| rlc::value(&n.to_le_bytes(), r))
     }
 
+    pub fn code_hash(&self, n: U256) -> Value<F> {
+        self.challenges
+            .evm_word()
+            .map(|r| 
+                if cfg!(feature = "poseidon-codehash") {
+                    // only FieldExt is not enough for ToScalar trait so we have to make workaround
+                    rlc::value(&n.to_le_bytes(), F::from(256u64))
+                } else {
+                    rlc::value(&n.to_le_bytes(), r)
+                }
+            )
+    }
+
     pub fn keccak_rlc(&self, le_bytes: &[u8]) -> Value<F> {
         self.challenges
             .keccak_input()
@@ -203,7 +216,7 @@ impl<'r, 'b, F: FieldExt> CachedRegion<'r, 'b, F> {
     }
 
     pub fn empty_code_hash_rlc(&self) -> Value<F> {
-        self.word_rlc(CodeDB::empty_code_hash().to_word())
+        self.code_hash(CodeDB::empty_code_hash().to_word())
     }
 
     /// Constrains a cell to have a constant value.

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -197,16 +197,14 @@ impl<'r, 'b, F: FieldExt> CachedRegion<'r, 'b, F> {
     }
 
     pub fn code_hash(&self, n: U256) -> Value<F> {
-        self.challenges
-            .evm_word()
-            .map(|r| 
-                if cfg!(feature = "poseidon-codehash") {
-                    // only FieldExt is not enough for ToScalar trait so we have to make workaround
-                    rlc::value(&n.to_le_bytes(), F::from(256u64))
-                } else {
-                    rlc::value(&n.to_le_bytes(), r)
-                }
-            )
+        self.challenges.evm_word().map(|r| {
+            if cfg!(feature = "poseidon-codehash") {
+                // only FieldExt is not enough for ToScalar trait so we have to make workaround
+                rlc::value(&n.to_le_bytes(), F::from(256u64))
+            } else {
+                rlc::value(&n.to_le_bytes(), r)
+            }
+        })
     }
 
     pub fn keccak_rlc(&self, le_bytes: &[u8]) -> Value<F> {

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -257,7 +257,7 @@ impl<F: Field> RestoreContextGadget<F> {
         }
 
         self.caller_code_hash
-            .assign(region, offset, region.word_rlc(caller_code_hash))?;
+            .assign(region, offset, region.code_hash(caller_code_hash))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -11,8 +11,11 @@ use crate::{
     },
     util::{build_tx_log_expression, Challenges, Expr},
 };
-use bus_mapping::{state_db::EMPTY_CODE_HASH_LE, util::{KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO}};
-use eth_types::{Field, ToLittleEndian, ToWord};
+use bus_mapping::{
+    state_db::EMPTY_CODE_HASH_LE,
+    util::{KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO},
+};
+use eth_types::{Field, ToLittleEndian, ToScalar, ToWord};
 use gadgets::util::{and, not};
 use halo2_proofs::{
     circuit::Value,
@@ -471,9 +474,7 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
 
     pub(crate) fn empty_code_hash_rlc(&self) -> Expression<F> {
         if cfg!(feature = "poseidon-codehash") {
-            let mut bytes = Vec::from(POSEIDON_CODE_HASH_ZERO.to_word().to_le_bytes());
-            bytes.resize(64, 0);
-            Expression::Constant(F::from_bytes_wide(bytes.as_slice().try_into().unwrap()))
+            Expression::Constant(POSEIDON_CODE_HASH_ZERO.to_word().to_scalar().unwrap())
         } else {
             self.word_rlc((*EMPTY_CODE_HASH_LE).map(|byte| byte.expr()))
         }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -472,7 +472,7 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
     pub(crate) fn empty_code_hash_rlc(&self) -> Expression<F> {
         if cfg!(feature = "poseidon-codehash") {
             let mut bytes = Vec::from(POSEIDON_CODE_HASH_ZERO.to_word().to_le_bytes());
-            bytes.resize(32, 0);
+            bytes.resize(64, 0);
             Expression::Constant(F::from_bytes_wide(bytes.as_slice().try_into().unwrap()))
         } else {
             self.word_rlc((*EMPTY_CODE_HASH_LE).map(|byte| byte.expr()))

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -191,13 +191,16 @@ impl MptUpdates {
 impl MptUpdate {
     pub(crate) fn value_assignments<F: Field>(&self, word_randomness: F) -> (F, F) {
         let assign = |x: Word| match self.key {
-            Key::Account { 
-                field_tag : AccountFieldTag::CodeHash, .. 
-            } => if cfg!(feature = "poseidon-codehash") {
-                x.to_scalar().unwrap()
-            } else {
-                rlc::value(&x.to_le_bytes(), word_randomness)
-            },
+            Key::Account {
+                field_tag: AccountFieldTag::CodeHash,
+                ..
+            } => {
+                if cfg!(feature = "poseidon-codehash") {
+                    x.to_scalar().unwrap()
+                } else {
+                    rlc::value(&x.to_le_bytes(), word_randomness)
+                }
+            }
             Key::Account {
                 field_tag:
                     AccountFieldTag::Nonce | AccountFieldTag::NonExisting | AccountFieldTag::CodeSize,

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -191,6 +191,13 @@ impl MptUpdates {
 impl MptUpdate {
     pub(crate) fn value_assignments<F: Field>(&self, word_randomness: F) -> (F, F) {
         let assign = |x: Word| match self.key {
+            Key::Account { 
+                field_tag : AccountFieldTag::CodeHash, .. 
+            } => if cfg!(feature = "poseidon-codehash") {
+                x.to_scalar().unwrap()
+            } else {
+                rlc::value(&x.to_le_bytes(), word_randomness)
+            },
             Key::Account {
                 field_tag:
                     AccountFieldTag::Nonce | AccountFieldTag::NonExisting | AccountFieldTag::CodeSize,

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -594,28 +594,30 @@ impl Rw {
                 match field_tag {
                     // Only these two tags have values that may not fit into a scalar, so we need to
                     // RLC. (for poseidon hash feature, CodeHash not need rlc)
-                    CallContextFieldTag::CodeHash => if cfg!(feature = "poseidon-codehash") {
-                        value.to_scalar().unwrap()
-                    } else {
-                        rlc::value(&value.to_le_bytes(), randomness)
-                    },
-                    CallContextFieldTag::Value => {
-                        rlc::value(&value.to_le_bytes(), randomness)
+                    CallContextFieldTag::CodeHash => {
+                        if cfg!(feature = "poseidon-codehash") {
+                            value.to_scalar().unwrap()
+                        } else {
+                            rlc::value(&value.to_le_bytes(), randomness)
+                        }
                     }
+                    CallContextFieldTag::Value => rlc::value(&value.to_le_bytes(), randomness),
                     _ => value.to_scalar().unwrap(),
                 }
             }
             Self::Account {
                 value, field_tag, ..
             } => match field_tag {
-                AccountFieldTag::KeccakCodeHash
-                | AccountFieldTag::Balance => rlc::value(&value.to_le_bytes(), randomness),
-                AccountFieldTag::CodeHash => 
+                AccountFieldTag::KeccakCodeHash | AccountFieldTag::Balance => {
+                    rlc::value(&value.to_le_bytes(), randomness)
+                }
+                AccountFieldTag::CodeHash => {
                     if cfg!(feature = "poseidon-codehash") {
                         value.to_scalar().unwrap()
                     } else {
                         rlc::value(&value.to_le_bytes(), randomness)
-                    },
+                    }
+                }
                 AccountFieldTag::Nonce
                 | AccountFieldTag::NonExisting
                 | AccountFieldTag::CodeSize => value.to_scalar().unwrap(),
@@ -645,14 +647,16 @@ impl Rw {
                 field_tag,
                 ..
             } => Some(match field_tag {
-                AccountFieldTag::KeccakCodeHash
-                | AccountFieldTag::Balance => rlc::value(&value_prev.to_le_bytes(), randomness),
-                AccountFieldTag::CodeHash => 
+                AccountFieldTag::KeccakCodeHash | AccountFieldTag::Balance => {
+                    rlc::value(&value_prev.to_le_bytes(), randomness)
+                }
+                AccountFieldTag::CodeHash => {
                     if cfg!(feature = "poseidon-codehash") {
                         value_prev.to_scalar().unwrap()
                     } else {
                         rlc::value(&value_prev.to_le_bytes(), randomness)
-                    },                
+                    }
+                }
                 AccountFieldTag::Nonce
                 | AccountFieldTag::NonExisting
                 | AccountFieldTag::CodeSize => value_prev.to_scalar().unwrap(),


### PR DESCRIPTION
The 'poseidon-codehash' feature is specified for our l2geth, in which 'dual codehash' has applied so the codehash field in account can be always contained in a single scalar of the field (even the code hash for empty code). It would be waste of cost if we still apply it as a rlc of the bytes of codehash.

This PR switch each place refering codehash and assign the codehash as single scalar when 'poseidon-codehash' feature is enabled. Execpt for bytecode circuit, only unified change is required for most places in the code (replacing the calling of `word_rlc` to a specified `code_hash` function)

Following test should be passed:
[ ] The failed `bytecode_invalid_hash_data` test before
[ ] Regression for all the unit tests
[ ] A mock proving of the supercircuit on real-world trace from alpha testnet
