### PR TITLE
`BeginTx` check for init-code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ fmt: ## Check whether the code is formated correctly
 	@cargo fmt --all -- --check
 
 test-light: ## Run light tests
-	@cargo test --release --all --exclude integration-tests --exclude circuit-benchmarks
+	@cargo test --release --workspace --exclude integration-tests --exclude circuit-benchmarks
 
 test-heavy: ## Run heavy tests serially to avoid OOM
 	@cargo test --release --features scroll --all --exclude integration-tests --exclude circuit-benchmarks serial_  -- --ignored # --test-threads 1

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -25,6 +25,7 @@ use crate::{
 use eth_types::{
     evm_types::{
         gas_utils::memory_expansion_gas_cost, Gas, GasCost, MemoryAddress, OpcodeId, StackAddress,
+        MAX_CODE_SIZE,
     },
     sign_types::SignData,
     Address, Bytecode, GethExecStep, ToAddress, ToBigEndian, ToWord, Word, H256, U256,
@@ -1404,7 +1405,7 @@ impl<'a> CircuitInputStateRef<'a> {
                 if call.is_create() {
                     let offset = step.stack.nth_last(0)?;
                     let length = step.stack.nth_last(1)?;
-                    if length > Word::from(0x6000u64) {
+                    if length > Word::from(MAX_CODE_SIZE) {
                         return Ok(Some(ExecError::MaxCodeSizeExceeded));
                     } else if length > Word::zero()
                         && !call_ctx.memory.is_empty()

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -1,6 +1,8 @@
 //! Definition of each opcode of the EVM.
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, ExecStep},
+    circuit_input_builder::{
+        CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
+    },
     error::{
         ContractAddressCollisionError, DepthError, ExecError, InsufficientBalanceError,
         NonceUintOverflowError, OogError,
@@ -17,7 +19,7 @@ use crate::{
 use core::fmt::Debug;
 use eth_types::{
     evm_types::{gas_utils::tx_data_gas_cost, GasCost, MAX_REFUND_QUOTIENT_OF_GAS_USED},
-    evm_unimplemented, GethExecStep, GethExecTrace, ToAddress, ToWord, Word,
+    evm_unimplemented, Bytecode, GethExecStep, GethExecTrace, ToAddress, ToWord, Word,
 };
 use ethers_core::utils::get_contract_address;
 
@@ -618,7 +620,8 @@ pub fn gen_begin_tx_ops(
     // We feed the RLP-encoded bytes to the block's SHA3 inputs, which gets assigned
     // to the Keccak circuit, so that the BeginTxGadget can do a lookup to the
     // Keccak table and verify the contract address.
-    if state.tx.is_create() {
+    if state.tx.is_create() && state.tx.calls[0].is_success() {
+        // 1. add RLP-bytes for contract address to keccak circuit.
         state.block.sha3_inputs.push({
             let mut stream = ethers_core::utils::rlp::RlpStream::new();
             stream.begin_list(2);
@@ -626,6 +629,32 @@ pub fn gen_begin_tx_ops(
             stream.append(&nonce_prev);
             stream.out().to_vec()
         });
+        // 2. add init code to keccak circuit.
+        let init_code = state.tx.input.as_slice();
+        state.block.sha3_inputs.push(init_code.to_vec());
+        // 3. add init code to copy circuit.
+        let code_hash = CodeDB::hash(init_code);
+        let bytes = Bytecode::from(init_code.to_vec())
+            .code
+            .iter()
+            .map(|element| (element.value, element.is_code))
+            .collect::<Vec<(u8, bool)>>();
+        let rw_counter_start = state.block_ctx.rwc;
+        state.push_copy(
+            &mut exec_step,
+            CopyEvent {
+                src_addr: 0,
+                src_addr_end: init_code.len() as u64,
+                src_type: CopyDataType::TxCalldata,
+                src_id: NumberOrHash::Number(state.tx_ctx.id()),
+                dst_addr: 0,
+                dst_type: CopyDataType::Bytecode,
+                dst_id: NumberOrHash::Hash(code_hash),
+                log_id: None,
+                rw_counter_start,
+                bytes,
+            },
+        );
     }
 
     // There are 4 branches from here.

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -620,7 +620,7 @@ pub fn gen_begin_tx_ops(
     // We feed the RLP-encoded bytes to the block's SHA3 inputs, which gets assigned
     // to the Keccak circuit, so that the BeginTxGadget can do a lookup to the
     // Keccak table and verify the contract address.
-    if state.tx.is_create() && state.tx.calls[0].is_success() {
+    if state.tx.is_create() {
         // 1. add RLP-bytes for contract address to keccak circuit.
         state.block.sha3_inputs.push({
             let mut stream = ethers_core::utils::rlp::RlpStream::new();

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -353,6 +353,28 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             },
         );
 
+        meta.create_gate(
+            "Last Step (check value accumulator) TxCalldata => Bytecode",
+            |meta| {
+                let mut cb = BaseConstraintBuilder::default();
+
+                cb.require_equal(
+                    "value_acc == rlc_acc on the last row",
+                    meta.query_advice(value_acc, Rotation::next()),
+                    meta.query_advice(rlc_acc, Rotation::next()),
+                );
+
+                cb.gate(and::expr([
+                    meta.query_fixed(q_enable, Rotation::cur()),
+                    meta.query_advice(is_last, Rotation::next()),
+                    and::expr([
+                        meta.query_advice(is_tx_calldata, Rotation::cur()),
+                        meta.query_advice(is_bytecode, Rotation::next()),
+                    ]),
+                ]))
+            },
+        );
+
         meta.create_gate("Last Step (check value accumulator) RlcAcc", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 use bus_mapping::circuit_input_builder::CopyDataType;
-use eth_types::{Address, Field, ToLittleEndian, ToScalar};
+use eth_types::{Address, Field, ToLittleEndian, ToScalar, U256};
 use ethers_core::utils::{get_contract_address, keccak256, rlp::RlpStream};
 use gadgets::util::{expr_from_bytes, not, or, Expr};
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -867,13 +867,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let (init_code_rlc, keccak_code_hash_rlc) = if tx.is_create {
             let init_code_rlc =
                 region.keccak_rlc(&tx.call_data.iter().cloned().rev().collect::<Vec<u8>>());
-            let keccak_code_hash_rlc = region.keccak_rlc(
-                &keccak256(&tx.call_data)
-                    .iter()
-                    .cloned()
-                    .rev()
-                    .collect::<Vec<u8>>(),
-            );
+            let keccak_code_hash_rlc = region.word_rlc(U256::from(keccak256(&tx.call_data)));
             (init_code_rlc, keccak_code_hash_rlc)
         } else {
             (Value::known(F::zero()), Value::known(F::zero()))

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -23,6 +23,7 @@ use crate::{
         AccountFieldTag, BlockContextFieldTag, CallContextFieldTag, TxFieldTag as TxContextFieldTag,
     },
 };
+use bus_mapping::circuit_input_builder::CopyDataType;
 use eth_types::{Address, Field, ToLittleEndian, ToScalar};
 use ethers_core::utils::{get_contract_address, keccak256, rlp::RlpStream};
 use gadgets::util::{expr_from_bytes, not, or, Expr};
@@ -71,6 +72,8 @@ pub(crate) struct BeginTxGadget<F> {
     is_precompile_lt: LtGadget<F, N_BYTES_ACCOUNT_ADDRESS>,
     /// Keccak256(RLP([tx_caller_address, tx_nonce]))
     caller_nonce_hash_bytes: [Cell<F>; N_BYTES_WORD],
+    keccak_code_hash: Cell<F>,
+    init_code_rlc: Cell<F>,
     /// RLP gadget for CREATE address.
     create: ContractCreateGadget<F, false>,
     is_caller_callee_equal: Cell<F>,
@@ -328,7 +331,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         });
 
         // 1. Handle contract creation transaction.
-        cb.condition(tx_is_create.expr(), |cb| {
+        let (init_code_rlc, keccak_code_hash) = cb.condition(tx_is_create.expr(), |cb| {
             let output_rlc = cb.word_rlc::<N_BYTES_WORD>(
                 caller_nonce_hash_bytes
                     .iter()
@@ -338,6 +341,28 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     .unwrap(),
             );
             cb.keccak_table_lookup(create.input_rlc(cb), create.input_length(), output_rlc);
+
+            let keccak_code_hash = cb.query_cell_phase2();
+            let init_code_rlc = cb.query_cell_phase2();
+            // keccak table lookup for init code.
+            cb.keccak_table_lookup(
+                init_code_rlc.expr(),
+                tx_call_data_length.expr(),
+                keccak_code_hash.expr(),
+            );
+            // copy table lookup for init code.
+            cb.copy_table_lookup(
+                tx_id.expr(),                    // src_id
+                CopyDataType::TxCalldata.expr(), // src_tag
+                cb.curr.state.code_hash.expr(),  // dst_id
+                CopyDataType::Bytecode.expr(),   // dst_tag
+                0.expr(),                        // src_addr
+                tx_call_data_length.expr(),      // src_addr_end
+                0.expr(),                        // dst_addr
+                tx_call_data_length.expr(),      // length
+                init_code_rlc.expr(),            // rlc_acc
+                0.expr(),                        // rwc increase
+            );
 
             cb.account_write(
                 call_callee_address.expr(),
@@ -418,6 +443,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 log_id: To(0.expr()),
                 ..StepStateTransition::new_context()
             });
+
+            (init_code_rlc, keccak_code_hash)
         });
 
         // 2. Handle call to precompiled contracts.
@@ -623,6 +650,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             intrinsic_gas_cost,
             is_precompile_lt,
             caller_nonce_hash_bytes,
+            init_code_rlc,
+            keccak_code_hash,
             create,
             is_caller_callee_equal,
             coinbase,
@@ -835,6 +864,24 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         {
             c.assign(region, offset, Value::known(F::from(*v as u64)))?;
         }
+        let (init_code_rlc, keccak_code_hash_rlc) = if tx.is_create {
+            let init_code_rlc =
+                region.keccak_rlc(&tx.call_data.iter().cloned().rev().collect::<Vec<u8>>());
+            let keccak_code_hash_rlc = region.keccak_rlc(
+                &keccak256(&tx.call_data)
+                    .iter()
+                    .cloned()
+                    .rev()
+                    .collect::<Vec<u8>>(),
+            );
+            (init_code_rlc, keccak_code_hash_rlc)
+        } else {
+            (Value::known(F::zero()), Value::known(F::zero()))
+        };
+        self.init_code_rlc.assign(region, offset, init_code_rlc)?;
+        self.keccak_code_hash
+            .assign(region, offset, keccak_code_hash_rlc)?;
+
         self.create.assign(
             region,
             offset,

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1613,6 +1613,7 @@ impl CopyTable {
                     (
                         match (copy_event.src_type, copy_event.dst_type) {
                             (CopyDataType::Memory, CopyDataType::Bytecode) => rlc_acc,
+                            (CopyDataType::TxCalldata, CopyDataType::Bytecode) => rlc_acc,
                             (_, CopyDataType::RlcAcc) => rlc_acc,
                             (CopyDataType::Memory, CopyDataType::Precompile(_)) => rlc_acc,
                             (CopyDataType::Precompile(_), CopyDataType::Memory) => rlc_acc,

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -67,8 +67,8 @@ impl MockChallenges {
     pub fn construct<F: FieldExt>(_meta: &mut ConstraintSystem<F>) -> Self {
         Self {
             evm_word: 0x100,
-            keccak_input: 0x100,
-            lookup_input: 0x100,
+            keccak_input: 0x101,
+            lookup_input: 0x102,
         }
     }
     /// ..


### PR DESCRIPTION
### Description

Fixes the soundness bug: There was no check for initialisation code for a contract creation tx (`tx.to == None`).

### Issue Link

Closes #605 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update