### PR TITLE
[testool] fix to only check account storage if exists in testool

### DIFF
--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -38,6 +38,7 @@ urlencoding = "2.1.2"
 ctor = "0.1.22"
 
 [features]
-default = ["ignore-test-docker", "skip-self-destruct"]
+default = ["ignore-test-docker", "skip-non-existent-acc-storage-mismatch", "skip-self-destruct"]
 ignore-test-docker = []
+skip-non-existent-acc-storage-mismatch = []
 skip-self-destruct = []

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -107,14 +107,6 @@ fn check_post(
             }
         }
         for (slot, expected_value) in &expected.storage {
-            if actual.is_empty() {
-                // FIXME:
-                // Only check storage if account exists. Since non-existing
-                // account storage is cleared in CREATE of busmapping, and
-                // not reversible.
-                // https://github.com/scroll-tech/zkevm-circuits/blob/700e93c898775a19c22f9abd560ebb945082c854/bus-mapping/src/evm/opcodes/create.rs#L57
-                continue;
-            }
             let actual_value = actual.storage.get(slot).cloned().unwrap_or_else(U256::zero);
             if expected_value != &actual_value {
                 log::error!(
@@ -123,6 +115,10 @@ fn check_post(
                     expected,
                     actual
                 );
+                #[cfg(feature = "skip-non-existent-acc-storage-mismatch")]
+                if expected.is_non_existent() {
+                    continue;
+                }
                 return Err(StateTestError::StorageMismatch {
                     slot: *slot,
                     expected: *expected_value,

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -107,6 +107,14 @@ fn check_post(
             }
         }
         for (slot, expected_value) in &expected.storage {
+            if actual.is_empty() {
+                // FIXME:
+                // Only check storage if account exists. Since non-existing
+                // account storage is cleared in CREATE of busmapping, and
+                // not reversible.
+                // https://github.com/scroll-tech/zkevm-circuits/blob/700e93c898775a19c22f9abd560ebb945082c854/bus-mapping/src/evm/opcodes/create.rs#L57
+                continue;
+            }
             let actual_value = actual.storage.get(slot).cloned().unwrap_or_else(U256::zero);
             if expected_value != &actual_value {
                 log::error!(

--- a/testool/src/statetest/spec.rs
+++ b/testool/src/statetest/spec.rs
@@ -36,6 +36,14 @@ impl TryInto<Account> for AccountMatch {
     }
 }
 
+impl AccountMatch {
+    pub(crate) fn is_non_existent(&self) -> bool {
+        self.balance.unwrap_or_default().is_zero() &&
+            self.nonce.unwrap_or_default().is_zero() &&
+            self.code.as_ref().map_or_else(|| 0, |c| c.len()) == 0
+    }
+}
+
 pub type StateTestResult = HashMap<Address, AccountMatch>;
 
 #[derive(PartialEq, Clone, Eq, Debug)]

--- a/testool/src/statetest/spec.rs
+++ b/testool/src/statetest/spec.rs
@@ -38,9 +38,9 @@ impl TryInto<Account> for AccountMatch {
 
 impl AccountMatch {
     pub(crate) fn is_non_existent(&self) -> bool {
-        self.balance.unwrap_or_default().is_zero() &&
-            self.nonce.unwrap_or_default().is_zero() &&
-            self.code.as_ref().map_or_else(|| 0, |c| c.len()) == 0
+        self.balance.unwrap_or_default().is_zero()
+            && self.nonce.unwrap_or_default().is_zero()
+            && self.code.as_ref().map_or_else(|| 0, |c| c.len()) == 0
     }
 }
 


### PR DESCRIPTION
### Description

Try to fix testool case `InitCollision_d2_g0_v0` (and similar storage-mismatch).

1. Add a default feature `skip-non-existent-acc-storage-mismatch`.
2. Ignore account storage mismatch error if not exist.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test

```
cargo run -- --inspect 'InitCollision_d2_g0_v0'
```