### PR TITLE
fix state circuit: value_prev column is initial_value for first access for (ext)codecopy

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1657,6 +1657,7 @@ impl<'a> CircuitInputStateRef<'a> {
         dst_addr: u64,
         src_addr_end: u64,
         bytes_left: u64,
+        memory_updated: Memory,
     ) -> Result<(CopyEventSteps, Vec<u8>), Error> {
         let mut copy_steps = Vec::with_capacity(bytes_left as usize);
         let mut prev_bytes: Vec<u8> = vec![];
@@ -1666,10 +1667,7 @@ impl<'a> CircuitInputStateRef<'a> {
 
         let (dst_begin_slot, full_length, _) = Memory::align_range(dst_addr, bytes_left);
 
-        let code_slot_bytes = self
-            .call_ctx()?
-            .memory
-            .read_chunk(dst_begin_slot.into(), full_length.into());
+        let code_slot_bytes = memory_updated.read_chunk(dst_begin_slot.into(), full_length.into());
 
         let mut copy_start = 0u64;
         let mut first_set = true;
@@ -2191,7 +2189,6 @@ impl<'a> CircuitInputStateRef<'a> {
 
         Ok((read_steps, write_steps))
     }
-
     // TODO: add new gen_copy_steps for common use
     pub(crate) fn gen_memory_copy_steps(
         steps: &mut CopyEventSteps,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -290,7 +290,7 @@ impl<'a> CircuitInputStateRef<'a> {
         step: &mut ExecStep,
         address: MemoryAddress, //Caution: make sure this address = slot passing
         value: Word,
-    ) -> Result<(Vec<u8>), Error> {
+    ) -> Result<Vec<u8>, Error> {
         let mem = &mut self.call_ctx_mut()?.memory;
         let value_prev = mem.read_word(address);
         let value_prev_bytes = value_prev.to_be_bytes();
@@ -1669,8 +1669,7 @@ impl<'a> CircuitInputStateRef<'a> {
 
         let code_slot_bytes = memory_updated.read_chunk(dst_begin_slot.into(), full_length.into());
 
-        let mut copy_start = 0u64;
-        let mut first_set = true;
+        let copy_start = dst_addr - dst_begin_slot;
         for (idx, value) in code_slot_bytes.iter().enumerate() {
             if (idx as u64 + dst_begin_slot < dst_addr)
                 || (idx as u64 + dst_begin_slot >= dst_addr + bytes_left)
@@ -1679,11 +1678,6 @@ impl<'a> CircuitInputStateRef<'a> {
                 copy_steps.push((*value, false, true));
             } else {
                 // real copy byte
-                if first_set {
-                    copy_start = idx as u64;
-                    first_set = false;
-                }
-
                 let addr = src_addr
                     .checked_add(idx as u64 - copy_start)
                     .unwrap_or(src_addr_end);

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -76,18 +76,16 @@ fn gen_copy_event(
     let src_addr = u64::try_from(code_offset)
         .unwrap_or(u64::MAX)
         .min(src_addr_end);
-    ///////memory_update
+
     let call_ctx = state.call_ctx_mut()?;
     let memory = &mut call_ctx.memory;
     memory.extend_for_range(dst_offset, length.into());
-    // memory.copy_from(dst_offset, code_offset, length, &code);
     let memory_updated = {
         let mut memory_updated = memory.clone();
         memory_updated.copy_from(dst_offset, code_offset, length.into(), &bytecode.to_vec());
         memory_updated
     };
 
-    /// /end
     let mut exec_step = state.new_step(geth_step)?;
     let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
         &mut exec_step,

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -19,7 +19,6 @@ impl Opcode for Codecopy {
         let geth_step = &geth_steps[0];
         let mut exec_steps = vec![gen_codecopy_step(state, geth_step)?];
 
-
         let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
         Ok(exec_steps)

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -19,19 +19,6 @@ impl Opcode for Codecopy {
         let geth_step = &geth_steps[0];
         let mut exec_steps = vec![gen_codecopy_step(state, geth_step)?];
 
-        // reconstruction
-        let dst_offset = geth_step.stack.nth_last(0)?;
-        let code_offset = geth_step.stack.nth_last(1)?;
-        let length = geth_step.stack.nth_last(2)?;
-
-        let code_hash = state.call()?.code_hash;
-        let code = state.code(code_hash)?;
-
-        let call_ctx = state.call_ctx_mut()?;
-        let memory = &mut call_ctx.memory;
-
-        // TODO: move to the "memory_updated" approach.
-        memory.copy_from(dst_offset, code_offset, length, &code);
 
         let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
@@ -89,7 +76,18 @@ fn gen_copy_event(
     let src_addr = u64::try_from(code_offset)
         .unwrap_or(u64::MAX)
         .min(src_addr_end);
+    ///////memory_update
+    let call_ctx = state.call_ctx_mut()?;
+    let memory = &mut call_ctx.memory;
+    memory.extend_for_range(dst_offset, length.into());
+    // memory.copy_from(dst_offset, code_offset, length, &code);
+    let memory_updated = {
+        let mut memory_updated = memory.clone();
+        memory_updated.copy_from(dst_offset, code_offset, length.into(), &bytecode.to_vec());
+        memory_updated
+    };
 
+    /// /end
     let mut exec_step = state.new_step(geth_step)?;
     let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
         &mut exec_step,
@@ -98,6 +96,7 @@ fn gen_copy_event(
         dst_addr,
         src_addr_end,
         length,
+        memory_updated,
     )?;
 
     Ok(CopyEvent {

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -22,21 +22,6 @@ impl Opcode for Extcodecopy {
         let geth_step = &geth_steps[0];
         let mut exec_steps = vec![gen_extcodecopy_step(state, geth_step)?];
 
-        // reconstruction
-        let address = geth_steps[0].stack.nth_last(0)?.to_address();
-        let dst_offset = geth_steps[0].stack.nth_last(1)?;
-        let code_offset = geth_step.stack.nth_last(2)?;
-        let length = geth_steps[0].stack.nth_last(3)?;
-
-        let (_, account) = state.sdb.get_account(&address);
-        let code_hash = account.code_hash;
-        let code = state.code(code_hash)?;
-
-        let call_ctx = state.call_ctx_mut()?;
-        let memory = &mut call_ctx.memory;
-
-        // TODO: move to the "memory_updated" approach.
-        memory.copy_from(dst_offset, code_offset, length, &code);
 
         let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
@@ -149,14 +134,25 @@ fn gen_copy_event(
         .unwrap_or(u64::MAX)
         .min(src_addr_end);
 
-    let mut exec_step = state.new_step(geth_step)?;
+    let call_ctx = state.call_ctx_mut()?;
+    let memory = &mut call_ctx.memory;
+    memory.extend_for_range(dst_offset, length.into());
+    // memory.copy_from(dst_offset, code_offset, length, &code);
+    let memory_updated = {
+        let mut memory_updated = memory.clone();
+        memory_updated.copy_from(dst_offset, code_offset, length.into(), &bytecode.to_vec());
+        memory_updated
+    };
+
+    /// end
     let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
-        &mut exec_step,
+        exec_step,
         &bytecode,
         src_addr,
         dst_addr,
         src_addr_end,
         length,
+        memory_updated,
     )?;
 
     Ok(CopyEvent {
@@ -416,8 +412,13 @@ mod extcodecopy_tests {
             .iter()
             .map(|(b, _, _)| *b)
             .collect::<Vec<_>>();
-        assert_eq!(builder.block.container.memory_word.len(), word_ops);
+        let prev_bytes = builder.block.copy_events[0]
+            .copy_bytes
+            .bytes_write_prev
+            .clone()
+            .unwrap();
 
+        assert_eq!(builder.block.container.memory_word.len(), word_ops);
         assert_eq!(
             (0..word_ops)
                 .map(|idx| &builder.block.container.memory_word[idx])
@@ -431,7 +432,7 @@ mod extcodecopy_tests {
                             call_id,
                             MemoryAddress(copy_start + idx * 32),
                             Word::from(&copied_bytes[idx * 32..(idx + 1) * 32]),
-                            Word::from(&copied_bytes[idx * 32..(idx + 1) * 32]), // TODO: get previous value
+                            Word::from(&prev_bytes[idx * 32..(idx + 1) * 32]), // TODO: get previous value
                         ),
                     )
                 })
@@ -440,7 +441,6 @@ mod extcodecopy_tests {
 
         let copy_events = builder.block.copy_events.clone();
         assert_eq!(copy_events.len(), 1);
-        //assert_eq!(copy_events[0].bytes.len(), copy_size);
         assert_eq!(copy_events[0].src_id, NumberOrHash::Hash(code_hash));
         assert_eq!(copy_events[0].src_addr as usize, data_offset);
         assert_eq!(copy_events[0].src_addr_end as usize, code_ext.len());

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -137,14 +137,12 @@ fn gen_copy_event(
     let call_ctx = state.call_ctx_mut()?;
     let memory = &mut call_ctx.memory;
     memory.extend_for_range(dst_offset, length.into());
-    // memory.copy_from(dst_offset, code_offset, length, &code);
     let memory_updated = {
         let mut memory_updated = memory.clone();
         memory_updated.copy_from(dst_offset, code_offset, length.into(), &bytecode.to_vec());
         memory_updated
     };
 
-    /// end
     let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
         exec_step,
         &bytecode,
@@ -432,7 +430,8 @@ mod extcodecopy_tests {
                             call_id,
                             MemoryAddress(copy_start + idx * 32),
                             Word::from(&copied_bytes[idx * 32..(idx + 1) * 32]),
-                            Word::from(&prev_bytes[idx * 32..(idx + 1) * 32]), // TODO: get previous value
+                            // get previous value
+                            Word::from(&prev_bytes[idx * 32..(idx + 1) * 32]),
                         ),
                     )
                 })

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -22,7 +22,6 @@ impl Opcode for Extcodecopy {
         let geth_step = &geth_steps[0];
         let mut exec_steps = vec![gen_extcodecopy_step(state, geth_step)?];
 
-
         let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
         Ok(exec_steps)

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -138,8 +138,8 @@ impl fmt::Debug for MemoryWordOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("MemoryWordOp { ")?;
         f.write_fmt(format_args!(
-            "call_id: {:?}, addr: {:?}, value: 0x{:?}",
-            self.call_id, self.address, self.value
+            "call_id: {:?}, addr: {:?}, value: 0x{:?} value_prev {:?}",
+            self.call_id, self.address, self.value, self.value_prev
         ))?;
         f.write_str(" }")
     }


### PR DESCRIPTION
### Description

on memory_opt_update branch,  it is because the the pre_value not set correctly, which cause state circuit fail to pass contraint  value_prev column is initial_value for first access. fix to get correct prev_bytes
### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update






