### PR TITLE
[Fix]L1fee constraint

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -48,7 +48,9 @@ use std::{
     collections::{BTreeMap, HashMap},
     iter,
 };
-pub use transaction::{Transaction, TransactionContext, TxL1Fee, TX_L1_FEE_PRECISION};
+pub use transaction::{
+    Transaction, TransactionContext, TxL1Fee, TX_L1_COMMIT_EXTRA_COST, TX_L1_FEE_PRECISION,
+};
 
 /// Circuit Setup Parameters
 #[derive(Debug, Clone, Copy)]

--- a/bus-mapping/src/circuit_input_builder/transaction.rs
+++ b/bus-mapping/src/circuit_input_builder/transaction.rs
@@ -20,6 +20,8 @@ use super::{call::ReversionGroup, Call, CallContext, CallKind, CodeSource, ExecS
 
 /// Precision of transaction L1 fee
 pub const TX_L1_FEE_PRECISION: u64 = 1_000_000_000;
+/// Extra cost as the bytes of rlped tx commited to L1 (assume to non-zero, overestimated a bit)
+pub const TX_L1_COMMIT_EXTRA_COST: u64 = 64;
 
 #[derive(Debug, Default)]
 /// Context of a [`Transaction`] which can mutate in an [`ExecStep`].
@@ -460,7 +462,7 @@ impl TxL1Fee {
     /// Calculate L1 fee and remainder of transaction.
     pub fn tx_l1_fee(&self, tx_data_gas_cost: u64) -> (u64, u64) {
         // <https://github.com/scroll-tech/go-ethereum/blob/49192260a177f1b63fc5ea3b872fb904f396260c/rollup/fees/rollup_fee.go#L118>
-        let tx_l1_gas = tx_data_gas_cost + self.fee_overhead;
+        let tx_l1_gas = tx_data_gas_cost + self.fee_overhead + TX_L1_COMMIT_EXTRA_COST;
         let tx_l1_fee = self.fee_scalar as u128 * self.base_fee as u128 * tx_l1_gas as u128;
 
         (

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_fee.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_fee.rs
@@ -10,7 +10,7 @@ use crate::{
     util::Expr,
 };
 use bus_mapping::{
-    circuit_input_builder::{TxL1Fee, TX_L1_FEE_PRECISION},
+    circuit_input_builder::{TxL1Fee, TX_L1_COMMIT_EXTRA_COST, TX_L1_FEE_PRECISION},
     l2_predeployed::l1_gas_price_oracle,
 };
 use eth_types::{Field, ToLittleEndian, ToScalar};
@@ -153,7 +153,7 @@ impl<F: Field> TxL1FeeGadget<F> {
         .map(|word| from_bytes::expr(&word.cells[..N_BYTES_U64]));
 
         // <https://github.com/scroll-tech/go-ethereum/blob/49192260a177f1b63fc5ea3b872fb904f396260c/rollup/fees/rollup_fee.go#L118>
-        let tx_l1_gas = tx_data_gas_cost + 1088.expr() + fee_overhead;
+        let tx_l1_gas = tx_data_gas_cost + TX_L1_COMMIT_EXTRA_COST.expr() + fee_overhead;
         cb.require_equal(
             "fee_scalar * base_fee * tx_l1_gas == tx_l1_fee * 10e9 + remainder",
             fee_scalar * base_fee * tx_l1_gas,

--- a/zkevm-circuits/src/witness/l1_msg.rs
+++ b/zkevm-circuits/src/witness/l1_msg.rs
@@ -34,3 +34,63 @@ pub fn rom_table_rows() -> Vec<RomTableRow> {
         .map(|row| (row.0, row.1, row.2, L1MsgHash, row.3).into())
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use bus_mapping::circuit_input_builder::TxL1Fee;
+    use eth_types::{evm_types::gas_utils::tx_data_gas_cost, Transaction};
+
+    #[test]
+    fn test_l1fee_calc_pre_eip155() {
+        let txs: Vec<Transaction> = serde_json::from_str(
+            r#"[
+                {
+                    "type": "0x0",
+                    "nonce": "0x4",
+                    "hash": "0x8da3fedb103b6da8ccc2514094336d1a76df166238f4d8e8558fbe54cce2516a",
+                    "gas": "0xd25e",
+                    "gasPrice": "0x3b9aca00",
+                    "from": "0x1c5a77d9fa7ef466951b2f01f724bca3a5820b63",
+                    "to": "0x03f8133dd5ed58838b20af1296f62f44e69baa48",
+                    "chainId": "0xcf55",
+                    "value": "0x0",
+                    "input": "0xa9059cbb000000000000000000000000c0c4c8baea3f6acb49b6e1fb9e2adeceeacb0ca200000000000000000000000000000000000000000000000000000000000003e8",
+                    "isCreate": false,
+                    "v": "0x19ecd",
+                    "r": "0xaaa87d285f44e2683266d83116ee3df09313f38e91393bfe2966e947c31e4002",
+                    "s": "0x9e105efcad78b8e836aa9c588e39f0d81b2d6552d04762d0e02652a9ea94b1d"    
+                },
+                {
+                    "type": "0x0",
+                    "nonce": "0x14",
+                    "hash": "0xfef778b40acae6c4f00205f3dafae2af1dff90d402c19b090c4b12cad08e7461",
+                    "gas": "0x5cb2",
+                    "gasPrice": "0x3b9aca00",
+                    "from": "0x1c5a77d9fa7ef466951b2f01f724bca3a5820b63",
+                    "to": "0x58a2239aa5412f78d8f675c4d8ad5102a3fa5837",
+                    "chainId": "0xcf55",
+                    "value": "0x0",
+                    "input": "0xb0f2b72a000000000000000000000000000000000000000000000000000000000000000a",
+                    "isCreate": false,
+                    "v": "0x19ece",
+                    "r": "0xa0ed5a985f5b74215ba05b0c3fc2a2af1c26c65d9426867eda637fa5d7d388eb",
+                    "s": "0x81054ba4a31ee6f0715f36d1005393623b97703c061afe5518a7e31ecbfda6f"
+                }                
+            ]"#,
+        ).unwrap();
+
+        let l1fee = TxL1Fee {
+            base_fee: 0x64,
+            fee_overhead: 0x17d4,
+            fee_scalar: 0x4a42fc80,
+        };
+
+        let expected = [(173usize, 0xfffe8u64), (140, 0xf3f2f)];
+
+        for (tx, (rlp_expected, l1fee_expected)) in txs.into_iter().zip(expected) {
+            let rlp = tx.rlp().to_vec();
+            assert_eq!(rlp.len(), rlp_expected);
+            assert_eq!(l1fee.tx_l1_fee(tx_data_gas_cost(&rlp)).0, l1fee_expected)
+        }
+    }
+}


### PR DESCRIPTION
This PR fixed the constraints of l1fee calculation, respects with the new implement in l2geth. It also add unittests to demostrate the new l1fee calculating progress.

Mock prove of supercirct can pass for the latest trace with this fixing.