### PR TITLE
Refactor SigCircuit Witness Assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "halo2_proofs",
  "hex",
  "lazy_static",
+ "log",
  "num-bigint",
  "poseidon-circuit",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,6 @@ dependencies = [
  "halo2_proofs",
  "hex",
  "lazy_static",
- "log",
  "num-bigint",
  "poseidon-circuit",
  "rand",

--- a/zkevm-circuits/src/sig_circuit/utils.rs
+++ b/zkevm-circuits/src/sig_circuit/utils.rs
@@ -117,7 +117,7 @@ impl<'v, F: Field> From<&AssignedValueNoTimer<F>> for AssignedValue<'v, F> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct AssignedSignatureVerify<F: Field> {
     pub(crate) address: AssignedValueNoTimer<F>,
     pub(crate) msg_len: usize,

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -2162,9 +2162,9 @@ impl SigTable {
         challenges: &Challenges<Value<F>>,
     ) -> Result<(), Error> {
         layouter.assign_region(
-            || "signature verification table",
+            || "sig table (dev load)",
             |mut region| {
-                let signatures: Vec<SignData> = block.get_sign_data(false)?;
+                let signatures: Vec<SignData> = block.get_sign_data(false);
 
                 for (offset, sign_data) in signatures.iter().enumerate() {
                     let addr: F = sign_data.get_addr().to_scalar().unwrap();


### PR DESCRIPTION
This PR refactors the witness assignment to `SigCircuit`.

The goal is mainly to:
- Remove most `mut` vectors that were populated, instead replace with iterator `map`
- Remove the need for `offset: &mut usize`
- Make `Block -> get_sign_data` infallible, as the overflow condition is checked in witness assignment anyway (dev load is ignored as it is for dev purposes)