### PR TITLE
fix returndatacopy and state test

### DIFF
--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -107,7 +107,7 @@ fn gen_copy_event(
         last_callee_return_data_offset + last_callee_return_data_length,
     );
 
-    let (read_steps, write_steps) = state.gen_copy_steps_for_return_data(
+    let (read_steps, write_steps, prev_bytes) = state.gen_copy_steps_for_return_data(
         exec_step,
         src_addr,
         src_addr_end,
@@ -126,7 +126,7 @@ fn gen_copy_event(
         dst_addr,
         log_id: None,
         rw_counter_start,
-        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
+        copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(prev_bytes)),
     })
 }
 

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -151,21 +151,6 @@ impl MemoryWordOp {
         Self::new_write(call_id, address, value, value)
     }
 
-    /// Create a new instance of a `MemoryWordOp` with value_prev provided
-    pub fn new_with_prev_value(
-        call_id: usize,
-        address: MemoryAddress,
-        value: Word,
-        value_prev: Word,
-    ) -> MemoryWordOp {
-        MemoryWordOp {
-            call_id,
-            address,
-            value,
-            value_prev,
-        }
-    }
-
     /// Create a new instance of a `MemoryOp` from it's components.
     pub fn new_write(
         call_id: usize,

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -151,6 +151,21 @@ impl MemoryWordOp {
         Self::new_write(call_id, address, value, value)
     }
 
+    /// Create a new instance of a `MemoryWordOp` with value_prev provided
+    pub fn new_with_prev_value(
+        call_id: usize,
+        address: MemoryAddress,
+        value: Word,
+        value_prev: Word,
+    ) -> MemoryWordOp {
+        MemoryWordOp {
+            call_id,
+            address,
+            value,
+            value_prev,
+        }
+    }
+
     /// Create a new instance of a `MemoryOp` from it's components.
     pub fn new_write(
         call_id: usize,

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -108,7 +108,7 @@ fn state_circuit_simple_2() {
     let memory_op_2 = Operation::new(
         RWCounter::from(17),
         RW::WRITE,
-        MemoryWordOp::new(1, MemoryAddress::from(1), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(1), 32.into(), 0.into()),
     );
     let memory_op_3 = Operation::new(
         RWCounter::from(87),

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -97,12 +97,12 @@ fn state_circuit_simple_2() {
     let memory_op_0 = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new(1, MemoryAddress::from(0), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let memory_op_1 = Operation::new(
         RWCounter::from(24),
         RW::READ,
-        MemoryWordOp::new(1, MemoryAddress::from(0), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 32.into()),
     );
 
     let memory_op_2 = Operation::new(
@@ -113,7 +113,7 @@ fn state_circuit_simple_2() {
     let memory_op_3 = Operation::new(
         RWCounter::from(87),
         RW::READ,
-        MemoryWordOp::new(1, MemoryAddress::from(1), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(1), 32.into(), 32.into()),
     );
 
     let stack_op_0 = Operation::new(
@@ -176,12 +176,12 @@ fn state_circuit_simple_6() {
     let memory_op_0 = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new(1, MemoryAddress::from(0), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let memory_op_1 = Operation::new(
         RWCounter::from(13),
         RW::READ,
-        MemoryWordOp::new(1, MemoryAddress::from(0), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 32.into()),
     );
     let storage_op_2 = Operation::new(
         RWCounter::from(19),
@@ -203,7 +203,7 @@ fn lexicographic_ordering_test_1() {
     let memory_op = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new(1, MemoryAddress::from(0), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let storage_op = Operation::new(
         RWCounter::from(19),
@@ -225,12 +225,12 @@ fn lexicographic_ordering_test_2() {
     let memory_op_0 = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new(1, MemoryAddress::from(0), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let memory_op_1 = Operation::new(
         RWCounter::from(13),
         RW::WRITE,
-        MemoryWordOp::new(1, MemoryAddress::from(0), 32.into()),
+        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 32.into()),
     );
     test_state_circuit_ok(vec![memory_op_0, memory_op_1], vec![], vec![]);
 }
@@ -479,6 +479,7 @@ fn nonlexicographic_order_tag() {
         call_id: 1,
         memory_address: 10,
         value: 12.into(),
+        value_prev: 0.into(),
     };
     let second = Rw::CallContext {
         rw_counter: 2,
@@ -678,6 +679,7 @@ fn read_inconsistency() {
             call_id: 1,
             memory_address: 10,
             value: 0.into(),
+            value_prev: 0.into(),
         },
         Rw::MemoryWord {
             rw_counter: 40,
@@ -685,6 +687,7 @@ fn read_inconsistency() {
             call_id: 1,
             memory_address: 10,
             value: 200.into(),
+            value_prev: 0.into(),
         },
     ];
 
@@ -722,6 +725,7 @@ fn invalid_memory_address() {
         call_id: 1,
         memory_address: 1u64 << 32,
         value: 12.into(),
+        value_prev: 0.into(),
     }];
 
     assert_error_matches(verify(rows), "memory address fits into 2 limbs");
@@ -735,6 +739,7 @@ fn bad_initial_memory_value() {
         call_id: 1,
         memory_address: 10,
         value: 0.into(),
+        value_prev: 0.into(),
     }];
 
     let v = Fr::from(200);

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -97,23 +97,23 @@ fn state_circuit_simple_2() {
     let memory_op_0 = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let memory_op_1 = Operation::new(
         RWCounter::from(24),
         RW::READ,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 32.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(0), 32.into(), 32.into()),
     );
 
     let memory_op_2 = Operation::new(
         RWCounter::from(17),
         RW::WRITE,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(1), 32.into(), 0.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(1), 32.into(), 0.into()),
     );
     let memory_op_3 = Operation::new(
         RWCounter::from(87),
         RW::READ,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(1), 32.into(), 32.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(1), 32.into(), 32.into()),
     );
 
     let stack_op_0 = Operation::new(
@@ -176,12 +176,12 @@ fn state_circuit_simple_6() {
     let memory_op_0 = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let memory_op_1 = Operation::new(
         RWCounter::from(13),
         RW::READ,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 32.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(0), 32.into(), 32.into()),
     );
     let storage_op_2 = Operation::new(
         RWCounter::from(19),
@@ -203,7 +203,7 @@ fn lexicographic_ordering_test_1() {
     let memory_op = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let storage_op = Operation::new(
         RWCounter::from(19),
@@ -225,12 +225,12 @@ fn lexicographic_ordering_test_2() {
     let memory_op_0 = Operation::new(
         RWCounter::from(12),
         RW::WRITE,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 0.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(0), 32.into(), 0.into()),
     );
     let memory_op_1 = Operation::new(
         RWCounter::from(13),
         RW::WRITE,
-        MemoryWordOp::new_with_prev_value(1, MemoryAddress::from(0), 32.into(), 32.into()),
+        MemoryWordOp::new_write(1, MemoryAddress::from(0), 32.into(), 32.into()),
     );
     test_state_circuit_ok(vec![memory_op_0, memory_op_1], vec![], vec![]);
 }


### PR DESCRIPTION
### Description

fix returndatacopy with prev bytes and state test with memory word `value_prev`.
### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents


