### PR TITLE
Fix Clippy Linting Errors

### DIFF
--- a/circuit-benchmarks/src/bytecode_circuit.rs
+++ b/circuit-benchmarks/src/bytecode_circuit.rs
@@ -32,7 +32,7 @@ mod tests {
     fn bench_bytecode_circuit_prover() {
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         let degree: u32 = var("DEGREE")
             .unwrap_or_else(|_| "15".to_string())
             .parse()
@@ -63,7 +63,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -77,7 +77,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/copy_circuit.rs
+++ b/circuit-benchmarks/src/copy_circuit.rs
@@ -35,7 +35,7 @@ mod tests {
     fn bench_copy_circuit_prover() {
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         let degree: u32 = var("DEGREE")
             .unwrap_or_else(|_| "14".to_string())
             .parse()
@@ -55,7 +55,7 @@ mod tests {
         let circuit = CopyCircuit::<Fr>::new_from_block(&block);
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -68,7 +68,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -31,7 +31,7 @@ mod evm_circ_benches {
     fn bench_evm_circuit_prover() {
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         // Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "EVM Circuit";
 
@@ -63,7 +63,7 @@ mod evm_circ_benches {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -76,7 +76,7 @@ mod evm_circ_benches {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/exp_circuit.rs
+++ b/circuit-benchmarks/src/exp_circuit.rs
@@ -36,7 +36,7 @@ mod tests {
         env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         // Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Exp Circuit";
 
@@ -62,7 +62,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree as u32, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -75,7 +75,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/packed_multi_keccak.rs
+++ b/circuit-benchmarks/src/packed_multi_keccak.rs
@@ -28,7 +28,7 @@ mod tests {
     fn bench_packed_multi_keccak_circuit_prover() {
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         // Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Packed Multi-Keccak Circuit";
 
@@ -50,7 +50,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -63,7 +63,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/pi_circuit.rs
+++ b/circuit-benchmarks/src/pi_circuit.rs
@@ -35,7 +35,7 @@ mod tests {
     fn bench_pi_circuit_prover() {
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         // Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Pi Circuit";
 
@@ -63,7 +63,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree as u32, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -76,7 +76,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/state_circuit.rs
+++ b/circuit-benchmarks/src/state_circuit.rs
@@ -30,7 +30,7 @@ mod tests {
     fn bench_state_circuit_prover() {
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         // Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "State Circuit";
 
@@ -48,7 +48,7 @@ mod tests {
         ]);
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -64,7 +64,7 @@ mod tests {
         let instances: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -32,7 +32,7 @@ mod tests {
     fn bench_super_circuit_prover() {
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         // Unique string used by bench results module for parsing the result
         const BENCHMARK_ID: &str = "Super Circuit";
 
@@ -102,7 +102,7 @@ mod tests {
         let instance_refs: Vec<&[Fr]> = instance.iter().map(|v| &v[..]).collect();
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -115,7 +115,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );

--- a/circuit-benchmarks/src/tx_circuit.rs
+++ b/circuit-benchmarks/src/tx_circuit.rs
@@ -90,7 +90,7 @@ mod tests {
         env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
         let setup_prfx = crate::constants::SETUP_PREFIX;
         let proof_gen_prfx = crate::constants::PROOFGEN_PREFIX;
-        let proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
+        let _proof_ver_prfx = crate::constants::PROOFVER_PREFIX;
         let mut rng = ChaCha20Rng::seed_from_u64(42);
 
         // Unique string used by bench results module for parsing the result
@@ -104,7 +104,7 @@ mod tests {
         };
 
         // Bench setup generation
-        let setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
+        let _setup_message = format!("{} {} with degree = {}", BENCHMARK_ID, setup_prfx, degree);
         let start1 = start_timer!(|| setup_message);
         let general_params = ParamsKZG::<Bn256>::setup(degree as u32, &mut rng);
         let verifier_params: ParamsVerifierKZG<Bn256> = general_params.verifier_params().clone();
@@ -117,7 +117,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
+        let _proof_message = format!(
             "{} {} with degree = {}",
             BENCHMARK_ID, proof_gen_prfx, degree
         );


### PR DESCRIPTION
### Description

Just reading through some Scroll repos and though I'd help fix a minor nit. Right now there are some clippy lints blocking CI from progressing further, I simply added a `_` prefix to the unused variables, which doesn't affect behavior or readability at all, and allows CI to move onto benchmarks. It also allows `make test-all` as suggested in the README to run the actual benchmarks and not stop after lints fail.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Contents

Fixed unused variables

### How Has This Been Tested?

Locally with the `make test-all` and `cargo clippy`

