### PR TITLE
fix failed `testool` cases of precompile PR

### DIFF
--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -384,7 +384,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
 
                 // write the result in the callee's memory.
                 let rw_counter_start = state.block_ctx.rwc;
-                if call.is_success() && call.call_data_length > 0 && length > 0 {
+                if call.is_success() && call.call_data_length > 0 && !result.is_empty() {
                     let bytes: Vec<(u8, bool)> = result.iter().map(|b| (*b, false)).collect();
                     for (i, &(byte, _is_code)) in bytes.iter().enumerate() {
                         // push callee memory write


### PR DESCRIPTION
### Summary

1. Fix to check precompile `result.len()` when do precompile copy in bus-mapping.
2. Check `cd_length (caller.call_data_length) > 0` for precompile and output bytes in zkevm-circuits.

With this fix, remains `32` failed cases (not all related with precompile):
https://circuit-release.s3.us-west-2.amazonaws.com/testool/default.1686128189.0fd067f.html