### PR TITLE
[testool] fix failed `testool` cases of `NonceMismatch`

### DIFF
--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -151,13 +151,14 @@ fn into_traceconfig(st: StateTest) -> (String, TraceConfig, StateTestResult) {
         let mut addr_bytes = [0u8; 20];
         addr_bytes[19] = i as u8;
         let address = Address::from(addr_bytes);
-        let acc = eth_types::geth_types::Account {
-            // balance: 1.into(),
-            // nonce: 1.into(),
-            address,
-            ..Default::default()
-        };
-        accounts.insert(address, acc);
+        accounts
+            .entry(address)
+            .or_insert_with(|| eth_types::geth_types::Account {
+                // balance: 1.into(),
+                // nonce: 1.into(),
+                address,
+                ..Default::default()
+            });
     }
 
     (

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -153,7 +153,7 @@ fn into_traceconfig(st: StateTest) -> (String, TraceConfig, StateTestResult) {
         let address = Address::from(addr_bytes);
         accounts
             .entry(address)
-            .or_insert_with(|| eth_types::geth_types::Account {
+            .or_insert(eth_types::geth_types::Account {
                 // balance: 1.into(),
                 // nonce: 1.into(),
                 address,


### PR DESCRIPTION
### Description

Fix to add `0x0..1` - `0x0..9` accounts if non exists (by [hash_map::Entry::or_insert](https://doc.rust-lang.org/stable/std/collections/hash_map/enum.Entry.html#method.or_insert)).

Since some traces already have these accounts with nonce-1.

### Issue Link

Fix cases:
```
RevertPrecompiledTouch_noncestorage_d0_g0_v0
RevertPrecompiledTouch_noncestorage_d1_g0_v0
RevertPrecompiledTouch_noncestorage_d2_g0_v0
RevertPrecompiledTouch_noncestorage_d3_g0_v0
RevertPrecompiledTouch_nonce_d0_g0_v0
RevertPrecompiledTouch_nonce_d1_g0_v0
RevertPrecompiledTouch_nonce_d2_g0_v0
RevertPrecompiledTouch_nonce_d3_g0_v0
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test

Could be tested as:
```
cargo run -- --inspect 'RevertPrecompiledTouch_nonce_d3_g0_v0'
```