### PR TITLE
Re-use cells between mutually exclusive conditions

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -416,6 +416,12 @@ impl<F: FieldExt> CellManager<F> {
         }
     }
 
+    pub(crate) fn reset_heights_to(&mut self, heights: &[usize]) {
+        for (column, &height) in self.columns.iter_mut().zip_eq(heights.iter()) {
+            column.height = height;
+        }
+    }
+
     pub(crate) fn query_cells(&mut self, cell_type: CellType, count: usize) -> Vec<Cell<F>> {
         let mut cells = Vec::with_capacity(count);
         while cells.len() < count {
@@ -474,6 +480,10 @@ impl<F: FieldExt> CellManager<F> {
             .map(|column| column.height)
             .max()
             .unwrap()
+    }
+
+    pub(crate) fn get_heights(&self) -> Vec<usize> {
+        self.columns().iter().map(|column| column.height).collect()
     }
 
     /// Returns a map of CellType -> (width, height, num_cells)

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1448,7 +1448,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     /// used for constraining the internal states for precompile calls. Each precompile call
     /// expects a different cell layout, but since the next state can be at the most one precompile
     /// state, we can re-use cells assigned across all those conditions.
-    pub(crate) fn constrain_mutually_exclusive(
+    pub(crate) fn constrain_mutually_exclusive_next_step(
         &mut self,
         conditions: Vec<Expression<F>>,
         next_states: Vec<ExecutionState>,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -16,7 +16,7 @@ use bus_mapping::{
     util::{KECCAK_CODE_HASH_ZERO, POSEIDON_CODE_HASH_ZERO},
 };
 use eth_types::{Field, ToLittleEndian, ToScalar, ToWord};
-use gadgets::util::{and, not};
+use gadgets::util::{and, not, sum};
 use halo2_proofs::{
     circuit::Value,
     plonk::{
@@ -320,6 +320,8 @@ impl<'a, F: Field> ConstrainBuilderCommon<F> for EVMConstraintBuilder<'a, F> {
         self.push_constraint(name, constraint);
     }
 }
+
+pub(crate) type BoxedClosure<F> = Box<dyn FnOnce(&mut EVMConstraintBuilder<F>)>;
 
 impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     pub(crate) fn new(
@@ -1439,6 +1441,53 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         let ret = constraint(self);
         self.conditions.pop();
         ret
+    }
+
+    /// Constraints the next step, given mutually exclusive conditions to determine the next state
+    /// and constrain it using the provided respective constraint. This mechanism is specifically
+    /// used for constraining the internal states for precompile calls. Each precompile call
+    /// expects a different cell layout, but since the next state can be at the most one precompile
+    /// state, we can re-use cells assigned across all those conditions.
+    pub(crate) fn constrain_mutually_exclusive(
+        &mut self,
+        conditions: Vec<Expression<F>>,
+        next_states: Vec<ExecutionState>,
+        constraints: Vec<BoxedClosure<F>>,
+    ) {
+        assert_eq!(conditions.len(), constraints.len());
+        assert_eq!(conditions.len(), next_states.len());
+        self.require_boolean(
+            "at the most one condition is true from mutually exclusive conditions",
+            sum::expr(&conditions),
+        );
+
+        // record the heights of all columns (for the next step) as we begin cell assignment.
+        let start_heights = self.next.cell_manager.get_heights();
+
+        let mut max_end_heights: Vec<usize> = vec![0usize; start_heights.len()];
+        for ((&next_state, condition), constraint) in next_states
+            .iter()
+            .zip(conditions.into_iter())
+            .zip(constraints.into_iter())
+        {
+            // constraint the next step.
+            self.constrain_next_step(next_state, Some(condition), constraint);
+
+            // get the column heights at the end of querying cells in the above constraints.
+            let end_heights = self.next.cell_manager.get_heights();
+            for (max_end_height, end_height) in max_end_heights.iter_mut().zip(end_heights.iter()) {
+                if end_height > max_end_height {
+                    *max_end_height = *end_height;
+                }
+            }
+
+            // reset the column heights of the next step before proceeding to the next mutually
+            // exclusive condition/constraint/next_state.
+            self.next.cell_manager.reset_heights_to(&start_heights);
+        }
+
+        // reset height of next step to the maximum heights of each column.
+        self.next.cell_manager.reset_heights_to(&max_end_heights);
     }
 
     /// This function needs to be used with extra precaution. You need to make

--- a/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
@@ -9,7 +9,7 @@ use crate::evm_circuit::{
 };
 
 use super::{
-    constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+    constraint_builder::{BoxedClosure, ConstrainBuilderCommon, EVMConstraintBuilder},
     math_gadget::{BinaryNumberGadget, IsZeroGadget, LtGadget},
     CachedRegion, Cell,
 };
@@ -78,8 +78,38 @@ impl<F: Field> PrecompileGadget<F> {
             );
         });
 
-        cb.condition(address.value_equals(PrecompileCalls::Ecrecover), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileEcrecover, None, |cb| {
+        // TODO: is it possible to avoid this? Just a little messy, but `padding_gadget`,
+        // `input_bytes_rlc` and `output_bytes_rlc` will get dropped later, but the boxed closure
+        // lives longer.
+        let padded_rlc1 = padding_gadget.padded_rlc();
+        let input_bytes_rlc1 = input_bytes_rlc.expr();
+        let output_bytes_rlc1 = output_bytes_rlc.expr();
+        let output_bytes_rlc2 = output_bytes_rlc.expr();
+
+        let conditions = vec![
+            address.value_equals(PrecompileCalls::Ecrecover),
+            address.value_equals(PrecompileCalls::Sha256),
+            address.value_equals(PrecompileCalls::Ripemd160),
+            address.value_equals(PrecompileCalls::Identity),
+            address.value_equals(PrecompileCalls::Modexp),
+            address.value_equals(PrecompileCalls::Bn128Add),
+            address.value_equals(PrecompileCalls::Bn128Mul),
+            address.value_equals(PrecompileCalls::Bn128Pairing),
+            address.value_equals(PrecompileCalls::Blake2F),
+        ];
+        let next_states = vec![
+            ExecutionState::PrecompileEcrecover,
+            ExecutionState::PrecompileSha256,
+            ExecutionState::PrecompileRipemd160,
+            ExecutionState::PrecompileIdentity,
+            ExecutionState::PrecompileBigModExp,
+            ExecutionState::PrecompileBn256Add,
+            ExecutionState::PrecompileBn256ScalarMul,
+            ExecutionState::PrecompileBn256Pairing,
+            ExecutionState::PrecompileBlake2f,
+        ];
+        let constraints: Vec<BoxedClosure<F>> = vec![
+            Box::new(|cb| {
                 let (recovered, msg_hash_rlc, sig_v_rlc, sig_r_rlc, sig_s_rlc, recovered_addr_rlc) = (
                     cb.query_bool(),
                     cb.query_cell_phase2(),
@@ -98,7 +128,7 @@ impl<F: Field> PrecompileGadget<F> {
                 };
                 cb.require_equal(
                     "input bytes (RLC) = [msg_hash | sig_v_rlc | sig_r | sig_s]",
-                    padding_gadget.padded_rlc(),
+                    padded_rlc1,
                     (msg_hash_rlc.expr() * r_pow_96)
                         + (sig_v_rlc.expr() * r_pow_64)
                         + (sig_r_rlc.expr() * r_pow_32)
@@ -107,59 +137,37 @@ impl<F: Field> PrecompileGadget<F> {
                 // RLC of output bytes always equals RLC of the recovered address.
                 cb.require_equal(
                     "output bytes (RLC) = recovered address",
-                    output_bytes_rlc.expr(),
+                    output_bytes_rlc1.expr(),
                     recovered_addr_rlc.expr(),
                 );
                 // If the address was not recovered, RLC(address) == RLC(output) == 0.
                 cb.condition(not::expr(recovered.expr()), |cb| {
-                    cb.require_zero("output bytes == 0", output_bytes_rlc.expr());
+                    cb.require_zero("output bytes == 0", output_bytes_rlc1);
                 });
-            });
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Sha256), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileSha256, None, |_cb| {});
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Ripemd160), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileRipemd160, None, |_cb| {});
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Identity), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileIdentity, None, |_cb| {});
-            cb.condition(is_success, |cb| {
-                cb.require_equal(
-                    "input and output bytes are the same",
-                    input_bytes_rlc,
-                    output_bytes_rlc,
-                );
-                cb.require_equal(
-                    "input length and precompile return length are the same",
-                    cd_length,
-                    precompile_return_length,
-                );
-            });
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Modexp), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileBigModExp, None, |_cb| {});
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Bn128Add), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileBn256Add, None, |_cb| {});
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Bn128Mul), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileBn256ScalarMul, None, |_cb| {});
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Bn128Pairing), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileBn256Pairing, None, |_cb| {});
-        });
-
-        cb.condition(address.value_equals(PrecompileCalls::Blake2F), |cb| {
-            cb.constrain_next_step(ExecutionState::PrecompileBlake2f, None, |_cb| {});
-        });
+            }),
+            Box::new(|_cb| { /* Sha256 */ }),
+            Box::new(|_cb| { /* Ripemd160 */ }),
+            Box::new(|cb| {
+                cb.condition(is_success, |cb| {
+                    cb.require_equal(
+                        "input and output bytes are the same",
+                        input_bytes_rlc1,
+                        output_bytes_rlc2,
+                    );
+                    cb.require_equal(
+                        "input length and precompile return length are the same",
+                        cd_length,
+                        precompile_return_length,
+                    );
+                });
+            }),
+            Box::new(|_cb| { /* Modexp */ }),
+            Box::new(|_cb| { /* Bn128Add */ }),
+            Box::new(|_cb| { /* Bn128Mul */ }),
+            Box::new(|_cb| { /* Bn128Pairing */ }),
+            Box::new(|_cb| { /* Blake2F */ }),
+        ];
+        cb.constrain_mutually_exclusive(conditions, next_states, constraints);
 
         Self {
             address,

--- a/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
@@ -167,7 +167,7 @@ impl<F: Field> PrecompileGadget<F> {
             Box::new(|_cb| { /* Bn128Pairing */ }),
             Box::new(|_cb| { /* Blake2F */ }),
         ];
-        cb.constrain_mutually_exclusive(conditions, next_states, constraints);
+        cb.constrain_mutually_exclusive_next_step(conditions, next_states, constraints);
 
         Self {
             address,


### PR DESCRIPTION
### Description

The `PrecompileGadget` is constructed while we are in the `CALL_OP` step. This gadget conditionally constrains the next step, which could be any of the internal `ExecutionState`'s reserved for precompile calls, for instance `ExecutionState::PrecompileEcrecover` or `ExecutionState::PrecompileBn256Add`.

Each of those internal states (essentially their verification gadget) expect a different cell layout. In order to constrain the "next step", the same cell layout must be followed while querying cells and constraining the expressions in them.

Simply following a `cb.constrain_next_step(.., Some(condition), ..)` approach is not efficient because we will need to account for the cells queried for the previous condition, only then query the cells for the condition in question.

We notice that actually all the conditions are mutually exclusive, in the sense that, at the most one of them will be true (the next step can only be one kind of precompile call, if it is a precompile call). So we can in fact re-use the cells queried in the those conditions.

As proposed by @noel2004 , the constraint builder can allow such an API that fetches the starting heights (for all columns in the cell manager), resetting the heights to those before every mutually exclusive conditional constraint for the next step. At the end of this loop, we set the next step's cell manager column heights to the maximum that were reached amongst those constraints.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update