### PR TITLE
Upgrade poseidon circuit to 'septidon'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "halo2-mpt-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=goerli-0215-dual-hash#ae8acdf37eafbbb5b6dffcb9e977dab465970c83"
+source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0411#fd2b324272f0d5cf272c6ca282e3c817a2f23bb0"
 dependencies = [
  "halo2_proofs",
  "hex",
@@ -3635,7 +3635,7 @@ dependencies = [
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0215#b5e9b1440de088648a8661ccefbd28f7ebb3f252"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0408#5c8ca0004ffe13aa48e86316bfb41af789c914d5"
 dependencies = [
  "bitvec 1.0.1",
  "halo2_proofs",
@@ -5532,3 +5532,7 @@ source = "git+https://github.com/scroll-tech/zktrie.git?branch=scroll-dev-0226#1
 dependencies = [
  "gobuild",
 ]
+
+[[patch.unused]]
+name = "windows-sys"
+version = "0.36.1"

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -15,7 +15,7 @@ ethers-core = "0.17.0"
 ethers-signers = "0.17.0"
 ethers-providers = "0.17.0"
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
-poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0215"}
+poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0408", features=["short"]}
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"

--- a/eth-types/Cargo.toml
+++ b/eth-types/Cargo.toml
@@ -24,7 +24,7 @@ num = "0.4"
 num-bigint = { version = "0.4" }
 strum_macros = "0.24"
 strum = "0.24"
-poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0215"}
+poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0408", features=["short"]}
 [features]
 default = ["warn-unimplemented"]
 warn-unimplemented = []

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
-mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "goerli-0215-dual-hash" }
+mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0411" }
 zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "scroll-dev-0226", features = ["dual_codehash"] }
 bus-mapping = { path = "../bus-mapping" }
 eth-types = { path = "../eth-types" }


### PR DESCRIPTION
This PR upgrade poseidon circuit to the 'seption' version, i.e. the circuit designed by @naure which take only 8 rows for each permutation. It also upgrade mpt circuit to `scroll-dev-0411` which is almost the same as `goerli-0215-dual-hash` with septidon circuit being carried.

Mock proving on alpha testnet trace has passed.