### PR TITLE
Set empty keccak codehash when account comes into existence

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -5,6 +5,8 @@ use super::{
     CallKind, CodeSource, CopyEvent, ExecState, ExecStep, ExpEvent, Transaction,
     TransactionContext,
 };
+#[cfg(feature = "scroll")]
+use crate::util::KECCAK_CODE_HASH_ZERO;
 use crate::{
     error::{
         get_step_reported_error, ContractAddressCollisionError, DepthError, ExecError,
@@ -587,6 +589,16 @@ impl<'a> CircuitInputStateRef<'a> {
                     address: receiver,
                     field: AccountField::CodeHash,
                     value: CodeDB::empty_code_hash().to_word(),
+                    value_prev: Word::zero(),
+                },
+            )?;
+            #[cfg(feature = "scroll")]
+            self.push_op_reversible(
+                step,
+                AccountOp {
+                    address: receiver,
+                    field: AccountField::KeccakCodeHash,
+                    value: KECCAK_CODE_HASH_ZERO.to_word(),
                     value_prev: Word::zero(),
                 },
             )?;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -642,6 +642,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let must_create = tx.is_create;
         if (!callee_exists && !tx.value.is_zero()) || must_create {
             callee_code_hash = rws.next().account_codehash_pair().1;
+            #[cfg(feature = "scroll")]
+            let _callee_keccak_code_hash = rws.next();
         }
         let mut caller_balance_sub_value_pair = (zero, zero);
         let mut callee_balance_pair = (zero, zero);

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -619,6 +619,9 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             .assign_value(region, offset, code_hash_previous_rlc)?;
         let is_address_collision = !code_hash_previous.0.is_zero();
 
+        #[cfg(feature = "scroll")]
+        rw_offset += 1; // Write empty Keccak code hash.
+
         if is_precheck_ok == 1 && !is_address_collision {
             let [caller_balance_pair, callee_balance_pair] = if !value.is_zero() {
                 let account_balance_pair = [16, 17]
@@ -667,8 +670,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             Value::known(if is_precheck_ok == 0 || is_address_collision {
                 F::zero()
             } else {
-                block.rws[step.rw_indices
-                    [23 + rw_offset + usize::from(is_create2) + copy_rw_increase + is_precheck_ok]]
+                block.rws[step.rw_indices[23 + rw_offset]]
                     .call_context_value()
                     .to_scalar()
                     .unwrap()

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -620,7 +620,9 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         let is_address_collision = !code_hash_previous.0.is_zero();
 
         #[cfg(feature = "scroll")]
-        rw_offset += 1; // Write empty Keccak code hash.
+        {
+            rw_offset += 1; // Write empty Keccak code hash.
+        }
 
         if is_precheck_ok == 1 && !is_address_collision {
             let [caller_balance_pair, callee_balance_pair] = if !value.is_zero() {

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -667,7 +667,8 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             Value::known(if is_precheck_ok == 0 || is_address_collision {
                 F::zero()
             } else {
-                block.rws[step.rw_indices[23 + rw_offset]]
+                block.rws[step.rw_indices
+                    [23 + rw_offset + usize::from(is_create2) + copy_rw_increase + is_precheck_ok]]
                     .call_context_value()
                     .to_scalar()
                     .unwrap()

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -412,6 +412,14 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
                     0.expr(),
                     Some(reversion_info),
                 );
+                #[cfg(feature = "scroll")]
+                cb.account_write(
+                    receiver_address.clone(),
+                    AccountFieldTag::KeccakCodeHash,
+                    cb.empty_keccak_hash_rlc(),
+                    0.expr(),
+                    Some(reversion_info),
+                );
             },
         );
         // Skip transfer if value == 0
@@ -448,7 +456,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
             self.must_create.clone()]
-        ) * 1.expr() +
+        ) * 2.expr() +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()
@@ -460,7 +468,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
             self.must_create.clone()]
-        ) * 1.expr() +
+        ) * 2.expr() +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()
@@ -542,8 +550,14 @@ impl<F: Field> TransferGadget<F> {
                     0.expr(),
                     Some(reversion_info),
                 );
-                // TODO: also write empty keccak code hash? codesize seems not need yet. write a
-                // test to verify this.
+                #[cfg(feature = "scroll")]
+                cb.account_write(
+                    receiver_address.clone(),
+                    AccountFieldTag::KeccakCodeHash,
+                    cb.empty_keccak_hash_rlc(),
+                    0.expr(),
+                    Some(reversion_info),
+                );
             },
         );
         // Skip transfer if value == 0
@@ -581,22 +595,22 @@ impl<F: Field> TransferGadget<F> {
     }
 
     pub(crate) fn rw_delta(&self) -> Expression<F> {
-        // +1 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // +2 Write Account (receiver) CodeHash (account creation via code_hash update)
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
             self.must_create.clone()]
-        ) * 1.expr() +
+        ) * 2.expr() +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()
     }
 
     pub(crate) fn reversible_w_delta(&self) -> Expression<F> {
-        // +1 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // +2 Write Account (receiver) CodeHash (account creation via code_hash update)
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
-            self.must_create.clone()]
-        ) * 1.expr() +
+            self.must_create.clone(),
+        ]) * 2.expr() +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -453,10 +453,11 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
         // +1 Write Account (sender) Balance (Not Reversible tx fee)
         1.expr() +
         // +1 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // feature = "scroll": +1 Write Account (receiver) KeccakCodeHash
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
             self.must_create.clone()]
-        ) * 2.expr() +
+        ) * if cfg!(feature = "scroll") {2.expr()} else {1.expr()} +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()
@@ -465,10 +466,11 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
     pub(crate) fn reversible_w_delta(&self) -> Expression<F> {
         // NOTE: Write Account (sender) Balance (Not Reversible tx fee)
         // +1 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // feature = "scroll": +1 Write Account (receiver) KeccakCodeHash
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
             self.must_create.clone()]
-        ) * 2.expr() +
+        ) * if cfg!(feature = "scroll") {2.expr()} else {1.expr()} +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()
@@ -595,22 +597,24 @@ impl<F: Field> TransferGadget<F> {
     }
 
     pub(crate) fn rw_delta(&self) -> Expression<F> {
-        // +2 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // +1 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // feature = "scroll": +1 Write Account (receiver) KeccakCodeHash
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
             self.must_create.clone()]
-        ) * 2.expr() +
+        ) * if cfg!(feature = "scroll") {2.expr()} else {1.expr()} +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()
     }
 
     pub(crate) fn reversible_w_delta(&self) -> Expression<F> {
-        // +2 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // +1 Write Account (receiver) CodeHash (account creation via code_hash update)
+        // if feature = "scroll": +1 Write Account (receiver) KeccakCodeHash
         or::expr([
             not::expr(self.value_is_zero.expr()) * not::expr(self.receiver_exists.clone()),
             self.must_create.clone(),
-        ]) * 2.expr() +
+        ]) * if cfg!(feature = "scroll") {2.expr()} else {1.expr()} +
         // +1 Write Account (sender) Balance
         // +1 Write Account (receiver) Balance
         not::expr(self.value_is_zero.expr()) * 2.expr()

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(incomplete_features)]
 // Needed by DummyGadget in evm circuit
 #![feature(adt_const_params)]
+#![feature(stmt_expr_attributes)]
 #![feature(array_zip)]
 // Needed by some builder patterns in testing modules.
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(incomplete_features)]
 // Needed by DummyGadget in evm circuit
 #![feature(adt_const_params)]
-#![feature(stmt_expr_attributes)]
 #![feature(array_zip)]
 // Needed by some builder patterns in testing modules.
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents
Set the keccak code hash (in addition to the poseidon code hash which we already do) when an account comes into existence because of a transfer or create.
