### PR TITLE
Support EIP-3855 (PUSH0 instruction) for Shanghai

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -497,7 +497,7 @@ impl<'a> CircuitInputBuilder {
                 state_ref.block_ctx.rwc.0,
                 state_ref.call().map(|c| c.call_id).unwrap_or(0),
                 state_ref.call_ctx()?.memory.len(),
-                if geth_step.op.is_push() {
+                if geth_step.op.is_push_with_data() {
                     format!("{:?}", geth_trace.struct_logs[index + 1].stack.last())
                 } else if geth_step.op.is_call_without_value() {
                     format!(

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -153,11 +153,12 @@ type FnGenAssociatedOps = fn(
 ) -> Result<Vec<ExecStep>, Error>;
 
 fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
-    if opcode_id.is_push() {
+    if opcode_id.is_push_with_data() {
         return StackOnlyOpcode::<0, 1>::gen_associated_ops;
     }
 
     match opcode_id {
+        OpcodeId::PUSH0 => StackOnlyOpcode::<0, 0>::gen_associated_ops,
         OpcodeId::STOP => Stop::gen_associated_ops,
         OpcodeId::ADD => StackOnlyOpcode::<2, 1>::gen_associated_ops,
         OpcodeId::MUL => StackOnlyOpcode::<2, 1>::gen_associated_ops,

--- a/eth-types/src/bytecode.rs
+++ b/eth-types/src/bytecode.rs
@@ -94,9 +94,9 @@ impl Bytecode {
         self
     }
 
-    /// Push
+    /// Push, value is useless for `PUSH0`
     pub fn push<T: ToWord>(&mut self, n: u8, value: T) -> &mut Self {
-        debug_assert!((1..=32).contains(&n), "invalid push");
+        debug_assert!((..=32).contains(&n), "invalid push");
         let value = value.to_word();
 
         // Write the op code
@@ -163,7 +163,7 @@ impl Bytecode {
     pub fn append_asm(&mut self, op: &str) -> Result<(), Error> {
         match OpcodeWithData::from_str(op)? {
             OpcodeWithData::Opcode(op) => self.write_op(op),
-            OpcodeWithData::Push(n, value) => self.push(n, value),
+            OpcodeWithData::PushWithData(n, value) => self.push(n, value),
         };
         Ok(())
     }
@@ -174,7 +174,7 @@ impl Bytecode {
             OpcodeWithData::Opcode(opcode) => {
                 self.write_op(opcode);
             }
-            OpcodeWithData::Push(n, word) => {
+            OpcodeWithData::PushWithData(n, word) => {
                 self.push(n, word);
             }
         }
@@ -196,10 +196,10 @@ impl Bytecode {
 /// An ASM entry
 #[derive(Clone, PartialEq, Eq)]
 pub enum OpcodeWithData {
-    /// A non-push opcode
+    /// A `PUSH0` or non-push opcode
     Opcode(OpcodeId),
-    /// A push opcode
-    Push(u8, Word),
+    /// A `PUSH1` .. `PUSH32` opcode
+    PushWithData(u8, Word),
 }
 
 impl OpcodeWithData {
@@ -207,7 +207,7 @@ impl OpcodeWithData {
     pub fn opcode(&self) -> OpcodeId {
         match self {
             OpcodeWithData::Opcode(op) => *op,
-            OpcodeWithData::Push(n, _) => OpcodeId::push_n(*n).expect("valid push size"),
+            OpcodeWithData::PushWithData(n, _) => OpcodeId::push_n(*n).expect("valid push size"),
         }
     }
 }
@@ -218,23 +218,29 @@ impl FromStr for OpcodeWithData {
     #[allow(clippy::manual_range_contains)]
     fn from_str(op: &str) -> Result<Self, Self::Err> {
         let err = || Error::InvalidAsmError(op.to_string());
+
         if let Some(push) = op.strip_prefix("PUSH") {
             let n_value: Vec<_> = push.splitn(3, ['(', ')']).collect();
             let n = n_value[0].parse::<u8>().map_err(|_| err())?;
-            if n < 1 || n > 32 {
+            if n > 32 {
                 return Err(err());
             }
-            let value = if n_value[1].starts_with("0x") {
-                Word::from_str_radix(&n_value[1][2..], 16)
-            } else {
-                Word::from_str_radix(n_value[1], 10)
+
+            // Parse `PUSH0` below only for shanghai (otherwise as an invalid opcode).
+            if n > 0 {
+                let value = if n_value[1].starts_with("0x") {
+                    Word::from_str_radix(&n_value[1][2..], 16)
+                } else {
+                    Word::from_str_radix(n_value[1], 10)
+                }
+                .map_err(|_| err())?;
+
+                return Ok(OpcodeWithData::PushWithData(n, value));
             }
-            .map_err(|_| err())?;
-            Ok(OpcodeWithData::Push(n, value))
-        } else {
-            let opcode = OpcodeId::from_str(op).map_err(|_| err())?;
-            Ok(OpcodeWithData::Opcode(opcode))
         }
+
+        let opcode = OpcodeId::from_str(op).map_err(|_| err())?;
+        Ok(OpcodeWithData::Opcode(opcode))
     }
 }
 
@@ -242,7 +248,7 @@ impl ToString for OpcodeWithData {
     fn to_string(&self) -> String {
         match self {
             OpcodeWithData::Opcode(opcode) => format!("{:?}", opcode),
-            OpcodeWithData::Push(n, word) => format!("PUSH{}({})", n, word),
+            OpcodeWithData::PushWithData(n, word) => format!("PUSH{}({})", n, word),
         }
     }
 }
@@ -255,13 +261,16 @@ impl<'a> Iterator for BytecodeIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|byte| {
             let op = OpcodeId::from(byte.value);
-            if op.is_push() {
-                let n = op.data_len();
+            let n = op.data_len();
+            if n > 0 {
+                assert!(op.is_push_with_data());
+
                 let mut value = vec![0u8; n];
                 for value_byte in value.iter_mut() {
                     *value_byte = self.0.next().unwrap().value;
                 }
-                OpcodeWithData::Push(n as u8, Word::from(value.as_slice()))
+
+                OpcodeWithData::PushWithData(n as u8, Word::from(value.as_slice()))
             } else {
                 OpcodeWithData::Opcode(op)
             }
@@ -277,7 +286,7 @@ impl From<Vec<u8>> for Bytecode {
         while let Some(byte) = input_iter.next() {
             let op = OpcodeId::from(*byte);
             code.write_op(op);
-            if op.is_push() {
+            if op.is_push_with_data() {
                 let n = op.postfix().expect("opcode with postfix");
                 for _ in 0..n {
                     match input_iter.next() {
@@ -315,14 +324,14 @@ macro_rules! bytecode_internal {
     ($code:ident, ) => {};
     // PUSHX op codes
     ($code:ident, $x:ident ($v:expr) $($rest:tt)*) => {{
-        debug_assert!($crate::evm_types::OpcodeId::$x.is_push(), "invalid push");
+        debug_assert!($crate::evm_types::OpcodeId::$x.is_push_with_data(), "invalid push");
         let n = $crate::evm_types::OpcodeId::$x.postfix().expect("opcode with postfix");
         $code.push(n, $v);
         $crate::bytecode_internal!($code, $($rest)*);
     }};
     // Default opcode without any inputs
     ($code:ident, $x:ident $($rest:tt)*) => {{
-        debug_assert!(!$crate::evm_types::OpcodeId::$x.is_push(), "invalid push");
+        debug_assert!(!$crate::evm_types::OpcodeId::$x.is_push_with_data(), "invalid push");
         $code.write_op($crate::evm_types::OpcodeId::$x);
         $crate::bytecode_internal!($code, $($rest)*);
     }};
@@ -336,6 +345,13 @@ macro_rules! bytecode_internal {
         $code.$function($($args,)*);
         $crate::bytecode_internal!($code, $($rest)*);
     }};
+}
+
+impl Bytecode {
+    /// Helper function for `PUSH0`
+    pub fn op_push0(&mut self) -> &mut Self {
+        self.push(0, Word::zero())
+    }
 }
 
 macro_rules! impl_push_n {
@@ -538,6 +554,8 @@ mod tests {
     #[test]
     fn test_bytecode_roundtrip() {
         let code = bytecode! {
+            PUSH0
+            POP
             PUSH8(0x123)
             POP
             PUSH24(0x321)
@@ -556,6 +574,28 @@ mod tests {
     #[test]
     fn test_asm_disasm() {
         let code = bytecode! {
+            PUSH1(5)
+            PUSH2(0xa)
+            MUL
+            STOP
+        };
+        let mut code2 = Bytecode::default();
+        code.iter()
+            .map(|op| op.to_string())
+            .map(|op| OpcodeWithData::from_str(&op).unwrap())
+            .for_each(|op| {
+                code2.append_op(op);
+            });
+
+        assert_eq!(code.code, code2.code);
+    }
+
+    #[cfg(feature = "shanghai")]
+    #[test]
+    fn test_asm_disasm_for_shanghai() {
+        let code = bytecode! {
+            PUSH0
+            POP
             PUSH1(5)
             PUSH2(0xa)
             MUL

--- a/eth-types/src/evm_types/opcode_ids.rs
+++ b/eth-types/src/evm_types/opcode_ids.rs
@@ -95,6 +95,8 @@ pub enum OpcodeId {
     JUMPDEST,
 
     // PUSHn
+    /// `PUSH0`
+    PUSH0,
     /// `PUSH1`
     PUSH1,
     /// `PUSH2`
@@ -315,8 +317,19 @@ pub enum OpcodeId {
 }
 
 impl OpcodeId {
+    #[cfg(feature = "shanghai")]
+    /// Returns `true` if the `OpcodeId` is a `PUSHn` (including `PUSH0`).
+    pub fn is_push(&self) -> bool {
+        self.as_u8() >= Self::PUSH0.as_u8() && self.as_u8() <= Self::PUSH32.as_u8()
+    }
+    #[cfg(not(feature = "shanghai"))]
     /// Returns `true` if the `OpcodeId` is a `PUSHn`.
     pub fn is_push(&self) -> bool {
+        self.as_u8() >= Self::PUSH1.as_u8() && self.as_u8() <= Self::PUSH32.as_u8()
+    }
+
+    /// Returns `true` if the `OpcodeId` is a `PUSH1` .. `PUSH32` (excluding `PUSH0`).
+    pub fn is_push_with_data(&self) -> bool {
         self.as_u8() >= Self::PUSH1.as_u8() && self.as_u8() <= Self::PUSH32.as_u8()
     }
 
@@ -412,6 +425,7 @@ impl OpcodeId {
             OpcodeId::PC => 0x58u8,
             OpcodeId::MSIZE => 0x59u8,
             OpcodeId::JUMPDEST => 0x5bu8,
+            OpcodeId::PUSH0 => 0x5fu8,
             OpcodeId::PUSH1 => 0x60u8,
             OpcodeId::PUSH2 => 0x61u8,
             OpcodeId::PUSH3 => 0x62u8,
@@ -590,6 +604,7 @@ impl OpcodeId {
             OpcodeId::MSIZE => GasCost::QUICK,
             OpcodeId::GAS => GasCost::QUICK,
             OpcodeId::JUMPDEST => GasCost::ONE,
+            OpcodeId::PUSH0 => GasCost::QUICK,
             OpcodeId::PUSH1 => GasCost::FASTEST,
             OpcodeId::PUSH2 => GasCost::FASTEST,
             OpcodeId::PUSH3 => GasCost::FASTEST,
@@ -744,6 +759,7 @@ impl OpcodeId {
             OpcodeId::MSIZE => (1, 1024),
             OpcodeId::GAS => (1, 1024),
             OpcodeId::JUMPDEST => (0, 1024),
+            OpcodeId::PUSH0 => (1, 1024),
             OpcodeId::PUSH1 => (1, 1024),
             OpcodeId::PUSH2 => (1, 1024),
             OpcodeId::PUSH3 => (1, 1024),
@@ -850,8 +866,10 @@ impl OpcodeId {
 
     /// Returns PUSHn opcode from parameter n.
     pub fn push_n(n: u8) -> Result<Self, Error> {
-        if (1..=32).contains(&n) {
-            Ok(OpcodeId::from(OpcodeId::PUSH1.as_u8() + n - 1))
+        let op = OpcodeId::from(OpcodeId::PUSH0.as_u8().checked_add(n).unwrap_or_default());
+
+        if op.is_push() {
+            Ok(op)
         } else {
             Err(Error::InvalidOpConversion)
         }
@@ -860,7 +878,7 @@ impl OpcodeId {
     /// If operation has postfix returns it, otherwise None.
     pub fn postfix(&self) -> Option<u8> {
         if self.is_push() {
-            Some(self.as_u8() - OpcodeId::PUSH1.as_u8() + 1)
+            Some(self.as_u8() - OpcodeId::PUSH0.as_u8())
         } else if self.is_dup() {
             Some(self.as_u8() - OpcodeId::DUP1.as_u8() + 1)
         } else if self.is_swap() {
@@ -873,10 +891,10 @@ impl OpcodeId {
     }
 
     /// Returns number of bytes used by immediate data. This is > 0 only for
-    /// push opcodes.
+    /// `PUSH1` .. `PUSH32` opcodes.
     pub fn data_len(&self) -> usize {
-        if self.is_push() {
-            (self.as_u8() - OpcodeId::PUSH1.as_u8() + 1) as usize
+        if self.is_push_with_data() {
+            (self.as_u8() - OpcodeId::PUSH0.as_u8()) as usize
         } else {
             0
         }
@@ -946,6 +964,8 @@ impl From<u8> for OpcodeId {
             0x58u8 => OpcodeId::PC,
             0x59u8 => OpcodeId::MSIZE,
             0x5bu8 => OpcodeId::JUMPDEST,
+            #[cfg(feature = "shanghai")]
+            0x5fu8 => OpcodeId::PUSH0,
             0x60u8 => OpcodeId::PUSH1,
             0x61u8 => OpcodeId::PUSH2,
             0x62u8 => OpcodeId::PUSH3,
@@ -1100,6 +1120,10 @@ impl FromStr for OpcodeId {
             "PC" => OpcodeId::PC,
             "MSIZE" => OpcodeId::MSIZE,
             "JUMPDEST" => OpcodeId::JUMPDEST,
+            #[cfg(feature = "shanghai")]
+            "PUSH0" => OpcodeId::PUSH0,
+            #[cfg(not(feature = "shanghai"))]
+            "PUSH0" => OpcodeId::INVALID(0x5f),
             "PUSH1" => OpcodeId::PUSH1,
             "PUSH2" => OpcodeId::PUSH2,
             "PUSH3" => OpcodeId::PUSH3,
@@ -1167,7 +1191,6 @@ impl FromStr for OpcodeId {
             "RETURN" => OpcodeId::RETURN,
             "REVERT" => OpcodeId::REVERT,
             "INVALID" => OpcodeId::INVALID(0xfe),
-            "PUSH0" => OpcodeId::INVALID(0x5f),
             "SHA3" | "KECCAK256" => OpcodeId::SHA3,
             "ADDRESS" => OpcodeId::ADDRESS,
             "BALANCE" => OpcodeId::BALANCE,
@@ -1248,20 +1271,27 @@ mod opcode_ids_tests {
 
     #[test]
     fn push_n() {
+        #[cfg(feature = "shanghai")]
+        assert!(matches!(OpcodeId::push_n(0), Ok(OpcodeId::PUSH0)));
+        #[cfg(not(feature = "shanghai"))]
+        assert!(matches!(
+            OpcodeId::push_n(0),
+            Err(Error::InvalidOpConversion)
+        ));
         assert!(matches!(OpcodeId::push_n(1), Ok(OpcodeId::PUSH1)));
         assert!(matches!(OpcodeId::push_n(10), Ok(OpcodeId::PUSH10)));
         assert!(matches!(
             OpcodeId::push_n(100),
             Err(Error::InvalidOpConversion)
         ));
-        assert!(matches!(
-            OpcodeId::push_n(0),
-            Err(Error::InvalidOpConversion)
-        ));
     }
 
     #[test]
     fn postfix() {
+        #[cfg(feature = "shanghai")]
+        assert_eq!(OpcodeId::PUSH0.postfix(), Some(0));
+        #[cfg(not(feature = "shanghai"))]
+        assert_eq!(OpcodeId::PUSH0.postfix(), None);
         assert_eq!(OpcodeId::PUSH1.postfix(), Some(1));
         assert_eq!(OpcodeId::PUSH10.postfix(), Some(10));
         assert_eq!(OpcodeId::LOG2.postfix(), Some(2));
@@ -1270,6 +1300,7 @@ mod opcode_ids_tests {
 
     #[test]
     fn data_len() {
+        assert_eq!(OpcodeId::PUSH0.data_len(), 0);
         assert_eq!(OpcodeId::PUSH1.data_len(), 1);
         assert_eq!(OpcodeId::PUSH10.data_len(), 10);
         assert_eq!(OpcodeId::LOG2.data_len(), 0);

--- a/zkevm-circuits/src/bytecode_circuit/circuit.rs
+++ b/zkevm-circuits/src/bytecode_circuit/circuit.rs
@@ -867,9 +867,9 @@ impl<F: Field> BytecodeCircuitConfig<F> {
     /// load fixed tables
     pub(crate) fn load_aux_tables(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
         // push table: BYTE -> NUM_PUSHED:
-        // [0, OpcodeId::PUSH1] -> 0
-        // [OpcodeId::PUSH1, OpcodeId::PUSH32] -> [1..32]
-        // [OpcodeId::PUSH32, 256] -> 0
+        // byte < OpcodeId::PUSH1 -> 0
+        // byte >= OpcodeId::PUSH1 and byte <= OpcodeId::PUSH32 -> [1..32]
+        // byte > OpcodeId::PUSH32 and byte < 256 -> 0
         layouter.assign_region(
             || "push table",
             |mut region| {

--- a/zkevm-circuits/src/bytecode_circuit/test.rs
+++ b/zkevm-circuits/src/bytecode_circuit/test.rs
@@ -2,7 +2,7 @@
 use crate::{
     bytecode_circuit::{bytecode_unroller::*, circuit::BytecodeCircuit},
     table::BytecodeFieldTag,
-    util::{is_push, keccak, unusable_rows, Challenges, SubCircuit},
+    util::{is_push_with_data, keccak, unusable_rows, Challenges, SubCircuit},
 };
 use bus_mapping::{evm::OpcodeId, state_db::CodeDB};
 use eth_types::{Bytecode, Field, ToWord, Word};
@@ -64,7 +64,7 @@ fn bytecode_unrolling() {
     let mut bytecode = Bytecode::default();
     // First add all non-push bytes, which should all be seen as code
     for byte in 0u8..=255u8 {
-        if !is_push(byte) {
+        if !is_push_with_data(byte) {
             bytecode.write(byte, true);
             rows.push(BytecodeRow {
                 code_hash: Word::zero(),
@@ -87,7 +87,7 @@ fn bytecode_unrolling() {
             tag: Fr::from(BytecodeFieldTag::Byte as u64),
             index: Fr::from(rows.len() as u64),
             is_code: Fr::from(true as u64),
-            value: Fr::from(OpcodeId::PUSH1.as_u64() + ((n - 1) as u64)),
+            value: Fr::from(OpcodeId::PUSH0.as_u64() + n as u64),
         });
         for _ in 0..n {
             rows.push(BytecodeRow {

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_opcode.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_opcode.rs
@@ -84,7 +84,7 @@ mod test {
             vec![0xf6],
             vec![0xfe],
             // Multiple invalid opcodes
-            vec![0x5c, 0x5e, 0x5f],
+            vec![0x5c, 0x5e],
         ];
     }
 
@@ -108,6 +108,16 @@ mod test {
         let selfdestruct_opcode = 0xff_u8;
         test_root_ok(&[selfdestruct_opcode]);
         test_internal_ok(0x20, 0x00, &[selfdestruct_opcode]);
+    }
+
+    #[cfg(not(feature = "shanghai"))]
+    #[test]
+    fn invalid_opcode_push0_for_not_shanghai() {
+        // Should test with logs in `assign_exec_step`, otherwise it could also
+        // pass (since PushGadget).
+        let push0 = 0x5f;
+        test_root_ok(&[push0]);
+        test_internal_ok(0x20, 0x00, &[push0]);
     }
 
     fn test_root_ok(invalid_code: &[u8]) {

--- a/zkevm-circuits/src/evm_circuit/execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push.rs
@@ -8,21 +8,23 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            sum, CachedRegion, Cell, Word,
+            math_gadget::IsZeroGadget,
+            not, select, sum, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use array_init::array_init;
-use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
+use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian, U256};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct PushGadget<F> {
     same_context: SameContextGadget<F>,
+    is_push0: IsZeroGadget<F>,
     value: Word<F>,
-    selectors: [Cell<F>; 31],
+    selectors: [Cell<F>; 32],
 }
 
 impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
@@ -33,10 +35,22 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
+        let is_push0 = IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::PUSH0.expr());
+
         let value = cb.query_word_rlc();
+        cb.condition(not::expr(is_push0.expr()), |cb| cb.stack_push(value.expr()));
+
         // Query selectors for each opcode_lookup
         let selectors = array_init(|_| cb.query_bool());
 
+        // TODO:
+        // The below constraints are failed when running test case
+        // `push_gadget_out_of_range`. It seems that we cannot check the exact
+        // length of `n` data bytes followed by `PUSHn` opcode. Since even if the
+        // code ends with PUSH32 should succeed to run.
+        // <https://github.com/ethereum/go-ethereum/blob/master/core/vm/analysis.go#L66>
+        // <https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/43c67c91ca566fd2b7f3588979c537006090f185/eth-types/src/bytecode.rs#L288>
+        //
         // The pushed bytes are viewed as left-padded big-endian, but our random
         // linear combination uses little-endian, so we lookup from the LSB
         // which has index (program_counter + num_pushed), and then move left
@@ -51,19 +65,16 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
         //   [byte31,     ...,     byte2,     byte1,     byte0]
         //
         // for idx in 0..32 {
-        // let byte = &value.cells[idx];
-        // let index = cb.curr.state.program_counter.expr() + opcode.expr()
-        // - (OpcodeId::PUSH1.as_u8() - 1 + idx as u8).expr();
-        // if idx == 0 {
-        // cb.opcode_lookup_at(index, byte.expr(), 0.expr())
-        // } else {
-        // cb.condition(selectors[idx - 1].expr(), |cb| {
-        // cb.opcode_lookup_at(index, byte.expr(), 0.expr())
-        // });
-        // }
+        //     let byte = &value.cells[idx];
+        //     let index = cb.curr.state.program_counter.expr() + opcode.expr()
+        //         - (OpcodeId::PUSH0.as_u8() + idx as u8).expr();
+
+        //     cb.condition(selectors[idx].expr(), |cb| {
+        //         cb.opcode_lookup_at(index, byte.expr(), 0.expr())
+        //     });
         // }
 
-        for idx in 0..31 {
+        for idx in 0..32 {
             let selector_prev = if idx == 0 {
                 // First selector will always be 1
                 1.expr()
@@ -79,13 +90,13 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
             // byte should be 0 when selector is 0
             cb.require_zero(
                 "Constrain byte == 0 when selector == 0",
-                value.cells[idx + 1].expr() * (1.expr() - selectors[idx].expr()),
+                value.cells[idx].expr() * (1.expr() - selectors[idx].expr()),
             );
         }
 
-        // Deduce the number of additional bytes to push than PUSH1. Note that
-        // num_additional_pushed = n - 1 where n is the suffix number of PUSH*.
-        let num_additional_pushed = opcode.expr() - OpcodeId::PUSH1.as_u64().expr();
+        // Deduce the number of additional bytes to push than PUSH0. Note that
+        // num_additional_pushed = n where n is the suffix number of PUSH*.
+        let num_additional_pushed = opcode.expr() - OpcodeId::PUSH0.as_u64().expr();
         // Sum of selectors needs to be exactly the number of additional bytes
         // that needs to be pushed.
         cb.require_equal(
@@ -94,22 +105,28 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
             num_additional_pushed,
         );
 
-        // Push the value on the stack
-        cb.stack_push(value.expr());
+        let rw_counter = Delta(select::expr(is_push0.expr(), 0.expr(), 1.expr()));
+        let program_counter = Delta(opcode.expr() - (OpcodeId::PUSH0.as_u64() - 1).expr());
+        let stack_pointer = Delta((-1).expr());
+        let gas_left = Delta(select::expr(
+            is_push0.expr(),
+            -OpcodeId::PUSH0.constant_gas_cost().expr(),
+            -OpcodeId::PUSH1.constant_gas_cost().expr(),
+        ));
 
         // State transition
-        // `program_counter` needs to be increased by number of bytes pushed + 1
         let step_state_transition = StepStateTransition {
-            rw_counter: Delta(1.expr()),
-            program_counter: Delta(opcode.expr() - (OpcodeId::PUSH1.as_u64() - 2).expr()),
-            stack_pointer: Delta((-1).expr()),
-            gas_left: Delta(-OpcodeId::PUSH1.constant_gas_cost().expr()),
+            rw_counter,
+            program_counter,
+            stack_pointer,
+            gas_left,
             ..Default::default()
         };
         let same_context = SameContextGadget::construct(cb, opcode, step_state_transition);
 
         Self {
             same_context,
+            is_push0,
             value,
             selectors,
         }
@@ -127,12 +144,21 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let opcode = step.opcode.unwrap();
+        self.is_push0.assign(
+            region,
+            offset,
+            F::from(opcode.as_u64()) - F::from(OpcodeId::PUSH0.as_u64()),
+        )?;
 
-        let value = block.rws[step.rw_indices[0]].stack_value();
+        let value = if opcode.is_push_with_data() {
+            block.rws[step.rw_indices[0]].stack_value()
+        } else {
+            U256::zero()
+        };
         self.value
             .assign(region, offset, Some(value.to_le_bytes()))?;
 
-        let num_additional_pushed = opcode.postfix().expect("opcode with postfix") - 1;
+        let num_additional_pushed = opcode.postfix().expect("opcode with postfix");
         for (idx, selector) in self.selectors.iter().enumerate() {
             selector.assign(
                 region,
@@ -170,6 +196,8 @@ mod test {
 
     #[test]
     fn push_gadget_simple() {
+        #[cfg(feature = "shanghai")]
+        test_ok(OpcodeId::PUSH0, &[]);
         test_ok(OpcodeId::PUSH1, &[1]);
         test_ok(OpcodeId::PUSH2, &[1, 2]);
         test_ok(

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -76,7 +76,7 @@ pub enum ExecutionState {
     MSIZE,
     GAS,
     JUMPDEST,
-    PUSH, // PUSH1, PUSH2, ..., PUSH32
+    PUSH, // PUSH0, PUSH1, PUSH2, ..., PUSH32
     DUP,  // DUP1, DUP2, ..., DUP16
     SWAP, // SWAP1, SWAP2, ..., SWAP16
     LOG,  // LOG0, LOG1, ..., LOG4
@@ -225,6 +225,7 @@ impl ExecutionState {
             Self::GAS => vec![OpcodeId::GAS],
             Self::JUMPDEST => vec![OpcodeId::JUMPDEST],
             Self::PUSH => vec![
+                OpcodeId::PUSH0,
                 OpcodeId::PUSH1,
                 OpcodeId::PUSH2,
                 OpcodeId::PUSH3,

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -256,13 +256,13 @@ pub(crate) fn keccak(msg: &[u8]) -> Word {
     Word::from_big_endian(keccak.digest().as_slice())
 }
 
-pub(crate) fn is_push(byte: u8) -> bool {
-    OpcodeId::from(byte).is_push()
+pub(crate) fn is_push_with_data(byte: u8) -> bool {
+    OpcodeId::from(byte).is_push_with_data()
 }
 
 pub(crate) fn get_push_size(byte: u8) -> u64 {
-    if is_push(byte) {
-        byte as u64 - OpcodeId::PUSH1.as_u64() + 1
+    if is_push_with_data(byte) {
+        byte as u64 - OpcodeId::PUSH0.as_u64()
     } else {
         0u64
     }

--- a/zkevm-circuits/src/witness/bytecode.rs
+++ b/zkevm-circuits/src/witness/bytecode.rs
@@ -70,8 +70,8 @@ impl Bytecode {
             if push_data_left > 0 {
                 is_code = false;
                 push_data_left -= 1;
-            } else if (OpcodeId::PUSH1.as_u8()..=OpcodeId::PUSH32.as_u8()).contains(byte) {
-                push_data_left = *byte as usize - (OpcodeId::PUSH1.as_u8() - 1) as usize;
+            } else if (OpcodeId::PUSH0.as_u8()..=OpcodeId::PUSH32.as_u8()).contains(byte) {
+                push_data_left = *byte as usize - OpcodeId::PUSH0.as_u8() as usize;
             }
 
             if idx == dest {

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -164,7 +164,6 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
                     OpcodeId::NOT => ExecutionState::NOT,
                     OpcodeId::EXP => ExecutionState::EXP,
                     OpcodeId::POP => ExecutionState::POP,
-                    OpcodeId::PUSH32 => ExecutionState::PUSH,
                     OpcodeId::BYTE => ExecutionState::BYTE,
                     OpcodeId::MLOAD => ExecutionState::MEMORY,
                     OpcodeId::MSTORE => ExecutionState::MEMORY,


### PR DESCRIPTION
### Summary

1. Add `PUSH0` to `opcode_ids.rs` of `eth-types`. PUSH0 could be parsed from `0x5f` and PUSH0 string only for Shanghai, otherwise as an invalid opcode (`OpcodeId::INVALID(0x5f)`).

2. In `eth-types`, update `is_push` function to return true for PUSH0 .. PUSH32 (only for Shanghai). And add a new function `is_push_with_data`, it returns true for PUSH1 .. PUSH32.

3. Small fixes to replace `PUSH1 - 1` with `PUSH0` directly.

4. Update `ExecutionState::Push` and `PushGadget` to support `PUSH0`.

5. Add test cases to `PushGadget` and `ErrorInvalidOpcodeGadget`.

### Issue

https://github.com/scroll-tech/zkevm-circuits/issues/504

Upstream draft PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1361

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Test

Add `PUSH0` test to `PushGadget` only for Shanghai.
Add a new test case `invalid_opcode_push0_for_not_shanghai` to `ErrorInvalidOpcodeGadget` (only for not Shanghai).

```
cargo test -- --nocapture push_gadget invalid_opcode
cargo test --features shanghai -- --nocapture push_gadget invalid_opcode
```