### PR TITLE
[Fix] L1fee unittest

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_fee.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_fee.rs
@@ -192,9 +192,8 @@ mod tests {
     const TEST_FEE_OVERHEAD: u64 = 100;
     const TEST_FEE_SCALAR: u64 = 10;
     const TEST_TX_DATA_GAS_COST: u64 = 40; // 2 (zeros) * 4 + 2 (non-zeros) * 16
-    const TEST_TX_L1_FEE: u128 = 184;
+    const TEST_TX_L1_FEE: u128 = 30;
 
-    #[ignore]
     #[test]
     fn test_tx_l1_fee_with_right_values() {
         let witnesses = [
@@ -209,7 +208,6 @@ mod tests {
         try_test!(TxL1FeeGadgetTestContainer<Fr>, witnesses, true);
     }
 
-    #[ignore]
     #[test]
     fn test_tx_l1_fee_with_wrong_values() {
         let witnesses = [


### PR DESCRIPTION
Two unittest in l1fee `test_tx_l1_fee_with_right_values` and `test_tx_l1_fee_with_wrong_values` has been fixed, which is consistented the new implement in l2geth.

See https://github.com/scroll-tech/go-ethereum/pull/365 for reference