### PR TITLE
Fix testool cases and update `testool`

### DIFF
--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::{
     circuit_input_builder::access::gen_state_access_trace,
-    error::{DepthError, ExecError, InsufficientBalanceError, OogError},
+    error::{
+        ContractAddressCollisionError, DepthError, ExecError, InsufficientBalanceError, OogError,
+    },
     geth_errors::{
         GETH_ERR_GAS_UINT_OVERFLOW, GETH_ERR_OUT_OF_GAS, GETH_ERR_STACK_OVERFLOW,
         GETH_ERR_STACK_UNDERFLOW,
@@ -478,7 +480,9 @@ fn tracer_err_address_collision() {
         .set_account(&create2_address, Account::zero());
     assert_eq!(
         builder.state_ref().get_step_err(step, next_step).unwrap(),
-        Some(ExecError::ContractAddressCollision)
+        Some(ExecError::ContractAddressCollision(
+            ContractAddressCollisionError::Create2
+        ))
     );
 }
 

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -98,6 +98,15 @@ pub enum OogError {
     SelfDestruct,
 }
 
+/// Contract address collision errors by opcode/state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ContractAddressCollisionError {
+    /// Contract address collision during CREATE opcode.
+    Create,
+    /// Contract address collision during CREATE2 opcode.
+    Create2,
+}
+
 /// Depth above limit errors by opcode/state.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DepthError {
@@ -148,7 +157,7 @@ pub enum ExecError {
     /// For CALL, CALLCODE, CREATE, CREATE2
     InsufficientBalance(InsufficientBalanceError),
     /// For CREATE, CREATE2
-    ContractAddressCollision,
+    ContractAddressCollision(ContractAddressCollisionError),
     /// contract must not begin with 0xef due to EIP #3541 EVM Object Format
     /// (EOF)
     InvalidCreationCode,

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -40,3 +40,4 @@ ctor = "0.1.22"
 [features]
 default = ["ignore-test-docker"]
 ignore-test-docker = []
+skip-self-destruct = []

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -38,6 +38,6 @@ urlencoding = "2.1.2"
 ctor = "0.1.22"
 
 [features]
-default = ["ignore-test-docker"]
+default = ["ignore-test-docker", "skip-self-destruct"]
 ignore-test-docker = []
 skip-self-destruct = []

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -75,7 +75,7 @@ fn check_post(
         }
 
         if expected.nonce.map(|v| v == actual.nonce) == Some(false) {
-            log::trace!(
+            log::error!(
                 "nonce mismatch, expected {:?} actual {:?}",
                 expected,
                 actual
@@ -146,7 +146,7 @@ fn into_traceconfig(st: StateTest) -> (String, TraceConfig, StateTestResult) {
         let address = Address::from(addr_bytes);
         let acc = eth_types::geth_types::Account {
             // balance: 1.into(),
-            nonce: 1.into(),
+            // nonce: 1.into(),
             address,
             ..Default::default()
         };

--- a/testool/src/statetest/results.rs
+++ b/testool/src/statetest/results.rs
@@ -14,6 +14,8 @@ use strum_macros::{EnumIter, EnumString}; // 0.17.1
 
 const MAX_DETAILS_LEN: usize = 128;
 
+const OUTPUT_ALL_RESULT_LEVELS: [ResultLevel; 2] = [ResultLevel::Fail, ResultLevel::Panic];
+
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, EnumIter, EnumString, Serialize, Deserialize)]
 pub enum ResultLevel {
     #[strum(ascii_case_insensitive)]
@@ -166,7 +168,17 @@ impl Report {
 
         // strip_prefix `tests/` for rendering purpose. It helps to generate hyperlink
         let leading_tests_path = "tests/";
-        let mut tests_for_render = self.tests.clone();
+        let mut tests_for_render: HashMap<_, _> = self
+            .tests
+            .iter()
+            .filter_map(|(id, result)| {
+                if OUTPUT_ALL_RESULT_LEVELS.contains(&result.level) {
+                    Some((id.clone(), result.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
         for (_, result) in tests_for_render.iter_mut() {
             assert!(result.path.starts_with(leading_tests_path));
             result.path = result

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1432,9 +1432,6 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::ErrorWriteProtection => {
                 assign_exec_step!(self.error_write_protection)
             }
-            ExecutionState::ErrorContractAddressCollision => {
-                assign_exec_step!(self.create_gadget)
-            }
             ExecutionState::ErrorInvalidCreationCode => {
                 assign_exec_step!(self.error_invalid_creation_code)
             }

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -256,6 +256,12 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         );
 
         let not_address_collision = IsZeroGadget::construct(cb, code_hash_previous.expr());
+        /*
+        // CREATE2 may cause address collision error. And for a tricky
+        // case of CREATE, it could also cause this error. e.g. the `to`
+        // field of transaction is set to the calculated contract
+        // address (reference testool case
+        // `RevertDepthCreateAddressCollision_d0_g0_v0` for details).
         cb.condition(not::expr(not_address_collision.expr()), |cb| {
             cb.require_equal(
                 "op code is create2 for address collision",
@@ -263,6 +269,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 OpcodeId::CREATE2.expr(),
             );
         });
+        */
 
         // conditional transfer for address collision case
         let transfer = cb.condition(
@@ -434,7 +441,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 cb.require_step_state_transition(StepStateTransition {
                     rw_counter: Delta(cb.rw_counter_offset()),
                     program_counter: Delta(1.expr()),
-                    stack_pointer: Delta(3.expr()),
+                    stack_pointer: Delta(2.expr() + IS_CREATE2.expr()),
                     gas_left: To(gas_left.quotient()),
                     reversible_write_counter: Delta(2.expr()),
                     ..Default::default()

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -89,7 +89,6 @@ pub enum ExecutionState {
     ErrorInvalidOpcode,
     ErrorStack,
     ErrorWriteProtection,
-    ErrorContractAddressCollision,
     ErrorInvalidCreationCode,
     ErrorInvalidJump,
     ErrorReturnDataOutOfBound,

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -1,6 +1,9 @@
 use bus_mapping::{
     circuit_input_builder,
-    error::{DepthError, ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
+    error::{
+        ContractAddressCollisionError, DepthError, ExecError, InsufficientBalanceError,
+        NonceUintOverflowError, OogError,
+    },
     evm::OpcodeId,
     operation,
 };
@@ -75,7 +78,12 @@ impl From<&ExecError> for ExecutionState {
                 InsufficientBalanceError::Create => ExecutionState::CREATE,
                 InsufficientBalanceError::Create2 => ExecutionState::CREATE2,
             },
-            ExecError::ContractAddressCollision => ExecutionState::CREATE,
+            ExecError::ContractAddressCollision(contract_addr_collision_err) => {
+                match contract_addr_collision_err {
+                    ContractAddressCollisionError::Create => ExecutionState::CREATE,
+                    ContractAddressCollisionError::Create2 => ExecutionState::CREATE2,
+                }
+            }
             ExecError::NonceUintOverflow(nonce_overflow_err) => match nonce_overflow_err {
                 NonceUintOverflowError::Create => ExecutionState::CREATE,
                 NonceUintOverflowError::Create2 => ExecutionState::CREATE2,


### PR DESCRIPTION
### Description

1. `RevertDepthCreateAddressCollision_d0_g0_v0` is a special case which causes contract address collision for `CREATE` opcode (tx `to` address is same as the calculated contract address to deploy). Fix to support both `CREATE` and `CREATE2` for contract address collision error.

2.  `RevertPrecompiledTouchExactOOG_d10_g0_v0` cause `NonceMismatch` error in testool. Fix to comment out the nonce set (to 1) in [into_traceconfig](https://github.com/scroll-tech/zkevm-circuits/pull/472/files#diff-30cf512233894acc0c9747f071c19a3e797086dad860d3f29b3e8355a0ea6bc3L149) function (nonce is default as 0).

3. Add a new default feature `skip-self-destruct` to ignore test cases which contain `SELFDESTRUCT` opcode.

4. Fix to only display Fail and Panic results in HTML all-results section.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Could be tested in `testool` as:
```
cargo run -- --inspect 'RevertDepthCreateAddressCollision_d0_g0_v0'
cargo run -- --inspect 'RevertPrecompiledTouchExactOOG_d10_g0_v0'
```

### TODO

Continue on case `InitCollision_d2_g0_v0`.