### PR TITLE
Add `DepthError` for mapping error depth, and comment out dummy gadget for feature scroll

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -6,7 +6,10 @@ use super::{
     TransactionContext,
 };
 use crate::{
-    error::{get_step_reported_error, ExecError, InsufficientBalanceError, NonceUintOverflowError},
+    error::{
+        get_step_reported_error, DepthError, ExecError, InsufficientBalanceError,
+        NonceUintOverflowError,
+    },
     exec_trace::OperationRef,
     operation::{
         AccountField, AccountOp, CallContextField, CallContextOp, MemoryOp, Op, OpEnum, Operation,
@@ -1417,7 +1420,15 @@ impl<'a> CircuitInputStateRef<'a> {
             && next_pc != 0
         {
             if step.depth == 1025 {
-                return Ok(Some(ExecError::Depth));
+                return Ok(Some(ExecError::Depth(match step.op {
+                    OpcodeId::CALL
+                    | OpcodeId::CALLCODE
+                    | OpcodeId::DELEGATECALL
+                    | OpcodeId::STATICCALL => DepthError::Call,
+                    OpcodeId::CREATE => DepthError::Create,
+                    OpcodeId::CREATE2 => DepthError::Create2,
+                    op => unreachable!("ErrDepth cannot occur in {op}"),
+                })));
             }
 
             let sender = self.call()?.address;

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     circuit_input_builder::access::gen_state_access_trace,
-    error::{ExecError, InsufficientBalanceError, OogError},
+    error::{DepthError, ExecError, InsufficientBalanceError, OogError},
     geth_errors::{
         GETH_ERR_GAS_UINT_OVERFLOW, GETH_ERR_OUT_OF_GAS, GETH_ERR_STACK_OVERFLOW,
         GETH_ERR_STACK_UNDERFLOW,
@@ -220,7 +220,7 @@ fn tracer_err_depth() {
     let mut builder = CircuitInputBuilderTx::new(&block, step);
     assert_eq!(
         builder.state_ref().get_step_err(step, next_step).unwrap(),
-        Some(ExecError::Depth)
+        Some(ExecError::Depth(DepthError::Call))
     );
 }
 

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -98,6 +98,17 @@ pub enum OogError {
     SelfDestruct,
 }
 
+/// Depth above limit errors by opcode/state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DepthError {
+    /// Depth above limit during CALL/CALLCODE/DELEGATECALL/STATICCALL opcode.
+    Call,
+    /// Depth above limit during CREATE opcode.
+    Create,
+    /// Depth above limit during CREATE2 opcode.
+    Create2,
+}
+
 /// Insufficient balance errors by opcode/state.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InsufficientBalanceError {
@@ -133,7 +144,7 @@ pub enum ExecError {
     /// SELFDESTRUCT
     WriteProtection,
     /// For CALL, CALLCODE, DELEGATECALL, STATICCALL
-    Depth,
+    Depth(DepthError),
     /// For CALL, CALLCODE, CREATE, CREATE2
     InsufficientBalance(InsufficientBalanceError),
     /// For CREATE, CREATE2

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -72,6 +72,7 @@ mod codecopy;
 mod codesize;
 mod comparator;
 mod create;
+#[cfg(not(feature = "scroll"))]
 mod dummy;
 mod dup;
 mod end_block;
@@ -153,6 +154,7 @@ use codecopy::CodeCopyGadget;
 use codesize::CodesizeGadget;
 use comparator::ComparatorGadget;
 use create::CreateGadget;
+#[cfg(not(feature = "scroll"))]
 use dummy::DummyGadget;
 use dup::DupGadget;
 use end_block::EndBlockGadget;
@@ -331,11 +333,11 @@ pub(crate) struct ExecutionConfig<F> {
     error_oog_sha3: Box<ErrorOOGSha3Gadget<F>>,
     error_oog_create2: Box<ErrorOOGCreate2Gadget<F>>,
     error_code_store: Box<ErrorCodeStoreGadget<F>>,
+    #[cfg(not(feature = "scroll"))]
     error_oog_self_destruct:
         Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorOutOfGasSELFDESTRUCT }>>,
     error_invalid_jump: Box<ErrorInvalidJumpGadget<F>>,
     error_invalid_opcode: Box<ErrorInvalidOpcodeGadget<F>>,
-    error_depth: Box<DummyGadget<F, 0, 0, { ExecutionState::ErrorDepth }>>,
     error_invalid_creation_code: Box<ErrorInvalidCreationCodeGadget<F>>,
     error_precompile_failed: Box<ErrorPrecompileFailedGadget<F>>,
     error_return_data_out_of_bound: Box<ErrorReturnDataOutOfBoundGadget<F>>,
@@ -592,12 +594,12 @@ impl<F: Field> ExecutionConfig<F> {
             error_oog_sha3: configure_gadget!(),
             error_oog_exp: configure_gadget!(),
             error_oog_create2: configure_gadget!(),
+            #[cfg(not(feature = "scroll"))]
             error_oog_self_destruct: configure_gadget!(),
             error_code_store: configure_gadget!(),
             error_invalid_jump: configure_gadget!(),
             error_invalid_opcode: configure_gadget!(),
             error_write_protection: configure_gadget!(),
-            error_depth: configure_gadget!(),
             error_invalid_creation_code: configure_gadget!(),
             error_return_data_out_of_bound: configure_gadget!(),
             error_precompile_failed: configure_gadget!(),
@@ -1412,9 +1414,9 @@ impl<F: Field> ExecutionConfig<F> {
                 assign_exec_step!(self.error_oog_create2)
             }
             ExecutionState::ErrorOutOfGasSELFDESTRUCT => {
+                #[cfg(not(feature = "scroll"))]
                 assign_exec_step!(self.error_oog_self_destruct)
             }
-
             ExecutionState::ErrorCodeStore => {
                 assign_exec_step!(self.error_code_store)
             }
@@ -1429,9 +1431,6 @@ impl<F: Field> ExecutionConfig<F> {
             }
             ExecutionState::ErrorWriteProtection => {
                 assign_exec_step!(self.error_write_protection)
-            }
-            ExecutionState::ErrorDepth => {
-                assign_exec_step!(self.error_depth)
             }
             ExecutionState::ErrorContractAddressCollision => {
                 assign_exec_step!(self.create_gadget)

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -1190,7 +1190,7 @@ mod test {
     }
 
     #[test]
-    fn test_depth() {
+    fn callop_error_depth() {
         let callee_code = bytecode! {
             PUSH1(0x00)
             PUSH1(0x00)

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -89,7 +89,6 @@ pub enum ExecutionState {
     ErrorInvalidOpcode,
     ErrorStack,
     ErrorWriteProtection,
-    ErrorDepth,
     ErrorContractAddressCollision,
     ErrorInvalidCreationCode,
     ErrorInvalidJump,

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -1,6 +1,6 @@
 use bus_mapping::{
     circuit_input_builder,
-    error::{ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
+    error::{DepthError, ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
     evm::OpcodeId,
     operation,
 };
@@ -65,7 +65,11 @@ impl From<&ExecError> for ExecutionState {
             ExecError::InvalidOpcode => ExecutionState::ErrorInvalidOpcode,
             ExecError::StackOverflow | ExecError::StackUnderflow => ExecutionState::ErrorStack,
             ExecError::WriteProtection => ExecutionState::ErrorWriteProtection,
-            ExecError::Depth => ExecutionState::ErrorDepth,
+            ExecError::Depth(depth_err) => match depth_err {
+                DepthError::Call => ExecutionState::CALL_OP,
+                DepthError::Create => ExecutionState::CREATE,
+                DepthError::Create2 => ExecutionState::CREATE2,
+            },
             ExecError::InsufficientBalance(insuff_balance_err) => match insuff_balance_err {
                 InsufficientBalanceError::Call => ExecutionState::CALL_OP,
                 InsufficientBalanceError::Create => ExecutionState::CREATE,


### PR DESCRIPTION
### Description

1. Add `DepthError` for mapping error depth to call and create opcodes. Otherwise it seems that `ExecutionState::ErrorDepth` (deleted) was run into dummy gadget before.
2. And comment out dummy gadget for feature scroll (only used for selfdestruct and oog-selfdestruct).

### Issue Link

Related comment https://github.com/scroll-tech/zkevm-circuits/pull/463#issuecomment-1510042778

### Test

Both `callop_error_depth` (renamed) and `test_create_error_depth` cases could run successfully.