### PR TITLE
Feat: constrain tx data gas cost in RLP & Tx circuits

### DIFF
--- a/zkevm-circuits/src/rlp_circuit_fsm.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm.rs
@@ -91,6 +91,8 @@ pub struct RlpFsmDataTable {
     pub byte_value: Column<Advice>,
     /// The accumulated Random Linear Combination up until (including) the current byte.
     pub bytes_rlc: Column<Advice>,
+    /// The accumulated gas cost up until (including) the current byte.
+    pub gas_cost_acc: Column<Advice>,
 }
 
 impl<F: Field> LookupTable<F> for RlpFsmDataTable {
@@ -102,6 +104,7 @@ impl<F: Field> LookupTable<F> for RlpFsmDataTable {
             self.byte_rev_idx.into(),
             self.byte_value.into(),
             self.bytes_rlc.into(),
+            self.gas_cost_acc.into(),
         ]
     }
 
@@ -127,6 +130,7 @@ impl RlpFsmDataTable {
             byte_rev_idx: meta.advice_column(),
             byte_value: meta.advice_column(),
             bytes_rlc: meta.advice_column_in(SecondPhase),
+            gas_cost_acc: meta.advice_column(),
         }
     }
 }
@@ -243,6 +247,8 @@ pub struct RlpCircuitConfig<F> {
     byte_value: Column<Advice>,
     /// The RLC accumulator of all the bytes of this RLP instance.
     bytes_rlc: Column<Advice>,
+    /// The gas cost accumulator of all the bytes of this RLP instance.
+    gas_cost_acc: Column<Advice>,
     /// When the tag occupies several bytes, this index denotes the
     /// incremental index of the byte within this tag instance.
     tag_idx: Column<Advice>,
@@ -275,7 +281,7 @@ pub struct RlpCircuitConfig<F> {
     /// is_case3 = (0xc0 <= byte_value < 0xf8) && (is_tag_end == false)
     is_case3: Column<Advice>,
     /// Boolean to reduce the circuit's degree
-    /// transit_to_new_rlp_instance = (is_tag_end == true) && (depth == 1) && (state' != End)
+    /// transit_to_new_rlp_instance = (is_tag_end == true) && (depth == 0) && (state' != End)
     transit_to_new_rlp_instance: Column<Advice>,
     /// Boolean to reduce the circuit's degree
     is_same_rlp_instance: Column<Advice>,
@@ -331,6 +337,7 @@ impl<F: Field> RlpCircuitConfig<F> {
             byte_idx,
             byte_rev_idx,
             byte_value,
+            gas_cost_acc,
             state,
             tag,
             tag_next,
@@ -346,6 +353,7 @@ impl<F: Field> RlpCircuitConfig<F> {
             is_same_rlp_instance,
         ) = (
             meta.fixed_column(),
+            meta.advice_column(),
             meta.advice_column(),
             meta.advice_column(),
             meta.advice_column(),
@@ -597,6 +605,7 @@ impl<F: Field> RlpCircuitConfig<F> {
                 meta.query_advice(byte_rev_idx, Rotation::cur()),
                 meta.query_advice(byte_value, Rotation::cur()),
                 meta.query_advice(bytes_rlc, Rotation::cur()),
+                meta.query_advice(gas_cost_acc, Rotation::cur()),
             ];
             let mut table_exprs = vec![q_enabled];
             table_exprs.extend(data_table.table_exprs(meta));
@@ -809,11 +818,11 @@ impl<F: Field> RlpCircuitConfig<F> {
             let mut cb = BaseConstraintBuilder::default();
 
             cb.require_equal(
-                "transit_to_new = (is_tag_end == true) && (depth == 1) && (state' != End)",
+                "transit_to_new = (is_tag_end == true) && (depth == 0) && (state' != End)",
                 meta.query_advice(transit_to_new_rlp_instance, Rotation::cur()),
                 and::expr([
                     meta.query_advice(is_tag_end, Rotation::cur()),
-                    depth_eq_one.is_equal_expression.expr(),
+                    depth_check.is_equal_expression.expr(),
                     not::expr(is_next_end(meta)),
                 ]),
             );
@@ -993,6 +1002,16 @@ impl<F: Field> RlpCircuitConfig<F> {
                     },
                 );
                 cb.condition(
+                    and::expr([case_4.expr(), depth_check.is_equal_expression.expr()]),
+                    |cb| {
+                        let gas_cost = meta.query_advice(gas_cost_acc, Rotation::cur());
+
+                        // assertions
+                        emit_rlp_tag!(meta, cb, RlpTag::GasCost, false);
+                        constrain_eq!(meta, cb, rlp_table.tag_value, gas_cost);
+                    },
+                );
+                cb.condition(
                     meta.query_advice(transit_to_new_rlp_instance, Rotation::cur()),
                     |cb| {
                         let tx_id = meta.query_advice(rlp_table.tx_id, Rotation::cur());
@@ -1019,7 +1038,7 @@ impl<F: Field> RlpCircuitConfig<F> {
                 cb.condition(
                     and::expr([
                         case_4.expr(),
-                        not::expr(depth_eq_one.is_equal_expression.expr()),
+                        not::expr(depth_check.is_equal_expression.expr()), // depth > 0
                     ]),
                     |cb| {
                         update_state!(meta, cb, tag, tag_next_expr(meta));
@@ -1298,8 +1317,8 @@ impl<F: Field> RlpCircuitConfig<F> {
 
             // condition.
             cb.require_equal(
-                "depth == 1",
-                depth_eq_one.is_equal_expression.expr(),
+                "depth == 0",
+                depth_check.is_equal_expression.expr(),
                 true.expr(),
             );
             cb.require_equal("is_tag_end == true", is_tag_end_expr(meta), true.expr());
@@ -1340,6 +1359,7 @@ impl<F: Field> RlpCircuitConfig<F> {
             byte_rev_idx,
             byte_value,
             bytes_rlc,
+            gas_cost_acc,
             tag_idx,
             tag_length,
             tag_value_acc,
@@ -1517,12 +1537,18 @@ impl<F: Field> RlpCircuitConfig<F> {
             row,
             || witness.state_machine.bytes_rlc,
         )?;
+        region.assign_advice(
+            || "gas_cost_acc",
+            self.gas_cost_acc,
+            row,
+            || witness.state_machine.gas_cost_acc,
+        )?;
 
         // assign to intermediates
         let byte_value = witness.state_machine.byte_value;
         let is_case3 = (0xc0..0xf8).contains(&byte_value) && !witness.state_machine.tag.is_end();
         let transit_to_new = witness.state_machine.tag.is_end()
-            && (witness.state_machine.depth == 1)
+            && (witness.state_machine.depth == 0)
             && witness_next.is_some();
         region.assign_advice(
             || "is_tag_begin",

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -160,6 +160,8 @@ pub enum TxFieldTag {
     TxHashRLC,
     /// TxHash: Hash of the transaction with the signature
     TxHash,
+    /// Gas cost of the transaction charged in L1
+    TxGasCostInL1,
     /// The block number in which this tx is included.
     BlockNumber,
 }

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -133,7 +133,7 @@ pub enum TxFieldTag {
     CallDataLength,
     /// Gas cost for transaction call data (4 for byte == 0, 16 otherwise)
     CallDataGasCost,
-    /// Gas cost for rlp-encoded bytes of unsigned transaction (4 for byte == 0, 16 otherwise)
+    /// Gas cost of the transaction data charged in L1
     TxDataGasCost,
     /// Chain ID
     ChainID,
@@ -160,8 +160,6 @@ pub enum TxFieldTag {
     TxHashRLC,
     /// TxHash: Hash of the transaction with the signature
     TxHash,
-    /// Gas cost of the transaction charged in L1
-    TxGasCostInL1,
     /// The block number in which this tx is included.
     BlockNumber,
 }

--- a/zkevm-circuits/src/tx_circuit/test.rs
+++ b/zkevm-circuits/src/tx_circuit/test.rs
@@ -99,7 +99,8 @@ fn build_l1_msg_tx() -> Transaction {
     tx.is_create = eth_tx.to.is_none();
     tx.call_data_length = tx.call_data.len();
     tx.call_data_gas_cost = tx_data_gas_cost(&tx.call_data);
-    tx.tx_data_gas_cost = tx_data_gas_cost(&tx.rlp_signed);
+    // l1 msg's data has been charged in L1
+    tx.tx_data_gas_cost = 0;
     tx.v = eth_tx.v.as_u64();
     tx.r = eth_tx.r;
     tx.s = eth_tx.s;

--- a/zkevm-circuits/src/witness/l1_msg.rs
+++ b/zkevm-circuits/src/witness/l1_msg.rs
@@ -7,6 +7,7 @@ use crate::{
     },
 };
 use ethers_core::utils::rlp::Encodable;
+use crate::witness::rlp_fsm::{N_BYTES_CALLDATA, N_BYTES_LIST};
 
 #[derive(Clone, Debug)]
 pub struct L1MsgTx;
@@ -20,14 +21,16 @@ impl Encodable for L1MsgTx {
 pub fn rom_table_rows() -> Vec<RomTableRow> {
     let rows = vec![
         (TxType, BeginList, 1, vec![1]),
-        (BeginList, Nonce, 8, vec![2]),
+        (BeginList, Nonce, N_BYTES_LIST, vec![2]),
         (Nonce, Gas, N_BYTES_U64, vec![3]),
         (Gas, To, N_BYTES_U64, vec![4]),
         (To, TxValue, N_BYTES_ACCOUNT_ADDRESS, vec![5]),
         (TxValue, Data, N_BYTES_WORD, vec![6]),
-        (Data, Sender, 2usize.pow(24), vec![7]),
+        (Data, Sender, N_BYTES_CALLDATA, vec![7]),
         (Sender, EndList, N_BYTES_ACCOUNT_ADDRESS, vec![8]),
-        (EndList, BeginList, 0, vec![]),
+        (EndList, EndList, 0, vec![9]),
+        // used to emit TxGasCostInL1
+        (EndList, BeginList, 0, vec![])
     ];
 
     rows.into_iter()

--- a/zkevm-circuits/src/witness/l1_msg.rs
+++ b/zkevm-circuits/src/witness/l1_msg.rs
@@ -1,13 +1,13 @@
 use crate::{
     evm_circuit::param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_U64, N_BYTES_WORD},
     witness::{
+        rlp_fsm::{N_BYTES_CALLDATA, N_BYTES_LIST},
         Format::L1MsgHash,
         RomTableRow,
         Tag::{BeginList, Data, EndList, Gas, Nonce, Sender, To, TxType, Value as TxValue},
     },
 };
 use ethers_core::utils::rlp::Encodable;
-use crate::witness::rlp_fsm::{N_BYTES_CALLDATA, N_BYTES_LIST};
 
 #[derive(Clone, Debug)]
 pub struct L1MsgTx;
@@ -30,7 +30,7 @@ pub fn rom_table_rows() -> Vec<RomTableRow> {
         (Sender, EndList, N_BYTES_ACCOUNT_ADDRESS, vec![8]),
         (EndList, EndList, 0, vec![9]),
         // used to emit TxGasCostInL1
-        (EndList, BeginList, 0, vec![])
+        (EndList, BeginList, 0, vec![]),
     ];
 
     rows.into_iter()

--- a/zkevm-circuits/src/witness/rlp_fsm.rs
+++ b/zkevm-circuits/src/witness/rlp_fsm.rs
@@ -148,18 +148,24 @@ use crate::{
     },
 };
 
+// The number of bytes of list can not larger than 2^24.
+pub(crate) const N_BYTES_LIST: usize = 1 << 24;
+pub(crate) const N_BYTES_CALLDATA: usize = 1 << 24;
+
 fn eip155_tx_sign_rom_table_rows() -> Vec<RomTableRow> {
     let rows = vec![
-        (BeginList, Nonce, N_BYTES_U64, vec![1]),
+        (BeginList, Nonce, N_BYTES_LIST, vec![1]),
         (Nonce, GasPrice, N_BYTES_U64, vec![2]),
         (GasPrice, Gas, N_BYTES_WORD, vec![3]),
         (Gas, To, N_BYTES_U64, vec![4]),
         (To, TxValue, N_BYTES_ACCOUNT_ADDRESS, vec![5]),
         (TxValue, Data, N_BYTES_WORD, vec![6]),
-        (Data, ChainId, 2usize.pow(24), vec![7]),
+        (Data, ChainId, N_BYTES_CALLDATA, vec![7]),
         (ChainId, Zero1, N_BYTES_U64, vec![8]),
         (Zero1, Zero2, 1, vec![9]),
         (Zero2, EndList, 1, vec![10]),
+        (EndList, EndList, 0, vec![11]),
+        // used to emit TxGasCostInL1
         (EndList, BeginList, 0, vec![]),
     ];
 
@@ -170,16 +176,18 @@ fn eip155_tx_sign_rom_table_rows() -> Vec<RomTableRow> {
 
 fn eip155_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
     let rows = vec![
-        (BeginList, Nonce, N_BYTES_U64, vec![1]),
+        (BeginList, Nonce, N_BYTES_LIST, vec![1]),
         (Nonce, GasPrice, N_BYTES_U64, vec![2]),
         (GasPrice, Gas, N_BYTES_WORD, vec![3]),
         (Gas, To, N_BYTES_U64, vec![4]),
         (To, TxValue, N_BYTES_ACCOUNT_ADDRESS, vec![5]),
         (TxValue, Data, N_BYTES_WORD, vec![6]),
-        (Data, SigV, 2usize.pow(24), vec![7]),
+        (Data, SigV, N_BYTES_CALLDATA, vec![7]),
         (SigV, SigR, N_BYTES_U64, vec![8]),
         (SigR, SigS, N_BYTES_WORD, vec![9]),
         (SigS, EndList, N_BYTES_WORD, vec![10]),
+        (EndList, EndList, 0, vec![11]),
+        // used to emit TxGasCostInL1
         (EndList, BeginList, 0, vec![]),
     ];
 
@@ -190,13 +198,15 @@ fn eip155_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
 
 pub fn pre_eip155_tx_sign_rom_table_rows() -> Vec<RomTableRow> {
     let rows = vec![
-        (BeginList, Nonce, N_BYTES_U64, vec![1]),
+        (BeginList, Nonce, N_BYTES_LIST, vec![1]),
         (Nonce, GasPrice, N_BYTES_U64, vec![2]),
         (GasPrice, Gas, N_BYTES_WORD, vec![3]),
         (Gas, To, N_BYTES_U64, vec![4]),
         (To, TxValue, N_BYTES_ACCOUNT_ADDRESS, vec![5]),
         (TxValue, Data, N_BYTES_WORD, vec![6]),
-        (Data, EndList, 2usize.pow(24), vec![7]),
+        (Data, EndList, N_BYTES_CALLDATA, vec![7]),
+        (EndList, EndList, 0, vec![8]),
+        // used to emit TxGasCostInL1
         (EndList, BeginList, 0, vec![]),
     ];
 
@@ -207,16 +217,18 @@ pub fn pre_eip155_tx_sign_rom_table_rows() -> Vec<RomTableRow> {
 
 pub fn pre_eip155_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
     let rows = vec![
-        (BeginList, Nonce, N_BYTES_U64, vec![1]),
+        (BeginList, Nonce, N_BYTES_LIST, vec![1]),
         (Nonce, GasPrice, N_BYTES_U64, vec![2]),
         (GasPrice, Gas, N_BYTES_WORD, vec![3]),
         (Gas, To, N_BYTES_U64, vec![4]),
         (To, TxValue, N_BYTES_ACCOUNT_ADDRESS, vec![5]),
         (TxValue, Data, N_BYTES_WORD, vec![6]),
-        (Data, SigV, 2usize.pow(24), vec![7]),
+        (Data, SigV, N_BYTES_CALLDATA, vec![7]),
         (SigV, SigR, N_BYTES_U64, vec![8]),
         (SigR, SigS, N_BYTES_WORD, vec![9]),
         (SigS, EndList, N_BYTES_WORD, vec![10]),
+        (EndList, EndList, 0, vec![11]),
+        // used to emit TxGasCostInL1
         (EndList, BeginList, 0, vec![]),
     ];
 
@@ -228,7 +240,7 @@ pub fn pre_eip155_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
 pub fn eip1559_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
     let rows = vec![
         (TxType, BeginList, 1, vec![1]),
-        (BeginList, ChainId, 8, vec![2]),
+        (BeginList, ChainId, N_BYTES_LIST, vec![2]),
         (ChainId, Nonce, N_BYTES_U64, vec![3]),
         (Nonce, MaxPriorityFeePerGas, N_BYTES_U64, vec![4]),
         (MaxPriorityFeePerGas, MaxFeePerGas, N_BYTES_WORD, vec![5]),
@@ -236,19 +248,19 @@ pub fn eip1559_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
         (Gas, To, N_BYTES_U64, vec![7]),
         (To, TxValue, N_BYTES_ACCOUNT_ADDRESS, vec![8]),
         (TxValue, Data, N_BYTES_WORD, vec![9]),
-        (Data, BeginVector, 2usize.pow(24), vec![10, 11]),
-        (BeginVector, EndVector, 8, vec![21]), // access_list is none
-        (BeginVector, BeginList, 8, vec![12]),
-        (BeginList, AccessListAddress, 8, vec![13]),
+        (Data, BeginVector, N_BYTES_CALLDATA, vec![10, 11]),
+        (BeginVector, EndVector, N_BYTES_LIST, vec![21]), // access_list is none
+        (BeginVector, BeginList, N_BYTES_LIST, vec![12]),
+        (BeginList, AccessListAddress, N_BYTES_LIST, vec![13]),
         (
             AccessListAddress,
             BeginVector,
             N_BYTES_ACCOUNT_ADDRESS,
             vec![14, 15],
         ),
-        (BeginVector, EndVector, 8, vec![18]), /* access_list.storage_keys
+        (BeginVector, EndVector, N_BYTES_LIST, vec![18]), /* access_list.storage_keys
                                                 * is none */
-        (BeginVector, AccessListStorageKey, 8, vec![16, 17]),
+        (BeginVector, AccessListStorageKey, N_BYTES_LIST, vec![16, 17]),
         (AccessListStorageKey, EndVector, N_BYTES_WORD, vec![18]), // finished parsing storage keys
         (
             AccessListStorageKey,
@@ -263,6 +275,8 @@ pub fn eip1559_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
         (SigV, SigR, N_BYTES_U64, vec![23]),
         (SigR, SigS, N_BYTES_WORD, vec![24]),
         (SigS, EndList, N_BYTES_WORD, vec![25]),
+        (EndList, EndList, 0, vec![26]),
+        // used to exit TxGasCostInL1
         (EndList, BeginList, 0, vec![]),
     ];
 
@@ -273,7 +287,7 @@ pub fn eip1559_tx_hash_rom_table_rows() -> Vec<RomTableRow> {
 
 pub fn eip1559_tx_sign_rom_table_rows() -> Vec<RomTableRow> {
     let rows = vec![
-        (BeginList, ChainId, 8, vec![1]),
+        (BeginList, ChainId, N_BYTES_LIST, vec![1]),
         (ChainId, Nonce, N_BYTES_U64, vec![2]),
         (Nonce, MaxPriorityFeePerGas, N_BYTES_U64, vec![3]),
         (MaxPriorityFeePerGas, MaxFeePerGas, N_BYTES_WORD, vec![4]),
@@ -281,18 +295,18 @@ pub fn eip1559_tx_sign_rom_table_rows() -> Vec<RomTableRow> {
         (Gas, To, N_BYTES_U64, vec![6]),
         (To, TxValue, N_BYTES_ACCOUNT_ADDRESS, vec![7]),
         (TxValue, Data, N_BYTES_WORD, vec![8]),
-        (Data, BeginVector, 2usize.pow(24), vec![9, 10]),
-        (BeginVector, EndVector, 8, vec![20]), // access_list is none
-        (BeginVector, BeginList, 8, vec![11]),
-        (BeginList, AccessListAddress, 8, vec![12]),
+        (Data, BeginVector, N_BYTES_CALLDATA, vec![9, 10]),
+        (BeginVector, EndVector, N_BYTES_LIST, vec![20]), // access_list is none
+        (BeginVector, BeginList, N_BYTES_LIST, vec![11]),
+        (BeginList, AccessListAddress, N_BYTES_LIST, vec![12]),
         (
             AccessListAddress,
             BeginVector,
             N_BYTES_ACCOUNT_ADDRESS,
             vec![13, 14],
         ),
-        (BeginVector, EndVector, 8, vec![17]), /* access_list.storage_keys is none */
-        (BeginVector, AccessListStorageKey, 8, vec![15, 16]),
+        (BeginVector, EndVector, N_BYTES_LIST, vec![17]), /* access_list.storage_keys is none */
+        (BeginVector, AccessListStorageKey, N_BYTES_LIST, vec![15, 16]),
         (AccessListStorageKey, EndVector, N_BYTES_WORD, vec![17]), // finished parsing storage keys
         (
             AccessListStorageKey,
@@ -304,6 +318,8 @@ pub fn eip1559_tx_sign_rom_table_rows() -> Vec<RomTableRow> {
         (EndList, EndVector, 0, vec![20]), // finished parsing access_list
         (EndList, BeginList, 0, vec![11]), // parse another access_list entry
         (EndVector, EndList, 0, vec![21]),
+        (EndList, EndList, 0, vec![22]),
+        // used to emit TxGasCostInL1
         (EndList, BeginList, 0, vec![]),
     ];
 

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -104,6 +104,7 @@ impl Transaction {
             callee_address: Some(Address::zero()),
             is_create: false, // callee_address != None
             chain_id,
+            tx_data_gas_cost: tx_data_gas_cost(&rlp_signed),
             v: dummy_sig.v,
             r: dummy_sig.r,
             s: dummy_sig.s,
@@ -868,6 +869,11 @@ pub(super) fn tx_convert(
         chain_id, tx.chain_id
     );
     let callee_address = if tx.is_create() { None } else { Some(tx.to) };
+    let tx_gas_cost = if tx.tx_type.is_l1_msg() {
+        0
+    } else {
+        tx_data_gas_cost(&tx.rlp_bytes)
+    };
 
     Transaction {
         block_number: tx.block_num,
@@ -884,7 +890,7 @@ pub(super) fn tx_convert(
         call_data: tx.input.clone(),
         call_data_length: tx.input.len(),
         call_data_gas_cost: tx_data_gas_cost(&tx.input),
-        tx_data_gas_cost: tx_data_gas_cost(&tx.rlp_bytes),
+        tx_data_gas_cost: tx_gas_cost,
         chain_id,
         rlp_unsigned: tx.rlp_unsigned_bytes.clone(),
         rlp_signed: tx.rlp_bytes.clone(),

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -369,6 +369,15 @@ impl Transaction {
                 Some(*rlc)
             })
             .collect::<Vec<_>>();
+        let rlp_gas_cost_acc = rlp_bytes
+            .iter()
+            .scan(Value::known(F::zero()), |acc, &byte| {
+                let cost = if byte == 0 { 4 } else { 16 };
+                *acc = *acc + Value::known(F::from(cost));
+
+                Some(*acc)
+            })
+            .collect::<Vec<_>>();
         let mut cur = SmState {
             tag: rom_table[0].tag,
             state: DecodeTagStart,
@@ -419,10 +428,17 @@ impl Transaction {
                             assert_eq!(cur.byte_idx, rlp_bytes.len() - 1);
                             is_output = true;
                             rlp_tag = RlpTag::RLC;
+                        } else if cur.depth == 0 {
+                            // emit GasCost
+                            is_output = true;
+                            rlp_tag = RlpTag::GasCost;
                         }
 
                         // state transitions
-                        next.depth = cur.depth - 1;
+                        // if cur.depth == 0 then we are at the end of decoding
+                        if cur.depth > 0 {
+                            next.depth = cur.depth - 1;
+                        }
                         next.state = DecodeTagStart;
                     } else {
                         let byte_value = rlp_bytes[cur.byte_idx];
@@ -622,10 +638,12 @@ impl Transaction {
 
             assert!(cur.byte_idx < rlp_bytes.len());
             let (byte_value, bytes_rlc) = (rlp_bytes[cur.byte_idx], rlp_bytes_rlc[cur.byte_idx]);
+            let gas_cost_acc = rlp_gas_cost_acc[cur.byte_idx];
 
             let tag_value = match rlp_tag {
                 RlpTag::Len => cur.tag_value_acc + Value::known(F::from((cur.byte_idx + 1) as u64)),
                 RlpTag::RLC => bytes_rlc,
+                RlpTag::GasCost => gas_cost_acc,
                 RlpTag::Tag(_) => cur.tag_value_acc,
                 RlpTag::Null => unreachable!("Null is not used"),
             };
@@ -652,11 +670,12 @@ impl Transaction {
                     tag_acc_value: cur.tag_value_acc,
                     depth: cur.depth,
                     bytes_rlc,
+                    gas_cost_acc,
                 },
             });
             witness_table_idx += 1;
 
-            if cur.tag == EndList && next.depth == 0 {
+            if cur.tag == EndList && cur.depth == 0 {
                 break;
             }
             cur = next;
@@ -751,17 +770,23 @@ impl<F: Field> RlpFsmWitnessGen<F> for Transaction {
             rlp_bytes
                 .iter()
                 .enumerate()
-                .scan(Value::known(F::zero()), |rlc, (i, &byte_value)| {
-                    *rlc = *rlc * r + Value::known(F::from(byte_value as u64));
-                    Some(DataTable {
-                        tx_id,
-                        format,
-                        byte_idx: i + 1,
-                        byte_rev_idx: n - i,
-                        byte_value,
-                        bytes_rlc: *rlc,
-                    })
-                })
+                .scan(
+                    (Value::known(F::zero()), Value::known(F::zero())),
+                    |(rlc, gas_cost_acc), (i, &byte_value)| {
+                        let byte_cost = if byte_value == 0 { 4 } else { 16 };
+                        *rlc = *rlc * r + Value::known(F::from(byte_value as u64));
+                        *gas_cost_acc = *gas_cost_acc + Value::known(F::from(byte_cost));
+                        Some(DataTable {
+                            tx_id,
+                            format,
+                            byte_idx: i + 1,
+                            byte_rev_idx: n - i,
+                            byte_value,
+                            bytes_rlc: *rlc,
+                            gas_cost_acc: *gas_cost_acc,
+                        })
+                    },
+                )
                 .collect::<Vec<_>>()
         };
 
@@ -917,7 +942,9 @@ pub(super) fn tx_convert(
 #[cfg(test)]
 mod tests {
     use crate::witness::{tx::Challenges, RlpTag, Tag, Transaction};
-    use eth_types::{geth_types::TxType, Address, ToBigEndian, ToScalar};
+    use eth_types::{
+        evm_types::gas_utils::tx_data_gas_cost, geth_types::TxType, Address, ToBigEndian, ToScalar,
+    };
     use ethers_core::{
         types::{Transaction as EthTransaction, TransactionRequest},
         utils::rlp::{Decodable, Rlp},
@@ -973,7 +1000,7 @@ mod tests {
         ];
 
         // assertions
-        assert_eq!(tx_table.len() + 2, rlp_table.len()); // +2 for Len and RLC
+        assert_eq!(tx_table.len() + 3, rlp_table.len()); // +3 for Len, RLC and GasCost
 
         // assertions about RlpTag::Len
         assert_eq!(rlp_table[0].rlp_tag, RlpTag::Len);
@@ -988,10 +1015,17 @@ mod tests {
         }
 
         // assertions about RlpTag::RLC
-        assert_eq!(rlp_table[rlp_table.len() - 1].rlp_tag, RlpTag::RLC);
+        assert_eq!(rlp_table[rlp_table.len() - 2].rlp_tag, RlpTag::RLC); // -2 for GasCost is the last
+        assert_eq!(
+            unwrap_value(rlp_table[rlp_table.len() - 2].tag_value),
+            rlc(&tx.rlp_unsigned, keccak_input)
+        );
+
+        // assertions about RlpTag::GasCost
+        assert_eq!(rlp_table[rlp_table.len() - 1].rlp_tag, RlpTag::GasCost);
         assert_eq!(
             unwrap_value(rlp_table[rlp_table.len() - 1].tag_value),
-            rlc(&tx.rlp_unsigned, keccak_input)
+            Fr::from(tx_data_gas_cost(&tx.rlp_unsigned)),
         );
     }
 
@@ -1051,10 +1085,17 @@ mod tests {
         }
 
         // assertions about RlpTag::RLC
-        assert_eq!(rlp_table[rlp_table.len() - 1].rlp_tag, RlpTag::RLC);
+        assert_eq!(rlp_table[rlp_table.len() - 2].rlp_tag, RlpTag::RLC); // -2 for GasCost is the last
+        assert_eq!(
+            unwrap_value(rlp_table[rlp_table.len() - 2].tag_value),
+            rlc(&tx.rlp_signed, keccak_input)
+        );
+
+        // assertions about RlpTag::GasCost
+        assert_eq!(rlp_table[rlp_table.len() - 1].rlp_tag, RlpTag::GasCost);
         assert_eq!(
             unwrap_value(rlp_table[rlp_table.len() - 1].tag_value),
-            rlc(&tx.rlp_signed, keccak_input)
+            Fr::from(tx_data_gas_cost(&tx.rlp_signed)),
         );
     }
 
@@ -1112,7 +1153,7 @@ mod tests {
         ]);
 
         // assertions
-        assert_eq!(tx_table.len() + 2, rlp_table.len()); // +2 for Len and RLC
+        assert_eq!(tx_table.len() + 3, rlp_table.len()); // +3 for Len, RLC and GasCost
 
         // assertions about RlpTag::Len
         assert_eq!(rlp_table[1].rlp_tag, RlpTag::Len);
@@ -1128,10 +1169,17 @@ mod tests {
         }
 
         // assertions about RlpTag::RLC
-        assert_eq!(rlp_table[rlp_table.len() - 1].rlp_tag, RlpTag::RLC);
+        assert_eq!(rlp_table[rlp_table.len() - 2].rlp_tag, RlpTag::RLC); // -2 for GasCost is the last
+        assert_eq!(
+            unwrap_value(rlp_table[rlp_table.len() - 2].tag_value),
+            rlc(&tx.rlp_signed, keccak_input)
+        );
+
+        // assertions about RlpTag::GasCost
+        assert_eq!(rlp_table[rlp_table.len() - 1].rlp_tag, RlpTag::GasCost);
         assert_eq!(
             unwrap_value(rlp_table[rlp_table.len() - 1].tag_value),
-            rlc(&tx.rlp_signed, keccak_input)
+            Fr::from(tx_data_gas_cost(&tx.rlp_signed)),
         );
     }
 }


### PR DESCRIPTION
### Description

Prior to this pr, the tx data gas cost field is not constrained at all. To add the missing piece, this PR adds a new RlpTag (i.e. `GasCost`) and the last row of each RLP instance has this tag emited. 


### Issue Link

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Contents

