### PR TITLE
Fix ecrecover input rlc comparison (right-padding zeroes)

### DIFF
--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -269,14 +269,6 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                     callee_gas_left,
                 );
 
-                log::info!(
-                    "precompile returned {:?} with len {} and gas {} and is_success {}",
-                    result,
-                    result.len(),
-                    contract_gas_cost,
-                    call.is_success(),
-                );
-
                 // mutate the caller memory.
                 let caller_ctx_mut = state.caller_ctx_mut()?;
                 caller_ctx_mut.return_data = result.clone();

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -115,7 +115,6 @@ impl PrecompileCalls {
         match self {
             Self::Ecrecover | Self::Bn128Add => Some(128),
             Self::Bn128Mul => Some(96),
-            Self::Blake2F => Some(213),
             _ => None,
         }
     }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -425,7 +425,7 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
         let keccak_table = KeccakTable::construct(meta);
         let exp_table = ExpTable::construct(meta);
         let sig_table = SigTable::construct(meta);
-        let pow_of_rand_table = PowOfRandTable::construct(meta);
+        let pow_of_rand_table = PowOfRandTable::construct(meta, &challenges_expr);
         (
             EvmCircuitConfig::new(
                 meta,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -21,8 +21,8 @@ pub use crate::witness;
 use crate::{
     evm_circuit::param::{MAX_STEP_HEIGHT, STEP_STATE_HEIGHT},
     table::{
-        BlockTable, BytecodeTable, CopyTable, ExpTable, KeccakTable, LookupTable, RwTable,
-        SigTable, TxTable,
+        BlockTable, BytecodeTable, CopyTable, ExpTable, KeccakTable, LookupTable, PowOfRandTable,
+        RwTable, SigTable, TxTable,
     },
     util::{SubCircuit, SubCircuitConfig},
 };
@@ -49,6 +49,7 @@ pub struct EvmCircuitConfig<F> {
     keccak_table: KeccakTable,
     exp_table: ExpTable,
     sig_table: SigTable,
+    pow_of_rand_table: PowOfRandTable,
 }
 
 /// Circuit configuration arguments
@@ -71,6 +72,8 @@ pub struct EvmCircuitConfigArgs<F: Field> {
     pub exp_table: ExpTable,
     /// SigTable
     pub sig_table: SigTable,
+    // Power of Randomness Table.
+    pub pow_of_rand_table: PowOfRandTable,
 }
 
 /// Circuit exported cells after synthesis, used for subcircuit
@@ -97,6 +100,7 @@ impl<F: Field> SubCircuitConfig<F> for EvmCircuitConfig<F> {
             keccak_table,
             exp_table,
             sig_table,
+            pow_of_rand_table,
         }: Self::ConfigArgs,
     ) -> Self {
         let fixed_table = [(); 4].map(|_| meta.fixed_column());
@@ -114,6 +118,7 @@ impl<F: Field> SubCircuitConfig<F> for EvmCircuitConfig<F> {
             &keccak_table,
             &exp_table,
             &sig_table,
+            &pow_of_rand_table,
         ));
 
         meta.annotate_lookup_any_column(byte_table[0], || "byte_range");
@@ -128,6 +133,7 @@ impl<F: Field> SubCircuitConfig<F> for EvmCircuitConfig<F> {
         keccak_table.annotate_columns(meta);
         exp_table.annotate_columns(meta);
         sig_table.annotate_columns(meta);
+        pow_of_rand_table.annotate_columns(meta);
 
         Self {
             fixed_table,
@@ -141,6 +147,7 @@ impl<F: Field> SubCircuitConfig<F> for EvmCircuitConfig<F> {
             keccak_table,
             exp_table,
             sig_table,
+            pow_of_rand_table,
         }
     }
 }
@@ -418,6 +425,7 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
         let keccak_table = KeccakTable::construct(meta);
         let exp_table = ExpTable::construct(meta);
         let sig_table = SigTable::construct(meta);
+        let pow_of_rand_table = PowOfRandTable::construct(meta);
         (
             EvmCircuitConfig::new(
                 meta,
@@ -431,6 +439,7 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
                     keccak_table,
                     exp_table,
                     sig_table,
+                    pow_of_rand_table,
                 },
             ),
             challenges,
@@ -478,6 +487,9 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
         config
             .sig_table
             .dev_load(&mut layouter, block, &challenges)?;
+        config
+            .pow_of_rand_table
+            .dev_load(&mut layouter, &challenges)?;
 
         self.synthesize_sub(&config, &challenges, &mut layouter)
     }
@@ -661,7 +673,9 @@ mod evm_circuit_stats {
             exp_table,
             LOOKUP_CONFIG[7].1,
             sig_table,
-            LOOKUP_CONFIG[8].1
+            LOOKUP_CONFIG[8].1,
+            pow_of_rand_table,
+            LOOKUP_CONFIG[9].1
         );
     }
 

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -2,7 +2,8 @@ use super::{
     param::{
         BLOCK_TABLE_LOOKUPS, BYTECODE_TABLE_LOOKUPS, COPY_TABLE_LOOKUPS, EXP_TABLE_LOOKUPS,
         FIXED_TABLE_LOOKUPS, KECCAK_TABLE_LOOKUPS, N_BYTE_LOOKUPS, N_COPY_COLUMNS,
-        N_PHASE1_COLUMNS, RW_TABLE_LOOKUPS, SIG_TABLE_LOOKUPS, TX_TABLE_LOOKUPS,
+        N_PHASE1_COLUMNS, POW_OF_RAND_TABLE_LOOKUPS, RW_TABLE_LOOKUPS, SIG_TABLE_LOOKUPS,
+        TX_TABLE_LOOKUPS,
     },
     util::{instrumentation::Instrument, CachedRegion, CellManager, StoredExpression},
     EvmCircuitExports,
@@ -1228,6 +1229,7 @@ impl<F: Field> ExecutionConfig<F> {
             ("EVM_lookup_keccak", KECCAK_TABLE_LOOKUPS),
             ("EVM_lookup_exp", EXP_TABLE_LOOKUPS),
             ("EVM_lookup_sig", SIG_TABLE_LOOKUPS),
+            ("EVM_lookup_pow_of_rand", POW_OF_RAND_TABLE_LOOKUPS),
             ("EVM_adv_phase2", N_PHASE2_COLUMNS),
             ("EVM_copy", N_COPY_COLUMNS),
             ("EVM_lookup_byte", N_BYTE_LOOKUPS),

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -377,6 +377,7 @@ impl<F: Field> ExecutionConfig<F> {
         keccak_table: &dyn LookupTable<F>,
         exp_table: &dyn LookupTable<F>,
         sig_table: &dyn LookupTable<F>,
+        pow_of_rand_table: &dyn LookupTable<F>,
     ) -> Self {
         let mut instrument = Instrument::default();
         let q_usable = meta.complex_selector();
@@ -651,6 +652,7 @@ impl<F: Field> ExecutionConfig<F> {
             keccak_table,
             exp_table,
             sig_table,
+            pow_of_rand_table,
             &challenges,
             &cell_manager,
         );
@@ -907,6 +909,7 @@ impl<F: Field> ExecutionConfig<F> {
         keccak_table: &dyn LookupTable<F>,
         exp_table: &dyn LookupTable<F>,
         sig_table: &dyn LookupTable<F>,
+        pow_of_rand_table: &dyn LookupTable<F>,
         challenges: &Challenges<Expression<F>>,
         cell_manager: &CellManager<F>,
     ) {
@@ -924,6 +927,7 @@ impl<F: Field> ExecutionConfig<F> {
                         Table::Keccak => keccak_table,
                         Table::Exp => exp_table,
                         Table::Sig => sig_table,
+                        Table::PowOfRand => pow_of_rand_table,
                     }
                     .table_exprs(meta);
                     vec![(

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -949,10 +949,6 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             .assign(region, offset, code_address)?;
         self.is_precompile_lt
             .assign(region, offset, code_address, 0x0Au64.into())?;
-        if is_precompile_call {
-            self.precompile_gadget
-                .assign(region, offset, precompile_addr.0[19].into())?;
-        }
         let precompile_return_length = if is_precompile_call {
             let value_rw = block.rws[step.rw_indices[32 + rw_offset]];
             assert_eq!(
@@ -1028,27 +1024,39 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 .keccak_input()
                 .map(|randomness| rlc::value(return_bytes.iter().rev(), randomness));
             (
-                Value::known(F::from(input_len as u64)),
+                input_len as u64,
                 input_bytes_rlc,
                 output_bytes_rlc,
                 return_bytes_rlc,
             )
         } else {
             (
-                Value::known(F::zero()),
+                0,
                 Value::known(F::zero()),
                 Value::known(F::zero()),
                 Value::known(F::zero()),
             )
         };
 
-        self.input_len.assign(region, offset, input_len)?;
+        self.input_len
+            .assign(region, offset, Value::known(F::from(input_len)))?;
         self.input_bytes_rlc
             .assign(region, offset, input_bytes_rlc)?;
         self.output_bytes_rlc
             .assign(region, offset, output_bytes_rlc)?;
         self.return_bytes_rlc
             .assign(region, offset, return_bytes_rlc)?;
+
+        if is_precompile_call {
+            self.precompile_gadget.assign(
+                region,
+                offset,
+                precompile_addr.0[19].into(),
+                input_bytes_rlc,
+                input_len,
+                region.challenges().keccak_input(),
+            )?;
+        }
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -1053,7 +1053,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 offset,
                 precompile_addr.0[19].into(),
                 input_bytes_rlc,
-                input_len,
+                cd_length.as_u64(),
                 region.challenges().keccak_input(),
             )?;
         }

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -51,6 +51,7 @@ pub(crate) const LOOKUP_CONFIG: &[(Table, usize)] = &[
     (Table::Keccak, KECCAK_TABLE_LOOKUPS),
     (Table::Exp, EXP_TABLE_LOOKUPS),
     (Table::Sig, SIG_TABLE_LOOKUPS),
+    (Table::PowOfRand, POW_OF_RAND_TABLE_LOOKUPS),
 ];
 
 /// Fixed Table lookups done in EVMCircuit
@@ -79,6 +80,9 @@ pub const EXP_TABLE_LOOKUPS: usize = 1;
 
 /// Sig Table lookups done in EVMCircuit
 pub const SIG_TABLE_LOOKUPS: usize = 1;
+
+/// Power of Randomness lookups done from EVM Circuit.
+pub const POW_OF_RAND_TABLE_LOOKUPS: usize = 1;
 
 /// Maximum number of bytes that an integer can fit in field without wrapping
 /// around.

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -16,7 +16,7 @@ pub const MAX_STEP_HEIGHT: usize = 21;
 pub(crate) const STEP_STATE_HEIGHT: usize = 1;
 
 /// Number of Advice Phase2 columns in the EVM circuit
-pub(crate) const N_PHASE2_COLUMNS: usize = 4;
+pub(crate) const N_PHASE2_COLUMNS: usize = 5;
 
 /// Number of Advice Phase1 columns in the EVM circuit
 pub(crate) const N_PHASE1_COLUMNS: usize =
@@ -38,7 +38,8 @@ pub(crate) const EVM_LOOKUP_COLS: usize = FIXED_TABLE_LOOKUPS
     + COPY_TABLE_LOOKUPS
     + KECCAK_TABLE_LOOKUPS
     + EXP_TABLE_LOOKUPS
-    + SIG_TABLE_LOOKUPS;
+    + SIG_TABLE_LOOKUPS
+    + POW_OF_RAND_TABLE_LOOKUPS;
 
 /// Lookups done per row.
 pub(crate) const LOOKUP_CONFIG: &[(Table, usize)] = &[

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -144,6 +144,7 @@ pub(crate) enum Table {
     Keccak,
     Exp,
     Sig,
+    PowOfRand,
 }
 
 #[derive(Clone, Debug)]
@@ -300,6 +301,10 @@ pub(crate) enum Lookup<F> {
         sig_s_rlc: Expression<F>,
         recovered_addr: Expression<F>,
     },
+    PowOfRandTable {
+        exponent: Expression<F>,
+        pow_of_rand: Expression<F>,
+    },
     /// Conditional lookup enabled by the first element.
     Conditional(Expression<F>, Box<Lookup<F>>),
 }
@@ -320,6 +325,7 @@ impl<F: Field> Lookup<F> {
             Self::KeccakTable { .. } => Table::Keccak,
             Self::ExpTable { .. } => Table::Exp,
             Self::SigTable { .. } => Table::Sig,
+            Self::PowOfRandTable { .. } => Table::PowOfRand,
             Self::Conditional(_, lookup) => lookup.table(),
         }
     }
@@ -456,6 +462,10 @@ impl<F: Field> Lookup<F> {
                 sig_s_rlc.clone(),
                 recovered_addr.clone(),
             ],
+            Self::PowOfRandTable {
+                exponent,
+                pow_of_rand,
+            } => vec![exponent.clone(), pow_of_rand.clone()],
             Self::Conditional(condition, lookup) => lookup
                 .input_exprs()
                 .into_iter()

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -465,7 +465,11 @@ impl<F: Field> Lookup<F> {
             Self::PowOfRandTable {
                 exponent,
                 pow_of_rand,
-            } => vec![exponent.clone(), pow_of_rand.clone()],
+            } => vec![
+                1.expr(), /* q_enable */
+                exponent.clone(),
+                pow_of_rand.clone(),
+            ],
             Self::Conditional(condition, lookup) => lookup
                 .input_exprs()
                 .into_iter()

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1353,6 +1353,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Sig Table
+
     pub(crate) fn sig_table_lookup(
         &mut self,
         msg_hash_rlc: Expression<F>,
@@ -1371,6 +1372,22 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 recovered_addr: recovered_addr.expr(),
             },
         );
+    }
+
+    // Power of Randomness Table
+
+    pub(crate) fn pow_of_rand_lookup(
+        &mut self,
+        exponent: Expression<F>,
+        pow_of_rand: Expression<F>,
+    ) {
+        self.add_lookup(
+            "power of randomness",
+            Lookup::PowOfRandTable {
+                exponent,
+                pow_of_rand,
+            },
+        )
     }
 
     // Keccak Table

--- a/zkevm-circuits/src/evm_circuit/util/instrumentation.rs
+++ b/zkevm-circuits/src/evm_circuit/util/instrumentation.rs
@@ -106,6 +106,9 @@ impl Instrument {
                     CellType::Lookup(Table::Sig) => {
                         report.sig_table = data_entry;
                     }
+                    CellType::Lookup(Table::PowOfRand) => {
+                        report.pow_of_rand_table = data_entry;
+                    }
                 }
             }
             report_collection.push(report);
@@ -133,6 +136,7 @@ pub(crate) struct ExecStateReport {
     pub(crate) keccak_table: StateReportRow,
     pub(crate) exp_table: StateReportRow,
     pub(crate) sig_table: StateReportRow,
+    pub(crate) pow_of_rand_table: StateReportRow,
 }
 
 impl From<ExecutionState> for ExecStateReport {

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -82,7 +82,7 @@ use crate::{
     state_circuit::{StateCircuit, StateCircuitConfig, StateCircuitConfigArgs},
     table::{
         BlockTable, BytecodeTable, CopyTable, ExpTable, KeccakTable, MptTable, PoseidonTable,
-        RlpFsmRlpTable as RlpTable, RwTable, TxTable,
+        PowOfRandTable, RlpFsmRlpTable as RlpTable, RwTable, TxTable,
     },
 };
 
@@ -192,6 +192,8 @@ impl SubCircuitConfig<Fr> for SuperCircuitConfig<Fr> {
         log_circuit_info(meta, "keccak table");
         let sig_table = SigTable::construct(meta);
         log_circuit_info(meta, "sig table");
+        let pow_of_rand_table = PowOfRandTable::construct(meta);
+        log_circuit_info(meta, "power of randomness table");
 
         let keccak_circuit = KeccakCircuitConfig::new(
             meta,
@@ -326,6 +328,7 @@ impl SubCircuitConfig<Fr> for SuperCircuitConfig<Fr> {
                 keccak_table,
                 exp_table,
                 sig_table,
+                pow_of_rand_table,
             },
         );
         log_circuit_info(meta, "evm circuit");

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -192,7 +192,7 @@ impl SubCircuitConfig<Fr> for SuperCircuitConfig<Fr> {
         log_circuit_info(meta, "keccak table");
         let sig_table = SigTable::construct(meta);
         log_circuit_info(meta, "sig table");
-        let pow_of_rand_table = PowOfRandTable::construct(meta);
+        let pow_of_rand_table = PowOfRandTable::construct(meta, &challenges_expr);
         log_circuit_info(meta, "power of randomness table");
 
         let keccak_circuit = KeccakCircuitConfig::new(

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     copy_circuit::util::number_or_hash_to_field,
-    evm_circuit::util::rlc,
+    evm_circuit::util::{
+        constraint_builder::{BaseConstraintBuilder, ConstrainBuilderCommon},
+        rlc,
+    },
     exp_circuit::param::{OFFSET_INCREMENT, ROWS_PER_STEP},
     impl_expr,
     util::{build_tx_log_address, Challenges},
@@ -16,7 +19,7 @@ use core::iter::once;
 use eth_types::{sign_types::SignData, Field, ToLittleEndian, ToScalar, ToWord, Word, U256};
 use gadgets::{
     binary_number::{BinaryNumberChip, BinaryNumberConfig},
-    util::{split_u256, split_u256_limb64},
+    util::{and, not, split_u256, split_u256_limb64, Expr},
 };
 use halo2_proofs::{
     arithmetic::FieldExt,
@@ -2229,7 +2232,12 @@ impl<F: Field> LookupTable<F> for SigTable {
 /// Lookup table for powers of keccak randomness up to exponent in [0, 128)
 #[derive(Clone, Copy, Debug)]
 pub struct PowOfRandTable {
-    /// exponent.
+    /// Whether the row is enabled.
+    pub q_enable: Column<Fixed>,
+    /// Whether the row is the first enabled row.
+    pub is_first: Column<Fixed>,
+    /// exponent = [0, 1, 2, ..., 126, 127] for enabled rows.
+    /// exponent = 0 for all other rows (disabled).
     pub exponent: Column<Fixed>,
     /// power of keccak randomness.
     pub pow_of_rand: Column<Advice>,
@@ -2237,11 +2245,44 @@ pub struct PowOfRandTable {
 
 impl PowOfRandTable {
     /// Construct the powers of randomness table.
-    pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
-        Self {
+    pub fn construct<F: Field>(
+        meta: &mut ConstraintSystem<F>,
+        challenges: &Challenges<Expression<F>>,
+    ) -> Self {
+        let table = Self {
+            q_enable: meta.fixed_column(),
+            is_first: meta.fixed_column(),
             exponent: meta.fixed_column(),
             pow_of_rand: meta.advice_column_in(SecondPhase),
-        }
+        };
+
+        meta.create_gate("pow_of_rand_table: first row", |meta| {
+            let mut cb = BaseConstraintBuilder::default();
+            cb.require_equal(
+                "first row: rand ^ 0 == 1",
+                meta.query_advice(table.pow_of_rand, Rotation::cur()),
+                1.expr(),
+            );
+            cb.gate(and::expr([
+                meta.query_fixed(table.q_enable, Rotation::cur()),
+                meta.query_fixed(table.is_first, Rotation::cur()),
+            ]))
+        });
+
+        meta.create_gate("pow_of_rand_table: all other enabled rows", |meta| {
+            let mut cb = BaseConstraintBuilder::default();
+            cb.require_equal(
+                "pow_of_rand::cur == pow_of_rand::prev * rand",
+                meta.query_advice(table.pow_of_rand, Rotation::cur()),
+                meta.query_advice(table.pow_of_rand, Rotation::prev()) * challenges.keccak_input(),
+            );
+            cb.gate(and::expr([
+                meta.query_fixed(table.q_enable, Rotation::cur()),
+                not::expr(meta.query_fixed(table.is_first, Rotation::cur())),
+            ]))
+        });
+
+        table
     }
 
     /// Assign values to the table.
@@ -2258,6 +2299,18 @@ impl PowOfRandTable {
                     std::iter::successors(Some(Value::known(F::one())), |&v| Some(v * r)).take(128);
 
                 for (idx, pow_of_rand) in pows_of_rand.enumerate() {
+                    region.assign_fixed(
+                        || format!("q_enable at offset = {idx}"),
+                        self.q_enable,
+                        idx,
+                        || Value::known(F::one()),
+                    )?;
+                    region.assign_fixed(
+                        || format!("is_first at offset = {idx}"),
+                        self.is_first,
+                        idx,
+                        || Value::known(if idx == 0 { F::one() } else { F::zero() }),
+                    )?;
                     region.assign_fixed(
                         || format!("exponent at offset = {idx}"),
                         self.exponent,
@@ -2280,10 +2333,28 @@ impl PowOfRandTable {
 
 impl<F: Field> LookupTable<F> for PowOfRandTable {
     fn columns(&self) -> Vec<Column<Any>> {
-        vec![self.exponent.into(), self.pow_of_rand.into()]
+        vec![
+            self.q_enable.into(),
+            self.is_first.into(),
+            self.exponent.into(),
+            self.pow_of_rand.into(),
+        ]
     }
 
     fn annotations(&self) -> Vec<String> {
-        vec![String::from("exponent"), String::from("pow_of_rand")]
+        vec![
+            String::from("q_enable"),
+            String::from("is_first"),
+            String::from("exponent"),
+            String::from("pow_of_rand"),
+        ]
+    }
+
+    fn table_exprs(&self, meta: &mut VirtualCells<F>) -> Vec<Expression<F>> {
+        vec![
+            meta.query_fixed(self.q_enable, Rotation::cur()),
+            meta.query_fixed(self.exponent, Rotation::cur()),
+            meta.query_advice(self.pow_of_rand, Rotation::cur()),
+        ]
     }
 }


### PR DESCRIPTION
### Description

Input RLC comparison in precompiles `ecrecover`, `ecAdd`, ecMul` can fail as inputs are right-padded with zeroes. Since those zeroes were not accounted for in the copy circuit, the RLC value was incorrect.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Rationale

We add a lookup table `PowOfRand` which represents the below table:

| exponent | power of randomness |
|-----------|----------------------|
| 0               | 1                    |
| 1 | r |
| 2 | r ^ 2 |
| ... | ... |
| 126 | r ^ 126 |
| 127 | r ^ 127 |

where `r` represents the keccak randomness (which is used as the randomness to calculate RLC of input bytes in the copy circuit).

The precompiles `ecrecover`, `ecAdd` and `ecMul` expect 128, 128 and 96 input bytes respectively, but if the calldata does not have sufficient number of bytes, zero bytes are padded to the right before running the precompile computation.

We use the following approach:
```rust
// no. of right padded zeroes is the difference between required input length and calldata length.
let n_padded_zeroes = input_len - calldata_len;
cb.range_lookup(n_padded_zeroes.expr(), 128);

// cell to hold the RLC value with padded zeroes.
let padded_input_rlc = cb.query_cell_phase2();

// get the power of randomness we are interested in.
let power_of_rand = cb.query_cell_phase2();
cb.lookup_pow_of_rand(n_padded_zeroes.expr(), power_of_rand.expr());

// validate value of padded RLC.
cb.require_equal("rlc eq", padded_input_rlc.expr(), input_rlc.expr() * power_of_rand.expr());
```