### PR TITLE
Support shanghai in geth tracer

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -44,3 +44,5 @@ rand = "0.8"
 default = ["test"]
 test = ["mock", "rand"]
 scroll = ["eth-types/scroll"]
+# Enable shanghai feature of mock only if mock is enabled (by test).
+shanghai = ["mock?/shanghai"]

--- a/external-tracer/src/lib.rs
+++ b/external-tracer/src/lib.rs
@@ -21,24 +21,23 @@ pub struct TraceConfig {
     pub accounts: HashMap<Address, Account>,
     /// transaction
     pub transactions: Vec<Transaction>,
-    /// logger
+    /// logger config
     pub logger_config: LoggerConfig,
+    /// chain config
+    pub chain_config: Option<ChainConfig>,
 }
 
 /// Configuration structure for `logger.Config`
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct LoggerConfig {
     /// enable memory capture
-    #[serde(rename = "EnableMemory")]
     pub enable_memory: bool,
     /// disable stack capture
-    #[serde(rename = "DisableStack")]
     pub disable_stack: bool,
     /// disable storage capture
-    #[serde(rename = "DisableStorage")]
     pub disable_storage: bool,
     /// enable return data capture
-    #[serde(rename = "EnableReturnData")]
     pub enable_return_data: bool,
 }
 
@@ -58,6 +57,32 @@ impl LoggerConfig {
         Self {
             enable_memory: true,
             ..Self::default()
+        }
+    }
+}
+
+/// Configuration structure for `params.ChainConfig`
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ChainConfig {
+    /// Shanghai switch time (nil = no fork, 0 = already on shanghai)
+    pub shanghai_time: Option<Word>,
+    /// TerminalTotalDifficulty is the amount of total difficulty reached by
+    /// the network that triggers the consensus upgrade.
+    pub terminal_total_difficulty: Option<Word>,
+    /// TerminalTotalDifficultyPassed is a flag specifying that the network already
+    /// passed the terminal total difficulty. Its purpose is to disable legacy sync
+    /// even without having seen the TTD locally (safer long term).
+    pub terminal_total_difficulty_passed: bool,
+}
+
+impl ChainConfig {
+    /// Create a chain config for Shanghai fork.
+    pub fn shanghai() -> Self {
+        Self {
+            shanghai_time: Some(0.into()),
+            terminal_total_difficulty: Some(0.into()),
+            terminal_total_difficulty_passed: true,
         }
     }
 }

--- a/external-tracer/src/lib.rs
+++ b/external-tracer/src/lib.rs
@@ -66,10 +66,10 @@ impl LoggerConfig {
 #[serde(rename_all = "PascalCase")]
 pub struct ChainConfig {
     /// Shanghai switch time (nil = no fork, 0 = already on shanghai)
-    pub shanghai_time: Option<Word>,
+    pub shanghai_time: Option<u64>,
     /// TerminalTotalDifficulty is the amount of total difficulty reached by
     /// the network that triggers the consensus upgrade.
-    pub terminal_total_difficulty: Option<Word>,
+    pub terminal_total_difficulty: Option<u64>,
     /// TerminalTotalDifficultyPassed is a flag specifying that the network already
     /// passed the terminal total difficulty. Its purpose is to disable legacy sync
     /// even without having seen the TTD locally (safer long term).
@@ -80,8 +80,8 @@ impl ChainConfig {
     /// Create a chain config for Shanghai fork.
     pub fn shanghai() -> Self {
         Self {
-            shanghai_time: Some(0.into()),
-            terminal_total_difficulty: Some(0.into()),
+            shanghai_time: Some(0),
+            terminal_total_difficulty: Some(0),
             terminal_total_difficulty_passed: true,
         }
     }

--- a/geth-utils/gethutil/trace.go
+++ b/geth-utils/gethutil/trace.go
@@ -143,6 +143,9 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
+		TerminalTotalDifficulty:       big.NewInt(0),
+		TerminalTotalDifficultyPassed: true,
+		ShanghaiTime:                  newUint64(0),
 	}
 
 	var txsGasLimit uint64
@@ -180,6 +183,8 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		return nil, fmt.Errorf("txs total gas: %d Exceeds block gas limit: %d", txsGasLimit, blockGasLimit)
 	}
 
+	randao := common.BigToHash(toBigInt(config.Block.Difficulty)) // TODO: fix
+
 	blockCtx := vm.BlockContext{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,
@@ -195,6 +200,7 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		BlockNumber: toBigInt(config.Block.Number),
 		Time:        toBigInt(config.Block.Timestamp).Uint64(),
 		Difficulty:  toBigInt(config.Block.Difficulty),
+		Random:      &randao,
 		BaseFee:     toBigInt(config.Block.BaseFee),
 		GasLimit:    blockGasLimit,
 	}

--- a/geth-utils/gethutil/trace.go
+++ b/geth-utils/gethutil/trace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/imdario/mergo"
 )
 
 // Copied from github.com/ethereum/go-ethereum/internal/ethapi.ExecutionResult
@@ -122,6 +123,7 @@ type TraceConfig struct {
 	Accounts      map[common.Address]Account `json:"accounts"`
 	Transactions  []Transaction              `json:"transactions"`
 	LoggerConfig  *logger.Config             `json:"logger_config"`
+	ChainConfig   *params.ChainConfig        `json:"chain_config"`
 }
 
 func newUint64(val uint64) *uint64 { return &val }
@@ -143,9 +145,10 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
-		TerminalTotalDifficulty:       big.NewInt(0),
-		TerminalTotalDifficultyPassed: true,
-		ShanghaiTime:                  newUint64(0),
+	}
+
+	if config.ChainConfig != nil {
+		mergo.Merge(&chainConfig, config.ChainConfig, mergo.WithOverride)
 	}
 
 	var txsGasLimit uint64

--- a/geth-utils/gethutil/trace.go
+++ b/geth-utils/gethutil/trace.go
@@ -151,6 +151,9 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		mergo.Merge(&chainConfig, config.ChainConfig, mergo.WithOverride)
 	}
 
+	// Debug for Shanghai
+	// fmt.Printf("geth-utils: ShanghaiTime = %d\n", *chainConfig.ShanghaiTime)
+
 	var txsGasLimit uint64
 	blockGasLimit := toBigInt(config.Block.GasLimit).Uint64()
 	messages := make([]core.Message, len(config.Transactions))

--- a/geth-utils/gethutil/trace.go
+++ b/geth-utils/gethutil/trace.go
@@ -186,6 +186,7 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		return nil, fmt.Errorf("txs total gas: %d Exceeds block gas limit: %d", txsGasLimit, blockGasLimit)
 	}
 
+	// For opcode PREVRANDAO
 	randao := common.BigToHash(toBigInt(config.Block.Difficulty)) // TODO: fix
 
 	blockCtx := vm.BlockContext{

--- a/geth-utils/go.mod
+++ b/geth-utils/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/ethereum/go-ethereum v1.11.5
 	github.com/holiman/uint256 v1.2.0
+	github.com/imdario/mergo v0.3.15 // indirect
 )
 
 // Uncomment for debugging

--- a/geth-utils/go.sum
+++ b/geth-utils/go.sum
@@ -434,6 +434,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
+github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.65.1/go.mod h1:J754/zds0vvpfwuq7Gc2wRdVwEodfpCFM7mYlOw2LqY=

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -14,3 +14,7 @@ ethers-signers = "0.17.0"
 ethers-core = "0.17.0"
 rand_chacha = "0.3"
 rand = "0.8"
+
+[features]
+default = []
+shanghai = []

--- a/mock/src/test_ctx.rs
+++ b/mock/src/test_ctx.rs
@@ -254,6 +254,10 @@ pub fn gen_geth_traces(
             .map(eth_types::geth_types::Transaction::from)
             .collect(),
         logger_config,
+        #[cfg(feature = "shanghai")]
+        chain_config: Some(external_tracer::ChainConfig::shanghai()),
+        #[cfg(not(feature = "shanghai"))]
+        chain_config: None,
     };
     let traces = trace(&trace_config)?;
     Ok(traces)

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -41,3 +41,4 @@ ctor = "0.1.22"
 default = ["ignore-test-docker", "skip-self-destruct"]
 ignore-test-docker = []
 skip-self-destruct = []
+shanghai = []

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -196,6 +196,10 @@ fn into_traceconfig(st: StateTest) -> (String, TraceConfig, StateTestResult) {
                 enable_memory: *bus_mapping::util::CHECK_MEM_STRICT,
                 ..Default::default()
             },
+            #[cfg(feature = "shanghai")]
+            chain_config: Some(external_tracer::ChainConfig::shanghai()),
+            #[cfg(not(feature = "shanghai"))]
+            chain_config: None,
         },
         st.result,
     )

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -67,6 +67,8 @@ test = ["ethers-signers", "mock", "bus-mapping/test"]
 # scroll-zkevm repo enables both "scroll" and "poseidon-codehash-lookup", 
 # while tests inside this repo should not enable "poseidon-codehash-lookup" feature. 
 scroll = ["bus-mapping/scroll", "eth-types/scroll", "zktrie", "enable-sign-verify", "reject-eip2718", "poseidon-codehash"]
+# Enable shanghai feature of mock only if mock is enabled (by test).
+shanghai = ["bus-mapping/shanghai", "mock?/shanghai"]
 poseidon-codehash-lookup = []
 test-circuits = []
 warn-unimplemented = ["eth-types/warn-unimplemented"]


### PR DESCRIPTION
### Summary

1. Add `shanghai` feature to bus-mapping, zkevm-circuits, mock and testool.

2. Add shanghai config fields to a new struct `ChainConfig` in external-tracer. It is optional in `TraceConfig`.

3. Fix to merge `ChainConfig` (if not null) from external-tracer in geth-utils.

### Test

Test feature `shanghai` for part test cases as:
```
cargo test --features shanghai -- --nocapture begin_tx_
```

### TODO

***Suppose to work on other tasks in separate PRs. Move to issue https://github.com/scroll-tech/zkevm-circuits/issues/504.***

add a feature flag "shanghai", with which, the shanghai fork of geth tracer used, the some circuit constraints changed accordingly like the gas of init code / warm coin base.
we can either merge this after ci pass (without push0), or add push0 to this pr too.

- [x] add feature shanghai and change tracer accordingly
- [ ] EIP-3651: Warm COINBASE https://github.com/scroll-tech/zkevm-circuits/pull/500
- [ ] EIP-3860: Limit and meter initcode
- [ ] EIP-3855: PUSH0 instruction
- [ ] EIP-4895: Beacon Chain push withdrawals
- [ ] EIP-6049: Deprecate SELFDESTRUCT - may also add `shanghai` feature to `SELFDESTRUCT` as https://github.com/scroll-tech/zkevm-circuits/pull/463
- [ ] upgrade testool/tests submodule commit and re-run testool 