### PR TITLE
copy_simplify_addr: always increment the address

### DIFF
--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -197,10 +197,10 @@ fn handle_copy(
     src_range.ensure_equal_length(&mut dst_range);
 
     let src_data = state.call_ctx()?.memory.read_chunk(src_range);
-
+    let dst_data_prev = state.caller_ctx()?.memory.read_chunk(dst_range);
     let dst_data = {
         // Copy src_data into dst_data
-        let mut dst_data = state.caller_ctx()?.memory.read_chunk(dst_range);
+        let mut dst_data = dst_data_prev.clone();
         dst_data[dst_range.shift().0..dst_range.shift().0 + copy_length]
             .copy_from_slice(&src_data[src_range.shift().0..src_range.shift().0 + copy_length]);
         dst_data
@@ -242,7 +242,7 @@ fn handle_copy(
             dst_id: NumberOrHash::Number(destination.id),
             dst_addr: destination.offset.try_into().unwrap(),
             log_id: None,
-            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
+            copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(dst_data_prev)),
         },
     );
 

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -781,7 +781,8 @@ mod test {
     fn run_test_circuits(ctx: TestContext<2, 1>) {
         CircuitTestBuilder::new_from_test_ctx(ctx)
             .params(CircuitsParams {
-                max_rws: 300000, // TODO: try smaller value?
+                max_rws: 70_000,
+                max_copy_rows: 140_000,
                 ..Default::default()
             })
             .run();

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1456,8 +1456,6 @@ pub struct CopyTable {
     /// The source/destination address for this copy step.  Can be memory
     /// address, byte index in the bytecode, tx call data, and tx log data.
     pub addr: Column<Advice>,
-    /// address for slot memory src or dest, review if can reuse `addr` .
-    // pub addr_slot: Column<Advice>,
     /// The end of the source buffer for the copy event.  Any data read from an
     /// address greater than or equal to this value will be 0.
     pub src_addr_end: Column<Advice>,
@@ -1485,7 +1483,7 @@ pub struct CopyTable {
 }
 
 type CopyTableRow<F> = [(Value<F>, &'static str); 9];
-type CopyCircuitRow<F> = [(Value<F>, &'static str); 13];
+type CopyCircuitRow<F> = [(Value<F>, &'static str); 12];
 
 impl CopyTable {
     /// Construct a new CopyTable
@@ -1675,7 +1673,6 @@ impl CopyTable {
             let is_code = Value::known(copy_step.is_code.map_or(F::zero(), |v| F::from(v)));
 
             // For LOG, format the address including the log_id.
-            let shift = addr % 32;
             let addr = if tag == CopyDataType::TxLog {
                 build_tx_log_address(addr, TxLogFieldTag::Data, copy_event.log_id.unwrap())
                     .to_scalar()
@@ -1683,7 +1680,6 @@ impl CopyTable {
             } else {
                 F::from(addr)
             };
-            let addr_slot = addr - F::from(shift);
 
             assignments.push((
                 tag,
@@ -1753,7 +1749,6 @@ impl CopyTable {
                         "front_mask",
                     ),
                     (Value::known(F::from(word_index)), "word_index"),
-                    (Value::known(addr_slot), "addr_slot"),
                 ],
             ));
 


### PR DESCRIPTION
In the Copy Circuit, simplify the handling of the address. Always increment it the same way for all data types.