### PR TITLE
[memory-opt] fix test case `test_precompiled_call` in CALL OP

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -790,18 +790,18 @@ mod test {
         };
 
         let call6 = bytecode! {
-            PUSH1(0x20)
-            PUSH1(0x20)
-            PUSH1(0x20)
+            PUSH1(0x10)
+            PUSH1(0x10)
+            PUSH1(0x10)
             PUSH1(0x00)
             PUSH1(0x04)
             PUSH1(0xFF)
         };
 
         let call7 = bytecode! {
-            PUSH1(0x20)
-            PUSH1(0x20)
-            PUSH1(0x20)
+            PUSH1(0x10)
+            PUSH1(0x10)
+            PUSH1(0x10)
             PUSH1(0x00)
             PUSH1(0x00)
             PUSH1(0x04)
@@ -809,7 +809,7 @@ mod test {
         };
 
         let tail = bytecode! {
-            PUSH1(0x20)
+            PUSH1(0x10)
             MLOAD
         };
 


### PR DESCRIPTION
### Description

Fix to replace `MemoryOp` with `MemoryWordOp` in precompiled call. This test case uses `MLOAD` to read call result.

### Test

`test_precompiled_call` could run successfully.

