### PR TITLE
Fix chain ID from Word to Uint64

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -587,14 +587,14 @@ pub fn keccak_inputs(block: &Block, code_db: &CodeDB) -> Result<Vec<Vec<u8>>, Er
     let mut keccak_inputs = Vec::new();
     // Tx Circuit
     let txs: Vec<geth_types::Transaction> = block.txs.iter().map(|tx| tx.into()).collect();
-    keccak_inputs.extend_from_slice(&keccak_inputs_tx_circuit(&txs, block.chain_id().as_u64())?);
+    keccak_inputs.extend_from_slice(&keccak_inputs_tx_circuit(&txs, block.chain_id())?);
     log::debug!(
         "keccak total len after txs: {}",
         keccak_inputs.iter().map(|i| i.len()).sum::<usize>()
     );
     // PI circuit
     keccak_inputs.push(keccak_inputs_pi_circuit(
-        block.chain_id().as_u64(),
+        block.chain_id(),
         block.prev_state_root,
         block.withdraw_root,
         &block.headers,
@@ -827,7 +827,7 @@ type EthBlock = eth_types::Block<eth_types::Transaction>;
 /// the necessary information and using the CircuitInputBuilder.
 pub struct BuilderClient<P: JsonRpcClient> {
     cli: GethClient<P>,
-    chain_id: Word,
+    chain_id: u64,
     circuits_params: CircuitsParams,
 }
 
@@ -895,7 +895,7 @@ impl<P: JsonRpcClient> BuilderClient<P> {
 
         Ok(Self {
             cli: client,
-            chain_id: chain_id.into(),
+            chain_id,
             circuits_params,
         })
     }

--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -7,7 +7,7 @@ use crate::{
     operation::{OperationContainer, RWCounter},
     Error,
 };
-use eth_types::{Address, Hash, ToWord, Word, U256};
+use eth_types::{Address, Hash, ToWord, Word};
 use std::collections::{BTreeMap, HashMap};
 
 /// Context of a [`Block`] which can mutate in a [`Transaction`].
@@ -70,7 +70,7 @@ impl Default for BlockSteps {
 #[derive(Debug, Clone)]
 pub struct BlockHead {
     /// chain id
-    pub chain_id: Word,
+    pub chain_id: u64,
     /// history hashes contains most recent 256 block hashes in history, where
     /// the lastest one is at history_hashes[history_hashes.len() - 1].
     pub history_hashes: Vec<Word>,
@@ -92,7 +92,7 @@ pub struct BlockHead {
 impl BlockHead {
     /// Create a new block.
     pub fn new(
-        chain_id: Word,
+        chain_id: u64,
         history_hashes: Vec<Word>,
         eth_block: &eth_types::Block<eth_types::Transaction>,
     ) -> Result<Self, Error> {
@@ -160,7 +160,7 @@ pub struct Block {
     /// Circuits Setup Paramteres
     pub circuits_params: CircuitsParams,
     /// chain id
-    pub chain_id: Word,
+    pub chain_id: u64,
 }
 
 impl Block {
@@ -187,7 +187,7 @@ impl Block {
     }
     /// Create a new block.
     pub fn new<TX>(
-        chain_id: Word,
+        chain_id: u64,
         history_hashes: Vec<Word>,
         eth_block: &eth_types::Block<eth_types::Transaction>,
         circuits_params: CircuitsParams,
@@ -219,7 +219,7 @@ impl Block {
     }
 
     /// Return the chain id.
-    pub fn chain_id(&self) -> U256 {
+    pub fn chain_id(&self) -> u64 {
         self.chain_id
     }
 

--- a/bus-mapping/src/evm/opcodes/chainid.rs
+++ b/bus-mapping/src/evm/opcodes/chainid.rs
@@ -54,7 +54,7 @@ mod chainid_tests {
             },
             (
                 RW::WRITE,
-                &StackOp::new(1, StackAddress::from(1023), *MOCK_CHAIN_ID)
+                &StackOp::new(1, StackAddress::from(1023), (*MOCK_CHAIN_ID).into())
             )
         );
     }

--- a/bus-mapping/src/mock.rs
+++ b/bus-mapping/src/mock.rs
@@ -20,7 +20,7 @@ pub struct BlockData {
     /// CodeDB
     pub code_db: CodeDB,
     /// chain id
-    pub chain_id: Word,
+    pub chain_id: u64,
     /// history hashes contains most recent 256 block hashes in history, where
     /// the lastest one is at history_hashes[history_hashes.len() - 1].
     pub history_hashes: Vec<Word>,

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -43,13 +43,11 @@ mod tests {
 
         let mut rng = ChaChaRng::seed_from_u64(2);
 
-        let chain_id = (*MOCK_CHAIN_ID).as_u64();
-
         let bytecode = bytecode! {
             STOP
         };
 
-        let wallet_a = LocalWallet::new(&mut rng).with_chain_id(chain_id);
+        let wallet_a = LocalWallet::new(&mut rng).with_chain_id(*MOCK_CHAIN_ID);
 
         let addr_a = wallet_a.address();
         let addr_b = address!("0x000000000000000000000000000000000000BBBB");

--- a/circuit-benchmarks/src/tx_circuit.rs
+++ b/circuit-benchmarks/src/tx_circuit.rs
@@ -80,9 +80,8 @@ mod tests {
 
         let max_txs: usize = 2_usize.pow(degree) / ROWS_PER_TX;
 
-        let chain_id: u64 = mock::MOCK_CHAIN_ID.low_u64();
         let txs = vec![mock::CORRECT_MOCK_TXS[0].clone().into()];
-        let circuit = TxCircuit::<Fr>::new(max_txs, MAX_CALLDATA, chain_id, txs);
+        let circuit = TxCircuit::<Fr>::new(max_txs, MAX_CALLDATA, *mock::MOCK_CHAIN_ID, txs);
         (degree as usize, circuit)
     }
 

--- a/eth-types/src/evm_types/block_utils.rs
+++ b/eth-types/src/evm_types/block_utils.rs
@@ -8,10 +8,10 @@ pub const NUM_PREV_BLOCK_ALLOWED: u64 = 256;
 
 /// Calculate block hash by chain ID and block number (only for scroll).
 /// Return a pair of input and output.
-pub fn calculate_block_hash(chain_id: U256, block_number: U256) -> (Vec<u8>, U256) {
+pub fn calculate_block_hash(chain_id: u64, block_number: U256) -> (Vec<u8>, U256) {
     let mut input = vec![0; 16];
 
-    U64([chain_id.low_u64()]).to_big_endian(&mut input[..8]);
+    U64([chain_id]).to_big_endian(&mut input[..8]);
     U64([block_number.low_u64()]).to_big_endian(&mut input[8..]);
 
     let output = U256::from_big_endian(&keccak256(&input));

--- a/eth-types/src/geth_types.rs
+++ b/eth-types/src/geth_types.rs
@@ -355,7 +355,7 @@ impl Transaction {
 #[derive(Debug, Clone)]
 pub struct GethData {
     /// chain id
-    pub chain_id: Word,
+    pub chain_id: u64,
     /// history hashes contains most recent 256 block hashes in history, where
     /// the lastest one is at history_hashes[history_hashes.len() - 1].
     pub history_hashes: Vec<Word>,
@@ -372,10 +372,10 @@ impl GethData {
     pub fn sign(&mut self, wallets: &HashMap<Address, LocalWallet>) {
         for tx in self.eth_block.transactions.iter_mut() {
             let wallet = wallets.get(&tx.from).unwrap();
-            assert_eq!(Word::from(wallet.chain_id()), self.chain_id);
+            assert_eq!(wallet.chain_id(), self.chain_id);
             let geth_tx: Transaction = (&*tx).into();
             let req: TransactionRequest = (&geth_tx).into();
-            let sig = wallet.sign_transaction_sync(&req.chain_id(self.chain_id.as_u64()).into());
+            let sig = wallet.sign_transaction_sync(&req.chain_id(self.chain_id).into());
             tx.v = U64::from(sig.v);
             tx.r = sig.r;
             tx.s = sig.s;

--- a/external-tracer/src/lib.rs
+++ b/external-tracer/src/lib.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct TraceConfig {
     /// chain id
-    pub chain_id: Word,
+    pub chain_id: u64,
     /// history hashes contains most recent 256 block hashes in history, where
     /// the lastest one is at history_hashes[history_hashes.len() - 1].
     pub history_hashes: Vec<Word>,

--- a/geth-utils/gethutil/trace.go
+++ b/geth-utils/gethutil/trace.go
@@ -115,7 +115,7 @@ type Transaction struct {
 }
 
 type TraceConfig struct {
-	ChainID *hexutil.Big `json:"chain_id"`
+	ChainID uint64 `json:"chain_id"`
 	// HistoryHashes contains most recent 256 block hashes in history,
 	// where the lastest one is at HistoryHashes[len(HistoryHashes)-1].
 	HistoryHashes []*hexutil.Big             `json:"history_hashes"`
@@ -130,7 +130,7 @@ func newUint64(val uint64) *uint64 { return &val }
 
 func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 	chainConfig := params.ChainConfig{
-		ChainID:             toBigInt(config.ChainID),
+		ChainID:             new(big.Int).SetUint64(config.ChainID),
 		HomesteadBlock:      big.NewInt(0),
 		DAOForkBlock:        big.NewInt(0),
 		DAOForkSupport:      true,

--- a/mock/src/block.rs
+++ b/mock/src/block.rs
@@ -34,7 +34,7 @@ pub struct MockBlock {
     // This field is handled here as we assume that all block txs have the same ChainId.
     // Also, the field is stored in the block_table since we don't have a chain_config
     // structure/table.
-    pub(crate) chain_id: Word,
+    pub(crate) chain_id: u64,
 }
 
 impl Default for MockBlock {
@@ -275,7 +275,7 @@ impl MockBlock {
     }
 
     /// Set chain_id field for the MockBlock.
-    pub fn chain_id(&mut self, chain_id: Word) -> &mut Self {
+    pub fn chain_id(&mut self, chain_id: u64) -> &mut Self {
         self.chain_id = chain_id;
         self
     }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -31,7 +31,7 @@ lazy_static! {
      /// Mock GASLIMIT value
     pub static ref MOCK_GASLIMIT: Word = Word::from(0x2386f26fc10000u64);
     /// Mock chain ID value
-    pub static ref MOCK_CHAIN_ID: Word = Word::from(1338u64);
+    pub static ref MOCK_CHAIN_ID: u64 = 1338;
     /// Mock DIFFICULTY value
     pub static ref MOCK_DIFFICULTY: Word = Word::from(0x200000u64);
     /// Mock accounts loaded with ETH to use for test cases.

--- a/mock/src/test_ctx.rs
+++ b/mock/src/test_ctx.rs
@@ -79,7 +79,7 @@ pub use external_tracer::LoggerConfig;
 #[derive(Debug)]
 pub struct TestContext<const NACC: usize, const NTX: usize> {
     /// chain id
-    pub chain_id: Word,
+    pub chain_id: u64,
     /// Account list
     pub accounts: [Account; NACC],
     /// history hashes contains most recent 256 block hashes in history, where
@@ -234,7 +234,7 @@ impl<const NACC: usize, const NTX: usize> TestContext<NACC, NTX> {
 /// Generates execution traces for the transactions included in the provided
 /// Block
 pub fn gen_geth_traces(
-    chain_id: Word,
+    chain_id: u64,
     block: Block<Transaction>,
     accounts: Vec<Account>,
     history_hashes: Option<Vec<Word>>,

--- a/mock/src/transaction.rs
+++ b/mock/src/transaction.rs
@@ -160,7 +160,7 @@ pub struct MockTransaction {
     pub access_list: AccessList,
     pub max_priority_fee_per_gas: Word,
     pub max_fee_per_gas: Word,
-    pub chain_id: Word,
+    pub chain_id: u64,
 }
 
 impl Default for MockTransaction {
@@ -210,7 +210,7 @@ impl From<MockTransaction> for Transaction {
             access_list: Some(mock.access_list),
             max_priority_fee_per_gas: Some(mock.max_priority_fee_per_gas),
             max_fee_per_gas: Some(mock.max_fee_per_gas),
-            chain_id: Some(mock.chain_id),
+            chain_id: Some(mock.chain_id.into()),
             other: OtherFields::default(),
         }
     }
@@ -323,7 +323,7 @@ impl MockTransaction {
     }
 
     /// Set chain_id field for the MockTransaction.
-    pub fn chain_id(&mut self, chain_id: Word) -> &mut Self {
+    pub fn chain_id(&mut self, chain_id: u64) -> &mut Self {
         self.chain_id = chain_id;
         self
     }
@@ -339,7 +339,7 @@ impl MockTransaction {
             .data(self.input.clone())
             .gas(self.gas)
             .gas_price(self.gas_price)
-            .chain_id(self.chain_id.low_u64());
+            .chain_id(self.chain_id);
 
         match (self.v, self.r, self.s) {
             (None, None, None) => {
@@ -348,7 +348,7 @@ impl MockTransaction {
                     let sig = self
                         .from
                         .as_wallet()
-                        .with_chain_id(self.chain_id.low_u64())
+                        .with_chain_id(self.chain_id)
                         .sign_transaction_sync(&tx.into());
                     // Set sig parameters
                     self.sig_data((sig.v, sig.r, sig.s));

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -166,7 +166,7 @@ fn into_traceconfig(st: StateTest) -> (String, TraceConfig, StateTestResult) {
     (
         st.id,
         TraceConfig {
-            chain_id: U256::one(),
+            chain_id: 1,
             history_hashes: vec![U256::from_big_endian(st.env.previous_hash.as_bytes())],
             block_constants: geth_types::BlockConstants {
                 coinbase: st.env.current_coinbase,
@@ -284,7 +284,7 @@ pub fn run_test(
             s: tx.s,
             v: U64::from(tx.v),
             block_number: Some(U64::from(trace_config.block_constants.number.as_u64())),
-            chain_id: Some(trace_config.chain_id),
+            chain_id: Some(trace_config.chain_id.into()),
             ..eth_types::Transaction::default()
         })
         .collect();
@@ -305,7 +305,7 @@ pub fn run_test(
     let mut wallets = HashMap::new();
     wallets.insert(
         wallet.address(),
-        wallet.with_chain_id(trace_config.chain_id.as_u64()),
+        wallet.with_chain_id(trace_config.chain_id),
     );
 
     // process the transaction

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -442,7 +442,7 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
             &block.txs,
             block.circuits_params.max_txs,
             block.circuits_params.max_calldata,
-            block.chain_id.as_u64(),
+            block.chain_id,
             &challenges,
         )?;
         block.rws.check_rw_counter_sanity();

--- a/zkevm-circuits/src/rlp_circuit_fsm.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm.rs
@@ -1843,7 +1843,7 @@ impl<F: Field> SubCircuit<F> for RlpCircuit<F, Transaction> {
         let padding_txs = (block.txs.len()..max_txs)
             .into_iter()
             .map(|i| {
-                let mut tx = Transaction::dummy(block.chain_id.as_u64());
+                let mut tx = Transaction::dummy(block.chain_id);
                 tx.id = i + 1;
                 tx
             })

--- a/zkevm-circuits/src/rlp_circuit_fsm/test.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm/test.rs
@@ -25,7 +25,7 @@ fn get_tx(is_eip155: bool) -> Transaction {
         .gas(word!("0x77320"))
         .nonce(word!("0x7f"));
     if is_eip155 {
-        tx = tx.chain_id(MOCK_CHAIN_ID.as_u64());
+        tx = tx.chain_id(*MOCK_CHAIN_ID);
     }
     let (tx_type, unsigned_bytes) = if is_eip155 {
         (TxType::Eip155, tx.rlp().to_vec())

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -609,7 +609,7 @@ impl<
             &block.txs,
             block.circuits_params.max_txs,
             block.circuits_params.max_calldata,
-            block.chain_id.as_u64(),
+            block.chain_id,
             &challenges,
         )?;
 

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -28,11 +28,9 @@ fn test_super_circuit<
     block: GethData,
     circuits_params: CircuitsParams,
 ) {
+    set_var("CHAIN_ID", MOCK_CHAIN_ID.to_string());
     let mut difficulty_be_bytes = [0u8; 32];
-    let mut chain_id_be_bytes = [0u8; 32];
     MOCK_DIFFICULTY.to_big_endian(&mut difficulty_be_bytes);
-    MOCK_CHAIN_ID.to_big_endian(&mut chain_id_be_bytes);
-    set_var("CHAIN_ID", hex::encode(chain_id_be_bytes));
     set_var("DIFFICULTY", hex::encode(difficulty_be_bytes));
 
     let (k, circuit, instance, _) =
@@ -72,7 +70,7 @@ fn callee_bytecode(is_return: bool, offset: u64, length: u64) -> Bytecode {
 fn block_1tx_deploy() -> GethData {
     let mut rng = ChaCha20Rng::seed_from_u64(2);
 
-    let chain_id = (*MOCK_CHAIN_ID).as_u64();
+    let chain_id = *MOCK_CHAIN_ID;
 
     let wallet_a = LocalWallet::new(&mut rng).with_chain_id(chain_id);
     let addr_a = wallet_a.address();
@@ -100,7 +98,7 @@ fn block_1tx_deploy() -> GethData {
 pub(crate) fn block_1tx() -> GethData {
     let mut rng = ChaCha20Rng::seed_from_u64(2);
 
-    let chain_id = (*MOCK_CHAIN_ID).as_u64();
+    let chain_id = *MOCK_CHAIN_ID;
 
     let bytecode = bytecode! {
         GAS
@@ -141,7 +139,7 @@ pub(crate) fn block_1tx() -> GethData {
 fn block_2tx() -> GethData {
     let mut rng = ChaCha20Rng::seed_from_u64(2);
 
-    let chain_id = (*MOCK_CHAIN_ID).as_u64();
+    let chain_id = *MOCK_CHAIN_ID;
 
     let bytecode = bytecode! {
         GAS

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -1942,7 +1942,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
 
     fn new_from_block(block: &witness::Block<F>) -> Self {
         for tx in &block.txs {
-            if tx.chain_id != block.chain_id.as_u64() {
+            if tx.chain_id != block.chain_id {
                 panic!(
                     "inconsistent chain id, block chain id {}, tx {:?}",
                     block.chain_id, tx.chain_id
@@ -1952,7 +1952,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
         Self::new(
             block.circuits_params.max_txs,
             block.circuits_params.max_calldata,
-            block.chain_id.as_u64(),
+            block.chain_id,
             block.txs.clone(),
         )
     }

--- a/zkevm-circuits/src/tx_circuit/test.rs
+++ b/zkevm-circuits/src/tx_circuit/test.rs
@@ -145,7 +145,7 @@ fn tx_circuit_2tx_2max_tx() {
                 mock_tx.into()
             })
             .collect(),
-            mock::MOCK_CHAIN_ID.as_u64(),
+            *mock::MOCK_CHAIN_ID,
             MAX_TXS,
             MAX_CALLDATA
         ),
@@ -158,9 +158,10 @@ fn tx_circuit_0tx_1max_tx() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 32;
 
-    let chain_id: u64 = mock::MOCK_CHAIN_ID.as_u64();
-
-    assert_eq!(run::<Fr>(vec![], chain_id, MAX_TXS, MAX_CALLDATA), Ok(()));
+    assert_eq!(
+        run::<Fr>(vec![], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        Ok(())
+    );
 }
 
 #[test]
@@ -168,11 +169,12 @@ fn tx_circuit_1tx_1max_tx() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 32;
 
-    let chain_id: u64 = mock::MOCK_CHAIN_ID.as_u64();
-
     let tx: Transaction = mock::CORRECT_MOCK_TXS[0].clone().into();
 
-    assert_eq!(run::<Fr>(vec![tx], chain_id, MAX_TXS, MAX_CALLDATA), Ok(()));
+    assert_eq!(
+        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        Ok(())
+    );
 }
 
 #[test]
@@ -180,10 +182,12 @@ fn tx_circuit_1tx_2max_tx() {
     const MAX_TXS: usize = 2;
     const MAX_CALLDATA: usize = 320;
 
-    let chain_id: u64 = mock::MOCK_CHAIN_ID.as_u64();
     let tx = build_pre_eip155_tx();
 
-    assert_eq!(run::<Fr>(vec![tx], chain_id, MAX_TXS, MAX_CALLDATA), Ok(()));
+    assert_eq!(
+        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        Ok(())
+    );
 }
 
 #[test]
@@ -191,10 +195,12 @@ fn tx_circuit_l1_msg_tx() {
     const MAX_TXS: usize = 4;
     const MAX_CALLDATA: usize = 400;
 
-    let chain_id: u64 = mock::MOCK_CHAIN_ID.as_u64();
     let tx = build_l1_msg_tx();
 
-    assert_eq!(run::<Fr>(vec![tx], chain_id, MAX_TXS, MAX_CALLDATA), Ok(()));
+    assert_eq!(
+        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        Ok(())
+    );
 }
 
 #[cfg(feature = "reject-eip2718")]
@@ -207,13 +213,7 @@ fn tx_circuit_bad_address() {
     // This address doesn't correspond to the account that signed this tx.
     tx.from = AddrOrWallet::from(address!("0x1230000000000000000000000000000000000456"));
 
-    assert!(run::<Fr>(
-        vec![tx.into()],
-        mock::MOCK_CHAIN_ID.as_u64(),
-        MAX_TXS,
-        MAX_CALLDATA
-    )
-    .is_err(),);
+    assert!(run::<Fr>(vec![tx.into()], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA).is_err(),);
 }
 
 #[test]
@@ -221,12 +221,11 @@ fn tx_circuit_to_is_zero() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 32;
 
-    let chain_id: u64 = mock::MOCK_CHAIN_ID.as_u64();
     let mut tx = mock::CORRECT_MOCK_TXS[5].clone();
     tx.transaction_index = U64::from(1);
 
     assert_eq!(
-        run::<Fr>(vec![tx.into()], chain_id, MAX_TXS, MAX_CALLDATA),
+        run::<Fr>(vec![tx.into()], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
         Ok(())
     );
 }

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -61,7 +61,7 @@ pub struct Block<F> {
     /// Mpt updates
     pub mpt_updates: MptUpdates,
     /// Chain ID
-    pub chain_id: Word,
+    pub chain_id: u64,
 }
 
 /// ...
@@ -184,7 +184,7 @@ pub struct BlockContext {
     /// The hash of previous blocks
     pub history_hashes: Vec<Word>,
     /// The chain id
-    pub chain_id: Word,
+    pub chain_id: u64,
     /// Original Block from geth
     pub eth_block: eth_types::Block<eth_types::Transaction>,
 }
@@ -235,7 +235,7 @@ impl BlockContext {
                 [
                     Value::known(F::from(BlockContextFieldTag::ChainId as u64)),
                     Value::known(current_block_number),
-                    randomness.map(|rand| rlc::value(&self.chain_id.to_le_bytes(), rand)),
+                    Value::known(F::from(self.chain_id)),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::NumTxs as u64)),
@@ -392,7 +392,7 @@ pub fn block_convert<F: Field>(
                 } else {
                     last_block_num + 1
                 };
-                tx_convert(tx, idx + 1, chain_id.as_u64(), next_block_num)
+                tx_convert(tx, idx + 1, chain_id, next_block_num)
             })
             .collect(),
         sigs: block.txs().iter().map(|tx| tx.signature).collect(),

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -787,7 +787,7 @@ impl From<MockTransaction> for Transaction {
                 .gas(mock_tx.gas)
                 .value(mock_tx.value)
                 .data(mock_tx.input.clone())
-                .chain_id(mock_tx.chain_id.as_u64());
+                .chain_id(mock_tx.chain_id);
             if !is_create {
                 legacy_tx = legacy_tx.to(mock_tx.to.as_ref().map(|to| to.address()).unwrap());
             }
@@ -813,7 +813,7 @@ impl From<MockTransaction> for Transaction {
             call_data_length: mock_tx.input.len(),
             call_data_gas_cost: tx_data_gas_cost(&mock_tx.input),
             tx_data_gas_cost: tx_data_gas_cost(&rlp_signed),
-            chain_id: mock_tx.chain_id.as_u64(),
+            chain_id: mock_tx.chain_id,
             rlp_unsigned,
             rlp_signed,
             v: sig.v,

--- a/zkevm-circuits/tests/prover_error.rs
+++ b/zkevm-circuits/tests/prover_error.rs
@@ -40,7 +40,7 @@ fn prover_error() {
     const MAX_CALLDATA: usize = 256;
     const MOCK_RANDOMNESS: u64 = 0x100;
     let k = 19;
-    let chain_id = Word::from(99);
+    let chain_id = 99;
     let circuit_params = CircuitsParams {
         max_txs: MAX_TXS,
         max_calldata: MAX_CALLDATA,


### PR DESCRIPTION

### Description

1. Fix all struct field `chain_id` from `Word` type to `u64`.

2. Fix field `chain_id` from Word (or Cell) to `U64Word` in blockhash and chainid gadgets.

3. Update `BLOCK_HEADER_CONST_BYTES_NUM` from `86` to `60` (`sizeof(U256) - sizeof(u64)`) in PI circuit.

### Issue Link

The chain ID could be restricted to Uint64 with [EIP-2294](https://eips.ethereum.org/EIPS/eip-2294) (being-reviewed).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test

CI could pass and remaining `32` failed cases for testool (same as before):
https://circuit-release.s3.us-west-2.amazonaws.com/testool/default.1687243508.b248006.html