### PR TITLE
[don't-merge] implement deployment collision

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -87,11 +87,12 @@ impl<'a> CircuitInputStateRef<'a> {
                     let code_hash = self.sdb.get_account(&call.address).1.code_hash;
                     let bytecode_len = self.code(code_hash).unwrap().len() as u64;
                     let deposit_cost = bytecode_len * GasCost::CODE_DEPOSIT_BYTE_COST.as_u64();
-                    assert!(
-                        gas_left >= deposit_cost,
-                        "gas left {gas_left} is not enough for deposit cost {deposit_cost}"
-                    );
-                    gas_left -= deposit_cost;
+                    gas_left = gas_left.checked_sub(deposit_cost).unwrap_or_else(|| {
+                        log::warn!(
+                            "gas left {gas_left} is not enough for deposit cost {deposit_cost}"
+                        );
+                        0
+                    });
                 }
 
                 Gas(gas_left)


### PR DESCRIPTION
### Description

Fix `testool` cases:
```
TransactionCollisionToEmptyButCode_d0_g1_v0
TransactionCollisionToEmptyButCode_d0_g1_v1
TransactionCollisionToEmptyButNonce_d0_g1_v0
TransactionCollisionToEmptyButNonce_d0_g1_v1
initCollidingWithNonEmptyAccount_d0_g0_v0
initCollidingWithNonEmptyAccount_d1_g0_v0
initCollidingWithNonEmptyAccount_d2_g0_v0
initCollidingWithNonEmptyAccount_d3_g0_v0
initCollidingWithNonEmptyAccount_d4_g0_v0
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test

Original `BeginTxGadget` test cases and above `testool` cases (for deployment collision).