### PR TITLE
[feat] add copy circuit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,7 @@ dependencies = [
  "halo2_proofs",
  "hex",
  "lazy_static",
+ "log",
  "num-bigint",
  "poseidon-circuit",
  "rand",

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -548,7 +548,12 @@ impl<F: Field> CopyCircuitConfig<F> {
         // to satisfy the query at `Rotation(2)` performed inside of the
         // `rows[2].value == rows[0].value * r + rows[1].value` requirement in the RLC
         // Accumulation gate.
-        assert!(copy_rows_needed + 2 <= max_copy_rows);
+        assert!(
+            copy_rows_needed + 2 <= max_copy_rows,
+            "copy rows not enough {} vs {}",
+            copy_rows_needed,
+            max_copy_rows
+        );
 
         let tag_chip = BinaryNumberChip::construct(self.copy_table.tag);
         let lt_chip = LtChip::construct(self.addr_lt_addr_end);

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -244,6 +244,7 @@ mod tests {
         evm_circuit::test::{rand_bytes, rand_word},
         test_util::CircuitTestBuilder,
     };
+    use bus_mapping::circuit_input_builder::CircuitsParams;
     use eth_types::{
         bytecode, evm_types::gas_utils::memory_copier_gas_cost, Bytecode, ToWord, U256,
     };
@@ -414,7 +415,12 @@ mod tests {
         )
         .unwrap();
 
-        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+        CircuitTestBuilder::new_from_test_ctx(ctx)
+            .params(CircuitsParams {
+                max_copy_rows: 1750,
+                ..Default::default()
+            })
+            .run();
     }
 
     fn test_internal(testing_data: &TestingData) {

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -463,7 +463,12 @@ mod tests {
         )
         .unwrap();
 
-        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+        CircuitTestBuilder::new_from_test_ctx(ctx)
+            .params(CircuitsParams {
+                max_copy_rows: 1750,
+                ..Default::default()
+            })
+            .run();
     }
 
     fn test_for_edge_memory_size(dst_offset: u64, copy_size: u64) {

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -241,6 +241,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
 #[cfg(test)]
 mod test {
     use crate::{evm_circuit::test::rand_bytes_array, test_util::CircuitTestBuilder};
+    use bus_mapping::circuit_input_builder::CircuitsParams;
     use eth_types::{
         address, bytecode, geth_types::Account, Address, Bytecode, Bytes, ToWord, Word,
     };
@@ -310,7 +311,12 @@ mod test {
         )
         .unwrap();
 
-        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+        CircuitTestBuilder::new_from_test_ctx(ctx)
+            .params(CircuitsParams {
+                max_copy_rows: 1750,
+                ..Default::default()
+            })
+            .run();
     }
 
     #[test]

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -326,6 +326,7 @@ mod test {
         CircuitTestBuilder::new_from_test_ctx(ctx)
             .params(CircuitsParams {
                 max_rws: 2048,
+                max_copy_rows: 1750,
                 ..Default::default()
             })
             .run();

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -175,6 +175,7 @@ mod tests {
         )
         .params(CircuitsParams {
             max_rws: 5500,
+            max_copy_rows: 1750,
             ..Default::default()
         })
         .run();

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -175,7 +175,7 @@ mod tests {
         )
         .params(CircuitsParams {
             max_rws: 5500,
-            max_copy_rows: 1750,
+            max_copy_rows: 3000,
             ..Default::default()
         })
         .run();

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -1,7 +1,7 @@
 //! Testing utilities
 
 use crate::{
-    copy_circuit::CopyCircuit,
+    copy_circuit::{CopyCircuit, ExternalData},
     evm_circuit::EvmCircuit,
     state_circuit::StateCircuit,
     util::{log2_ceil, SubCircuit},
@@ -249,9 +249,9 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
 
         // Run copy circuit test
         {
-            let (active_rows, max_rows) = CopyCircuit::<Fr>::min_num_rows_block(&block);
-            let k = log2_ceil(max_rows);
-            let copy_circuit = CopyCircuit::<Fr>::new(block.copy_events, max_rows);
+            let (active_rows, _max_rows) = CopyCircuit::<Fr>::min_num_rows_block(&block);
+            let k = block.get_test_degree();
+            let copy_circuit = CopyCircuit::<Fr>::new_from_block(&block);
             let instance = copy_circuit.instance();
             let prover = MockProver::<Fr>::run(k, &copy_circuit, instance).unwrap();
             let rows = (0..active_rows).collect();

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -1,7 +1,7 @@
 //! Testing utilities
 
 use crate::{
-    copy_circuit::{CopyCircuit, ExternalData},
+    copy_circuit::CopyCircuit,
     evm_circuit::EvmCircuit,
     state_circuit::StateCircuit,
     util::{log2_ceil, SubCircuit},
@@ -249,8 +249,10 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
 
         // Run copy circuit test
         {
-            let (active_rows, _max_rows) = CopyCircuit::<Fr>::min_num_rows_block(&block);
-            let k = block.get_test_degree();
+            let (active_rows, max_rows) = CopyCircuit::<Fr>::min_num_rows_block(&block);
+            let k1 = block.get_test_degree();
+            let k2 = log2_ceil(max_rows + NUM_BLINDING_ROWS);
+            let k = k1.max(k2);
             let copy_circuit = CopyCircuit::<Fr>::new_from_block(&block);
             let instance = copy_circuit.instance();
             let prover = MockProver::<Fr>::run(k, &copy_circuit, instance).unwrap();

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -242,9 +242,9 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
 
         // Run copy circuit test
         {
-            let active_rows = CopyCircuit::<Fr>::min_num_rows_block(&block).0;
-            let k = log2_ceil(active_rows);
-            let copy_circuit = CopyCircuit::<Fr>::new(block.copy_events, params.max_copy_rows);
+            let (active_rows, max_rows) = CopyCircuit::<Fr>::min_num_rows_block(&block);
+            let k = log2_ceil(max_rows);
+            let copy_circuit = CopyCircuit::<Fr>::new(block.copy_events, max_rows);
             let instance = copy_circuit.instance();
             let prover = MockProver::<Fr>::run(k, &copy_circuit, instance).unwrap();
             let rows = (0..active_rows).collect();

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -242,13 +242,12 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
 
         // Run copy circuit test
         {
-            let rows_needed = CopyCircuit::<Fr>::min_num_rows_block(&block).1;
-            let k = log2_ceil(rows_needed);
+            let active_rows = CopyCircuit::<Fr>::min_num_rows_block(&block).0;
+            let k = log2_ceil(active_rows);
             let copy_circuit = CopyCircuit::<Fr>::new(block.copy_events, params.max_copy_rows);
             let instance = copy_circuit.instance();
             let prover = MockProver::<Fr>::run(k, &copy_circuit, instance).unwrap();
-            let copy_events_len = copy_circuit.copy_events.len();
-            let rows = (params.max_copy_rows - copy_events_len..params.max_copy_rows).collect();
+            let rows = (0..active_rows).collect();
 
             self.state_checks.as_ref()(prover, &rows, &rows);
         }


### PR DESCRIPTION
### Description

Added test case for `CopyCircuit` 

### Issue Link

https://github.com/scroll-tech/zkevm-circuits/issues/491

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- Added test case for `CopyCircuit`

### Rationale

The `CopyCircuit` was introduced to represent the copy operation during the EVM execution. A test case was missing for this circuit. This PR adds a test case for `CopyCircuit`.

### How Has This Been Tested?

N/A