### PR TITLE
[Fix] revert block_convert in witness

### DIFF
--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -11,7 +11,7 @@ use bus_mapping::{
 };
 use eth_types::{sign_types::SignData, Address, Field, ToLittleEndian, ToScalar, Word, U256};
 use halo2_proofs::circuit::Value;
-use mpt_zktrie::state::builder::HASH_SCHEME_DONE;
+//use mpt_zktrie::state::builder::HASH_SCHEME_DONE;
 
 use super::{
     mpt::ZktrieState as MptState, step::step_convert, tx::tx_convert, Bytecode, ExecStep,
@@ -372,13 +372,27 @@ pub fn block_convert<F: Field>(
         block.circuits_params.max_rws
     };
 
-    let mut mpt_updates = MptUpdates::mock_from(&rws.table_assignments());
-    assert!(*HASH_SCHEME_DONE);
-    mpt_updates.mock_fill_state_roots();
+    #[cfg(not(test))]
+    let mpt_updates = MptUpdates::from_rws_with_mock_state_roots(
+        &rws.table_assignments(),
+        block.prev_state_root,
+        block.end_state_root(),
+    );
 
-    let mut block = block.clone();
-    block.prev_state_root = mpt_updates.old_root();
-    let block = &block;
+    #[cfg(test)]
+    let mut block_mock = block.clone();
+
+    #[cfg(test)]
+    let (block, mpt_updates) = {
+        use mpt_zktrie::state::builder::HASH_SCHEME_DONE;
+        let mut mpt_updates = MptUpdates::mock_from(&rws.table_assignments());
+        assert!(*HASH_SCHEME_DONE);
+        mpt_updates.mock_fill_state_roots();
+
+        //    let mut block = block.clone();
+        block_mock.prev_state_root = mpt_updates.old_root();
+        (&block_mock, mpt_updates)
+    };
 
     let _withdraw_root_check_rw = if end_block_last.rw_counter == 0 {
         0


### PR DESCRIPTION
The ` mock_fill_state_roots` should not be used if we are not performing unittest.

Here fixed the issue by put the usage of ` mock_fill_state_roots`  into a `#cfg[(test)]` block.