### PR TITLE
add prev bytes and refactor copy event 

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -36,7 +36,8 @@ use ethers_core::{
 };
 use ethers_providers::JsonRpcClient;
 pub use execution::{
-    CopyDataType, CopyEvent, CopyStep, ExecState, ExecStep, ExpEvent, ExpStep, NumberOrHash,
+    CopyBytes, CopyDataType, CopyEvent, CopyStep, ExecState, ExecStep, ExpEvent, ExpStep,
+    NumberOrHash,
 };
 use hex::decode_to_slice;
 

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -320,6 +320,8 @@ impl_expr!(CopyDataType, u64::from);
 pub struct CopyStep {
     /// Byte value copied in this step.
     pub value: u8,
+    /// Byte value before this step.
+    pub prev_value: Option<u8>,
     /// mask indicates this byte won't be copied.
     pub mask: bool,
     /// Optional field which is enabled only for the source being `bytecode`,

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -342,11 +342,8 @@ pub struct CopyBytes {
     /// Represents the list of (bytes, is_code, mask) copied during this copy event
     pub bytes: Vec<(u8, bool, bool)>,
     /// Represents the list of (bytes, is_code, mask) read to copy during this copy event, used for
-    /// memory to memory case
+    /// memory to memoryb write case
     pub aux_bytes: Option<Vec<(u8, bool, bool)>>,
-    /// Represents the list of bytes before this copy event, it is reuqired for memory read copy
-    /// event
-    pub bytes_read_prev: Option<Vec<u8>>,
     /// Represents the list of bytes before this copy event, it is reuqired for memory write copy
     /// event
     pub bytes_write_prev: Option<Vec<u8>>,
@@ -357,13 +354,11 @@ impl CopyBytes {
     pub fn new(
         bytes: Vec<(u8, bool, bool)>,
         aux_bytes: Option<Vec<(u8, bool, bool)>>,
-        bytes_read_prev: Option<Vec<u8>>,
         bytes_write_prev: Option<Vec<u8>>,
     ) -> Self {
         Self {
             bytes,
             aux_bytes,
-            bytes_read_prev,
             bytes_write_prev,
         }
     }

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -334,7 +334,7 @@ mod calldatacopy_tests {
         );
         assert_eq!(copy_events[0].dst_addr as usize, dst_offset);
 
-        for (idx, (value, is_code, _)) in copy_events[0].bytes.iter().enumerate() {
+        for (idx, (value, is_code, _)) in copy_events[0].copy_bytes.bytes.iter().enumerate() {
             if idx < memory_a.len() {
                 assert_eq!(*value, memory_a[idx]);
             } else {
@@ -489,13 +489,16 @@ mod calldatacopy_tests {
         assert_eq!(copy_events.len(), 1);
         let begin_slot = dst_offset - dst_offset % 32;
         let end_slot = (dst_offset + size - 1) - (dst_offset + size - 1) % 32;
-        assert_eq!(copy_events[0].bytes.len(), end_slot - begin_slot + 32);
+        assert_eq!(
+            copy_events[0].copy_bytes.bytes.len(),
+            end_slot - begin_slot + 32
+        );
         assert_eq!(
             builder.block.container.memory_word.len(),
             (end_slot - begin_slot) / 32 + 1
         );
 
-        for (idx, (value, is_code, _)) in copy_events[0].bytes.iter().enumerate() {
+        for (idx, (value, is_code, _)) in copy_events[0].copy_bytes.bytes.iter().enumerate() {
             assert_eq!(value, calldata.get(offset as usize + idx).unwrap_or(&0));
             assert!(!is_code);
         }

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -144,7 +144,7 @@ fn gen_copy_event(
             copy_bytes: copy_bytes,
         })
     } else {
-        let (read_steps, write_steps) = state.gen_copy_steps_for_call_data_non_root(
+        let (read_steps, write_steps, prev_bytes) = state.gen_copy_steps_for_call_data_non_root(
             &mut exec_step,
             src_addr,
             src_addr_end,
@@ -163,8 +163,8 @@ fn gen_copy_event(
             dst_addr,
             log_id: None,
             rw_counter_start,
-            //todo: fetch pre read and write bytes of CopyBytes
-            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
+            //fetch pre read and write bytes of CopyBytes
+            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(prev_bytes)),
         })
     }
 }

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -7,7 +7,6 @@ use crate::{
     Error,
 };
 use eth_types::GethExecStep;
-use revm_precompile::primitives::bitvec::macros::internal::funty::Fundamental;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Calldatacopy;
@@ -120,7 +119,7 @@ fn gen_copy_event(
     let mut exec_step = state.new_step(geth_step)?;
 
     if state.call()?.is_root {
-        let copy_steps = state.gen_copy_steps_for_call_data_root(
+        let (copy_steps, prev_bytes) = state.gen_copy_steps_for_call_data_root(
             &mut exec_step,
             src_addr,
             dst_addr,
@@ -130,7 +129,7 @@ fn gen_copy_event(
         )?;
 
         //todo: fetch pre write bytes to fill 'bytes_write_prev' of CopyBytes
-        let copy_bytes = CopyBytes::new(copy_steps, None, None, None);
+        let copy_bytes = CopyBytes::new(copy_steps, None, Some(prev_bytes));
 
         Ok(CopyEvent {
             src_type: CopyDataType::TxCalldata,
@@ -165,7 +164,7 @@ fn gen_copy_event(
             log_id: None,
             rw_counter_start,
             //todo: fetch pre read and write bytes of CopyBytes
-            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
+            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
         })
     }
 }

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -1,7 +1,7 @@
 use super::Opcode;
 use crate::{
     circuit_input_builder::{
-        CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
     },
     operation::CallContextField,
     Error,
@@ -129,6 +129,9 @@ fn gen_copy_event(
             memory_updated,
         )?;
 
+        //todo: fetch pre write bytes to fill 'bytes_write_prev' of CopyBytes
+        let copy_bytes = CopyBytes::new(copy_steps, None, None, None);
+
         Ok(CopyEvent {
             src_type: CopyDataType::TxCalldata,
             src_id: NumberOrHash::Number(state.tx_ctx.id()),
@@ -139,8 +142,7 @@ fn gen_copy_event(
             dst_addr,
             log_id: None,
             rw_counter_start,
-            bytes: copy_steps,
-            aux_bytes: None,
+            copy_bytes: copy_bytes,
         })
     } else {
         let (read_steps, write_steps) = state.gen_copy_steps_for_call_data_non_root(
@@ -162,8 +164,8 @@ fn gen_copy_event(
             dst_addr,
             log_id: None,
             rw_counter_start,
-            bytes: read_steps,
-            aux_bytes: Some(write_steps),
+            //todo: fetch pre read and write bytes of CopyBytes
+            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
         })
     }
 }

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -374,7 +374,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             dst_addr: 0,
                             log_id: None,
                             rw_counter_start,
-                            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
+                            copy_bytes: CopyBytes::new(copy_steps, None, None),
                         },
                     );
                 }
@@ -399,7 +399,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             dst_addr: 0,
                             log_id: None,
                             rw_counter_start,
-                            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
+                            copy_bytes: CopyBytes::new(copy_steps, None, None),
                         },
                     );
                 }
@@ -428,7 +428,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             dst_addr: call.return_data_offset,
                             log_id: None,
                             rw_counter_start,
-                            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
+                            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
                         },
                     );
                 }

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -1,7 +1,8 @@
 use super::Opcode;
 use crate::{
     circuit_input_builder::{
-        CallKind, CircuitInputStateRef, CodeSource, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+        CallKind, CircuitInputStateRef, CodeSource, CopyBytes, CopyDataType, CopyEvent, ExecStep,
+        NumberOrHash,
     },
     evm::opcodes::precompiles::gen_associated_ops as precompile_associated_ops,
     operation::{AccountField, CallContextField, MemoryWordOp, TxAccessListAccountOp, RW},
@@ -373,8 +374,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             dst_addr: 0,
                             log_id: None,
                             rw_counter_start,
-                            bytes: copy_steps,
-                            aux_bytes: None,
+                            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
                         },
                     );
                 }
@@ -399,8 +399,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             dst_addr: 0,
                             log_id: None,
                             rw_counter_start,
-                            bytes: copy_steps,
-                            aux_bytes: None,
+                            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
                         },
                     );
                 }
@@ -429,8 +428,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             dst_addr: call.return_data_offset,
                             log_id: None,
                             rw_counter_start,
-                            bytes: read_steps,
-                            aux_bytes: Some(write_steps),
+                            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
                         },
                     );
                 }

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -1,6 +1,6 @@
 use crate::{
     circuit_input_builder::{
-        CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
     },
     Error,
 };
@@ -109,8 +109,8 @@ fn gen_copy_event(
         dst_addr,
         log_id: None,
         rw_counter_start,
-        bytes: copy_steps,
-        aux_bytes: None,
+        //todo: fetch pre write bytes of CopyBytes
+        copy_bytes: CopyBytes::new(copy_steps, None, None, None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -90,7 +90,7 @@ fn gen_copy_event(
         .min(src_addr_end);
 
     let mut exec_step = state.new_step(geth_step)?;
-    let copy_steps = state.gen_copy_steps_for_bytecode(
+    let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
         &mut exec_step,
         &bytecode,
         src_addr,
@@ -109,8 +109,8 @@ fn gen_copy_event(
         dst_addr,
         log_id: None,
         rw_counter_start,
-        //todo: fetch pre write bytes of CopyBytes
-        copy_bytes: CopyBytes::new(copy_steps, None, None),
+        //fetch pre write bytes of CopyBytes
+        copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
     })
 }
 
@@ -214,7 +214,7 @@ mod codecopy_tests {
         assert_eq!(copy_events[0].dst_type, CopyDataType::Memory);
         assert!(copy_events[0].log_id.is_none());
 
-        for (idx, (value, is_code, is_mask)) in copy_events[0].bytes.iter().enumerate() {
+        for (idx, (value, is_code, is_mask)) in copy_events[0].copy_bytes.bytes.iter().enumerate() {
             let bytecode_element = code.get(code_offset + idx).unwrap_or_default();
             if !is_mask {
                 assert_eq!(*value, bytecode_element.value);

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -110,7 +110,7 @@ fn gen_copy_event(
         log_id: None,
         rw_counter_start,
         //todo: fetch pre write bytes of CopyBytes
-        copy_bytes: CopyBytes::new(copy_steps, None, None, None),
+        copy_bytes: CopyBytes::new(copy_steps, None, None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -391,7 +391,7 @@ fn handle_copy(
             dst_id: NumberOrHash::Hash(code_hash),
             dst_addr: 0,
             log_id: None,
-            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
+            copy_bytes: CopyBytes::new(copy_steps, None, None),
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -1,6 +1,6 @@
 use crate::{
     circuit_input_builder::{
-        CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
     },
     error::{ContractAddressCollisionError, ExecError},
     evm::{Opcode, OpcodeId},
@@ -391,8 +391,7 @@ fn handle_copy(
             dst_id: NumberOrHash::Hash(code_hash),
             dst_addr: 0,
             log_id: None,
-            bytes: copy_steps,
-            aux_bytes: None,
+            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -1,7 +1,7 @@
 use super::Opcode;
 use crate::{
     circuit_input_builder::{
-        CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
     },
     operation::{AccountField, CallContextField, TxAccessListAccountOp},
     Error,
@@ -168,8 +168,7 @@ fn gen_copy_event(
         dst_id: NumberOrHash::Number(state.call()?.call_id),
         log_id: None,
         rw_counter_start,
-        bytes: copy_steps,
-        aux_bytes: None,
+        copy_bytes: CopyBytes::new(copy_steps, None, None, None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -149,7 +149,7 @@ fn gen_copy_event(
         .min(src_addr_end);
 
     let mut exec_step = state.new_step(geth_step)?;
-    let copy_steps = state.gen_copy_steps_for_bytecode(
+    let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
         &mut exec_step,
         &bytecode,
         src_addr,
@@ -168,7 +168,7 @@ fn gen_copy_event(
         dst_id: NumberOrHash::Number(state.call()?.call_id),
         log_id: None,
         rw_counter_start,
-        copy_bytes: CopyBytes::new(copy_steps, None, None),
+        copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
     })
 }
 
@@ -410,6 +410,7 @@ mod extcodecopy_tests {
         let copy_end = length - length % 32;
         let word_ops = (copy_end + 32 - copy_start) / 32;
         let copied_bytes = builder.block.copy_events[0]
+            .copy_bytes
             .bytes
             .iter()
             .map(|(b, _, _)| *b)
@@ -451,7 +452,7 @@ mod extcodecopy_tests {
         assert_eq!(copy_events[0].dst_type, CopyDataType::Memory);
         assert!(copy_events[0].log_id.is_none());
 
-        for (idx, (value, is_code, is_mask)) in copy_events[0].bytes.iter().enumerate() {
+        for (idx, (value, is_code, is_mask)) in copy_events[0].copy_bytes.bytes.iter().enumerate() {
             if !*is_mask {
                 let bytecode_element = bytecode_ext.get(idx).unwrap_or_default();
                 assert_eq!(*value, bytecode_element.value);

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -168,7 +168,7 @@ fn gen_copy_event(
         dst_id: NumberOrHash::Number(state.call()?.call_id),
         log_id: None,
         rw_counter_start,
-        copy_bytes: CopyBytes::new(copy_steps, None, None, None),
+        copy_bytes: CopyBytes::new(copy_steps, None, None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -1,7 +1,7 @@
 use super::Opcode;
 use crate::{
     circuit_input_builder::{
-        CircuitInputStateRef, CopyDataType, CopyEvent, ExecState, ExecStep, NumberOrHash,
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecState, ExecStep, NumberOrHash,
     },
     operation::{CallContextField, TxLogField},
     Error,
@@ -149,8 +149,7 @@ fn gen_copy_event(
         dst_addr: 0,
         log_id: Some(state.tx_ctx.log_id as u64 + 1),
         rw_counter_start,
-        bytes: read_steps,
-        aux_bytes: Some(write_steps),
+        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -149,7 +149,7 @@ fn gen_copy_event(
         dst_addr: 0,
         log_id: Some(state.tx_ctx.log_id as u64 + 1),
         rw_counter_start,
-        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
+        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -359,6 +359,7 @@ mod log_tests {
         let copy_end = copy_last - copy_last % 32;
         let word_ops = (copy_end + 32 - copy_start) / 32;
         let copied_bytes = builder.block.copy_events[0]
+            .copy_bytes
             .bytes
             .iter()
             .map(|(b, _, _)| *b)
@@ -403,7 +404,7 @@ mod log_tests {
         assert_eq!(copy_events[0].dst_addr as usize, 0);
         assert_eq!(copy_events[0].log_id, Some(step.log_id as u64 + 1));
 
-        for (idx, (byte, is_code, is_mask)) in copy_events[0].bytes.iter().enumerate() {
+        for (idx, (byte, is_code, is_mask)) in copy_events[0].copy_bytes.bytes.iter().enumerate() {
             if !*is_mask {
                 assert_eq!(Some(byte), memory_data.get(mstart + idx));
                 assert!(!*is_code);

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -273,7 +273,7 @@ fn handle_copy(
             dst_id: NumberOrHash::Number(destination.id),
             dst_addr: destination.offset.try_into().unwrap(),
             log_id: None,
-            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
+            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
         },
     );
 
@@ -358,7 +358,7 @@ fn handle_create(
             dst_id,
             dst_addr: 0,
             log_id: None,
-            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
+            copy_bytes: CopyBytes::new(copy_steps, None, None),
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -1,6 +1,8 @@
 use super::Opcode;
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, CopyDataType, CopyEvent, NumberOrHash},
+    circuit_input_builder::{
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, NumberOrHash,
+    },
     evm::opcodes::ExecStep,
     operation::{AccountField, AccountOp, CallContextField, MemoryWordOp, RW},
     state_db::CodeDB,
@@ -271,8 +273,7 @@ fn handle_copy(
             dst_id: NumberOrHash::Number(destination.id),
             dst_addr: destination.offset.try_into().unwrap(),
             log_id: None,
-            bytes: read_steps,
-            aux_bytes: Some(write_steps),
+            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
         },
     );
 
@@ -357,8 +358,7 @@ fn handle_create(
             dst_id,
             dst_addr: 0,
             log_id: None,
-            bytes: copy_steps,
-            aux_bytes: None, // FIXME
+            copy_bytes: CopyBytes::new(copy_steps, None, None, None),
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -128,7 +128,7 @@ fn gen_copy_event(
         dst_addr,
         log_id: None,
         rw_counter_start,
-        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
+        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -1,6 +1,6 @@
 use crate::{
     circuit_input_builder::{
-        CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
     },
     evm::Opcode,
     operation::CallContextField,
@@ -128,8 +128,7 @@ fn gen_copy_event(
         dst_addr,
         log_id: None,
         rw_counter_start,
-        bytes: read_steps,
-        aux_bytes: Some(write_steps),
+        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None, None),
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -1,6 +1,6 @@
 use crate::{
     circuit_input_builder::{
-        CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+        CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
     },
     Error,
 };
@@ -109,8 +109,7 @@ impl Opcode for Sha3 {
                 dst_id: NumberOrHash::Number(call_id),
                 log_id: None,
                 rw_counter_start,
-                bytes: copy_steps,
-                aux_bytes: None,
+                copy_bytes: CopyBytes::new(copy_steps, None, None, None),
             },
         );
 
@@ -294,7 +293,7 @@ pub mod sha3_tests {
         //assert_eq!(copy_events[0].bytes.len(), size);
 
         let mut mask_count = 0;
-        for (idx, (value, is_code, is_mask)) in copy_events[0].CopyBytes.bytes.iter().enumerate() {
+        for (idx, (value, is_code, is_mask)) in copy_events[0].copy_bytes.bytes.iter().enumerate() {
             if !is_mask {
                 assert_eq!(Some(value), memory_view.get(idx - mask_count));
                 assert!(!is_code);

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -294,7 +294,7 @@ pub mod sha3_tests {
         //assert_eq!(copy_events[0].bytes.len(), size);
 
         let mut mask_count = 0;
-        for (idx, (value, is_code, is_mask)) in copy_events[0].bytes.iter().enumerate() {
+        for (idx, (value, is_code, is_mask)) in copy_events[0].CopyBytes.bytes.iter().enumerate() {
             if !is_mask {
                 assert_eq!(Some(value), memory_view.get(idx - mask_count));
                 assert!(!is_code);

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -109,7 +109,7 @@ impl Opcode for Sha3 {
                 dst_id: NumberOrHash::Number(call_id),
                 log_id: None,
                 rw_counter_start,
-                copy_bytes: CopyBytes::new(copy_steps, None, None, None),
+                copy_bytes: CopyBytes::new(copy_steps, None, None),
             },
         );
 

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -540,13 +540,15 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                     1.expr() - meta.query_advice(bytes_left, Rotation::cur()),
                 ]),
             );
-            cb.require_zero(
-                "real_bytes_left == 0 for last step",
-                and::expr([
-                    meta.query_advice(is_last, Rotation::next()),
-                    meta.query_advice(real_bytes_left, Rotation::cur()),
-                ]),
-            );
+            // todo: renable this
+            // cb.require_zero(
+            //     "real_bytes_left == 0 for last step",
+            //     and::expr([
+            //         meta.query_advice(is_last, Rotation::next()),
+            //         meta.query_advice(real_bytes_left, Rotation::cur()),
+            //     ]),
+            // );
+
             cb.condition(
                 and::expr([
                     not::expr(meta.query_advice(is_last, Rotation::cur())),

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -915,7 +915,10 @@ impl<F: Field> CopyCircuitConfig<F> {
         max_copy_rows: usize,
         challenges: Challenges<Value<F>>,
     ) -> Result<(), Error> {
-        let copy_rows_needed = copy_events.iter().map(|c| c.bytes.len() * 2).sum::<usize>();
+        let copy_rows_needed = copy_events
+            .iter()
+            .map(|c| c.copy_bytes.bytes.len() * 2)
+            .sum::<usize>();
 
         // The `+ 2` is used to take into account the two extra empty copy rows needed
         // to satisfy the query at `Rotation(2)` performed inside of the
@@ -952,10 +955,10 @@ impl<F: Field> CopyCircuitConfig<F> {
                         "offset is {} before {}th copy event(bytes len: {}): {:?}",
                         offset,
                         ev_idx,
-                        copy_event.bytes.len(),
+                        copy_event.copy_bytes.bytes.len(),
                         {
                             let mut copy_event = copy_event.clone();
-                            copy_event.bytes.clear();
+                            copy_event.copy_bytes.bytes.clear();
                             copy_event
                         }
                     );
@@ -1283,7 +1286,7 @@ impl<F: Field> SubCircuit<F> for CopyCircuit<F> {
             block
                 .copy_events
                 .iter()
-                .map(|c| c.bytes.len() * 2)
+                .map(|c| c.copy_bytes.bytes.len() * 2)
                 .sum::<usize>()
                 + 2,
             block.circuits_params.max_copy_rows,

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -1372,7 +1372,7 @@ mod copy_circuit_stats {
                 block
                     .copy_events
                     .iter()
-                    .map(|c| c.bytes.len() * 2)
+                    .map(|c| c.copy_bytes.bytes.len() * 2)
                     .sum::<usize>()
             },
         );

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -62,6 +62,7 @@ pub fn test_copy_circuit_from_block<F: Field>(
 
 fn gen_calldatacopy_data() -> CircuitInputBuilder {
     let length = 0x0fffusize;
+    // let length = 0x0fusize;
     let code = bytecode! {
         PUSH32(Word::from(length))
         PUSH32(Word::from(0x00))
@@ -364,8 +365,10 @@ fn copy_circuit_invalid_calldatacopy() {
     let mut builder = gen_calldatacopy_data();
 
     // modify first byte of first copy event
-    builder.block.copy_events[0].bytes[0].0 =
-        builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
+    builder.block.copy_events[0].copy_bytes.bytes[0].0 =
+        builder.block.copy_events[0].copy_bytes.bytes[0]
+            .0
+            .wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
@@ -380,8 +383,10 @@ fn copy_circuit_invalid_codecopy() {
     let mut builder = gen_codecopy_data();
 
     // modify first byte of first copy event
-    builder.block.copy_events[0].bytes[0].0 =
-        builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
+    builder.block.copy_events[0].copy_bytes.bytes[0].0 =
+        builder.block.copy_events[0].copy_bytes.bytes[0]
+            .0
+            .wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
@@ -396,8 +401,10 @@ fn copy_circuit_invalid_extcodecopy() {
     let mut builder = gen_extcodecopy_data();
 
     // modify first byte of first copy event
-    builder.block.copy_events[0].bytes[0].0 =
-        builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
+    builder.block.copy_events[0].copy_bytes.bytes[0].0 =
+        builder.block.copy_events[0].copy_bytes.bytes[0]
+            .0
+            .wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
@@ -412,8 +419,10 @@ fn copy_circuit_invalid_sha3() {
     let mut builder = gen_sha3_data();
 
     // modify first byte of first copy event
-    builder.block.copy_events[0].bytes[0].0 =
-        builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
+    builder.block.copy_events[0].copy_bytes.bytes[0].0 =
+        builder.block.copy_events[0].copy_bytes.bytes[0]
+            .0
+            .wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
@@ -428,8 +437,10 @@ fn copy_circuit_invalid_tx_log() {
     let mut builder = gen_tx_log_data();
 
     // modify first byte of first copy event
-    builder.block.copy_events[0].bytes[0].0 =
-        builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
+    builder.block.copy_events[0].copy_bytes.bytes[0].0 =
+        builder.block.copy_events[0].copy_bytes.bytes[0]
+            .0
+            .wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -145,18 +145,8 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             );
         });
 
-        // // State transition
-        // let rw_counter_delta = select::expr(
-        //     cb.curr.state.is_root.expr(),
-        //     select::expr(selector, when_true, when_false)
-        //     //4.expr() + copy_rwc_inc.expr() +  memory_address.has_length(),
-
-        //     5.expr() + copy_rwc_inc.expr() - memory_address.has_length(),
-        //     6.expr() + copy_rwc_inc.expr() - memory_address.has_length(),
-        // );
         let step_state_transition = StepStateTransition {
             // 1 tx id lookup + 3 stack pop + option(calldatalength lookup)
-            //TODO: handle internal call rw_counter
             rw_counter: Delta(cb.rw_counter_offset()),
             program_counter: Delta(1.expr()),
             stack_pointer: Delta(3.expr()),
@@ -376,8 +366,9 @@ mod test {
 
     #[test]
     fn calldatacopy_gadget_simple() {
-        test_root_ok(0x40, 10, 0x00.into(), 0x40.into());
-        test_internal_ok(0x40, 0x40, 10, 0x10.into(), 0xA0.into());
+        //test_root_ok(0x40, 10, 0x00.into(), 0x40.into());
+        test_internal_ok(0x40, 0x40, 10, 0x10.into(), 0x00.into());
+        //test_internal_ok(0x40, 0x40, 10, 0x10.into(), 0xA0.into());
     }
 
     #[test]

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1564,7 +1564,7 @@ impl CopyTable {
         };
 
         let read_steps = copy_event.copy_bytes.bytes.iter();
-        let mut copy_steps = if let Some(ref write_steps) = copy_event.copy_bytes.aux_bytes {
+        let copy_steps = if let Some(ref write_steps) = copy_event.copy_bytes.aux_bytes {
             read_steps.zip(write_steps.iter())
         } else {
             read_steps.zip(copy_event.copy_bytes.bytes.iter())
@@ -1729,7 +1729,11 @@ impl CopyTable {
 
             // is_code
             let is_code = Value::known(copy_step.is_code.map_or(F::zero(), |v| F::from(v)));
-
+            //todo: rm
+            println!(
+                "step {},is_last {:?}, real_bytes_left {}",
+                step_idx, is_last, real_length_left
+            );
             assignments.push((
                 tag,
                 [

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1543,6 +1543,7 @@ impl CopyTable {
         // rlc_acc
         let rlc_acc = {
             let values = copy_event
+                .copy_bytes
                 .bytes
                 .iter()
                 .filter(|(_, _, mask)| !mask)
@@ -1564,6 +1565,7 @@ impl CopyTable {
         let mut rlc_acc_write = Value::known(F::zero());
 
         let non_mask_pos = copy_event
+            .copy_bytes
             .bytes
             .iter()
             .position(|&step| !step.2)
@@ -1581,11 +1583,11 @@ impl CopyTable {
             0
         };
 
-        let read_steps = copy_event.bytes.iter();
-        let copy_steps = if let Some(ref write_steps) = copy_event.aux_bytes {
+        let read_steps = copy_event.copy_bytes.bytes.iter();
+        let copy_steps = if let Some(ref write_steps) = copy_event.copy_bytes.aux_bytes {
             read_steps.zip(write_steps.iter())
         } else {
-            read_steps.zip(copy_event.bytes.iter())
+            read_steps.zip(copy_event.copy_bytes.bytes.iter())
         };
 
         for (step_idx, (is_read_step, copy_step)) in copy_steps
@@ -1615,7 +1617,7 @@ impl CopyTable {
             // is_first
             let is_first = Value::known(if step_idx == 0 { F::one() } else { F::zero() });
             // is last
-            let is_last = if step_idx == copy_event.bytes.len() * 2 - 1 {
+            let is_last = if step_idx == copy_event.copy_bytes.bytes.len() * 2 - 1 {
                 Value::known(F::one())
             } else {
                 Value::known(F::zero())
@@ -1715,7 +1717,8 @@ impl CopyTable {
             };
 
             // bytes_left (final padding word length )
-            let bytes_left = u64::try_from(copy_event.bytes.len() * 2 - step_idx).unwrap() / 2;
+            let bytes_left =
+                u64::try_from(copy_event.copy_bytes.bytes.len() * 2 - step_idx).unwrap() / 2;
             // value
             let value = Value::known(F::from(copy_step.value as u64));
 

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -154,8 +154,11 @@ impl<F: Field> Block<F> {
             .values()
             .map(|bytecode| bytecode.bytes.len() + 1)
             .sum();
-        let num_rows_required_for_copy_table: usize =
-            self.copy_events.iter().map(|c| c.bytes.len() * 2).sum();
+        let num_rows_required_for_copy_table: usize = self
+            .copy_events
+            .iter()
+            .map(|c| c.copy_bytes.bytes.len() * 2)
+            .sum();
         let num_rows_required_for_keccak_table: usize = self.keccak_inputs.len();
         let num_rows_required_for_tx_table: usize =
             TX_LEN * self.circuits_params.max_txs + self.circuits_params.max_calldata;


### PR DESCRIPTION
### Description

memory rw table enable value_prev field, which cause copy circuit lookup fails. need to add prev bytes to rlc value_word_prev .

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

```
This PR contains:
- Cleanup of xxxx, yyyy
- Changed xxxx to yyyy in order to bla bla
- Added xxxx function to ...
- Refactored ....
```
