### PR TITLE
[Feat]Induce copy constraint for phase2 cell

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -456,7 +456,7 @@ mod evm_circuit_stats {
     use crate::{
         evm_circuit::{
             param::{
-                LOOKUP_CONFIG, N_BYTE_LOOKUPS, N_COPY_COLUMNS, N_PHASE1_COLUMNS, N_PHASE2_COLUMNS,
+                LOOKUP_CONFIG, N_BYTE_LOOKUPS, N_COPY_COLUMNS, N_PHASE1_COLUMNS, N_PHASE2_COLUMNS, N_PHASE2_COPY_COLUMNS,
             },
             step::ExecutionState,
             EvmCircuit,
@@ -598,6 +598,8 @@ mod evm_circuit_stats {
             N_PHASE2_COLUMNS,
             storage_perm,
             N_COPY_COLUMNS,
+            storage_perm_2,
+            N_PHASE2_COPY_COLUMNS,
             byte_lookup,
             N_BYTE_LOOKUPS,
             fixed_table,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -456,7 +456,8 @@ mod evm_circuit_stats {
     use crate::{
         evm_circuit::{
             param::{
-                LOOKUP_CONFIG, N_BYTE_LOOKUPS, N_COPY_COLUMNS, N_PHASE1_COLUMNS, N_PHASE2_COLUMNS, N_PHASE2_COPY_COLUMNS,
+                LOOKUP_CONFIG, N_BYTE_LOOKUPS, N_COPY_COLUMNS, N_PHASE1_COLUMNS, N_PHASE2_COLUMNS,
+                N_PHASE2_COPY_COLUMNS,
             },
             step::ExecutionState,
             EvmCircuit,

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -24,6 +24,8 @@ pub(crate) const N_PHASE1_COLUMNS: usize =
 
 // Number of copy columns
 pub(crate) const N_COPY_COLUMNS: usize = 2;
+// Number of copy columns for phase2
+pub(crate) const N_PHASE2_COPY_COLUMNS: usize = 1;
 
 pub(crate) const N_BYTE_LOOKUPS: usize = 24;
 

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -1,7 +1,8 @@
 use crate::{
     evm_circuit::{
         param::{
-            LOOKUP_CONFIG, N_BYTES_MEMORY_ADDRESS, N_BYTE_LOOKUPS, N_COPY_COLUMNS, N_PHASE2_COLUMNS, N_PHASE2_COPY_COLUMNS,
+            LOOKUP_CONFIG, N_BYTES_MEMORY_ADDRESS, N_BYTE_LOOKUPS, N_COPY_COLUMNS,
+            N_PHASE2_COLUMNS, N_PHASE2_COPY_COLUMNS,
         },
         table::Table,
     },
@@ -438,8 +439,8 @@ impl<F: FieldExt> CellManager<F> {
                 best_height = column.height;
             }
         }
-        // Replace a CellType::Storage by CellType::StoragePermutation (phase 1 or phase 2) if the later has
-        // better height
+        // Replace a CellType::Storage by CellType::StoragePermutation (phase 1 or phase 2) if the
+        // later has better height
         if cell_type == CellType::StoragePhase1 {
             for column in self.columns.iter() {
                 if column.cell_type == CellType::StoragePermutation && column.height < best_height {
@@ -447,9 +448,11 @@ impl<F: FieldExt> CellManager<F> {
                     best_height = column.height;
                 }
             }
-        }else if cell_type == CellType::StoragePhase2 {
+        } else if cell_type == CellType::StoragePhase2 {
             for column in self.columns.iter() {
-                if column.cell_type == CellType::StoragePermutationPhase2 && column.height < best_height {
+                if column.cell_type == CellType::StoragePermutationPhase2
+                    && column.height < best_height
+                {
                     best_index = Some(column.index);
                     best_height = column.height;
                 }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -439,6 +439,10 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         self.query_cell_with_type(CellType::StoragePermutation)
     }
 
+    pub(crate) fn query_copy_cell_phase2(&mut self) -> Cell<F> {
+        self.query_cell_with_type(CellType::StoragePermutationPhase2)
+    }
+
     pub(crate) fn query_cell_with_type(&mut self, cell_type: CellType) -> Cell<F> {
         self.query_cells(cell_type, 1).first().unwrap().clone()
     }

--- a/zkevm-circuits/src/evm_circuit/util/instrumentation.rs
+++ b/zkevm-circuits/src/evm_circuit/util/instrumentation.rs
@@ -73,6 +73,9 @@ impl Instrument {
                     CellType::StoragePermutation => {
                         report.storage_perm = data_entry;
                     }
+                    CellType::StoragePermutationPhase2 => {
+                        report.storage_perm_2 = data_entry;
+                    }                    
                     CellType::LookupByte => {
                         report.byte_lookup = data_entry;
                     }
@@ -116,6 +119,7 @@ pub(crate) struct ExecStateReport {
     pub(crate) storage_1: StateReportRow,
     pub(crate) storage_2: StateReportRow,
     pub(crate) storage_perm: StateReportRow,
+    pub(crate) storage_perm_2: StateReportRow,
     pub(crate) byte_lookup: StateReportRow,
     pub(crate) fixed_table: StateReportRow,
     pub(crate) tx_table: StateReportRow,

--- a/zkevm-circuits/src/evm_circuit/util/instrumentation.rs
+++ b/zkevm-circuits/src/evm_circuit/util/instrumentation.rs
@@ -75,7 +75,7 @@ impl Instrument {
                     }
                     CellType::StoragePermutationPhase2 => {
                         report.storage_perm_2 = data_entry;
-                    }                    
+                    }
                     CellType::LookupByte => {
                         report.byte_lookup = data_entry;
                     }


### PR DESCRIPTION
Current `ConstraintBuilder` in evm-circuit do not enable a phase 2 cell can be copy-constrainted. It is critical when we wish to export specified rlc value to connect with other circuit (like pi circuit).

This PR induce a new CellType `StoragePermutationPhase2`, which can be query from CellManager and the col it  is settled in being added into permutation. This new type is also added into occupancy report.