### PR TITLE
[memory_opt] fix failed precompile test

### DIFF
--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -357,7 +357,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                 if call.call_data_length > 0 {
                     let copy_steps = state.gen_copy_steps_for_precompile_calldata(
                         &mut exec_step,
-                        call.call_id,
+                        call.caller_id,
                         call.call_data_offset,
                         call.call_data_length,
                         &caller_memory,

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -1822,6 +1822,7 @@ mod test {
             CircuitTestBuilder::new_from_test_ctx(ctx)
                 .params(CircuitsParams {
                     max_rws: test_call.max_rws,
+                    max_copy_rows: 1100,
                     ..Default::default()
                 })
                 .run();


### PR DESCRIPTION
After merging latest `memory_opt` branch into `fix/callop-memory`, the test case `test_precompiled_call` could pass with below small fixes.

Seems that `first access reads` issue could be debugged by [check_value function](https://github.com/scroll-tech/zkevm-circuits/blob/develop/zkevm-circuits/src/witness/rw.rs#L44).

