### PR TITLE
refactor all copy bytes using rlc_acc equality check 

### DIFF
--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -510,11 +510,11 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 cb.gate(and::expr([
                     meta.query_fixed(q_enable, Rotation::cur()),
                     meta.query_advice(is_last, Rotation::next()),
-                    and::expr([
-                        meta.query_advice(is_memory, Rotation::cur()),
-                        meta.query_advice(is_memory, Rotation::next())
-                            + meta.query_advice(is_tx_log, Rotation::next()),
-                    ]),
+                    // and::expr([
+                    //     meta.query_advice(is_memory, Rotation::cur()),
+                    //     meta.query_advice(is_memory, Rotation::next())
+                    //         + meta.query_advice(is_tx_log, Rotation::next()),
+                    // ]),
                 ]))
             },
         );
@@ -569,20 +569,20 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             );
             // we use rlc to constraint the write == read specially for memory to memory case
             // here only handle non memory to memory nor to log cases
-            cb.condition(
-                not::expr(and::expr([
-                    meta.query_advice(is_memory, Rotation::cur()),
-                    meta.query_advice(is_memory, Rotation::next())
-                        + meta.query_advice(is_tx_log, Rotation::next()),
-                ])),
-                |cb| {
-                    cb.require_equal(
-                        "write value == read value",
-                        meta.query_advice(value, Rotation::cur()),
-                        meta.query_advice(value, Rotation::next()),
-                    );
-                },
-            );
+            // cb.condition(
+            //     not::expr(and::expr([
+            //         meta.query_advice(is_memory, Rotation::cur()),
+            //         meta.query_advice(is_memory, Rotation::next())
+            //             + meta.query_advice(is_tx_log, Rotation::next()),
+            //     ])),
+            //     |cb| {
+            //         cb.require_equal(
+            //             "write value == read value",
+            //             meta.query_advice(value, Rotation::cur()),
+            //             meta.query_advice(value, Rotation::next()),
+            //         );
+            //     },
+            // );
 
             cb.require_equal(
                 "value_acc is same for read-write rows",


### PR DESCRIPTION
### Description
currently there two methods to verify read bytes = write bytes as following:
1. write value == read value for non memory to memory(log)
2. rlc_acc_read == rlc_acc_write for actual copy bytes for memory to memory(log) case

in theory, we can use method 2 for all cases to simplify code and reduce maintain effort.

### Issue Link

[_link issue here_]

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

