### PR TITLE
Copy: fix conditions

### DIFF
--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -391,9 +391,6 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             // for all cases, rw_counter increase by 1 on word end for write step
             cb.condition(
                 and::expr([
-                    // exclude tx_calldata --> bytecode, which doesn't affect rw counter
-                    not::expr(meta.query_advice(is_tx_calldata, Rotation::cur()) +
-                    meta.query_advice(is_bytecode, Rotation::cur())),
                     not::expr(is_word_continue.is_lt(meta, None)),
                     not::expr(meta.query_advice(is_last, Rotation::cur())),
                     not::expr(meta.query_selector(q_step)), // TODO: rm

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1599,7 +1599,7 @@ impl CopyTable {
             // is_first
             let is_first = Value::known(if step_idx == 0 { F::one() } else { F::zero() });
             // is last
-            let is_last = if step_idx == copy_event.copy_bytes.bytes.len() * 2 - 1 {
+            let is_last = if step_idx == full_length * 2 - 1 {
                 Value::known(F::one())
             } else {
                 Value::known(F::zero())
@@ -1654,8 +1654,7 @@ impl CopyTable {
             };
 
             // bytes_left (final padding word length )
-            let bytes_left =
-                u64::try_from(copy_event.copy_bytes.bytes.len() * 2 - step_idx).unwrap() / 2;
+            let bytes_left = u64::try_from(full_length * 2 - step_idx).unwrap() / 2;
             // value
             let value = Value::known(F::from(copy_step.value as u64));
 
@@ -1694,10 +1693,7 @@ impl CopyTable {
                     (is_first, "is_first"),
                     (id, "id"),
                     (Value::known(addr), "addr"),
-                    (
-                        Value::known(F::from(addr_end)),
-                        "src_addr_end",
-                    ),
+                    (Value::known(F::from(addr_end)), "src_addr_end"),
                     (Value::known(F::from(bytes_left)), "bytes_left"),
                     (
                         Value::known(F::from(real_length_left as u64)),


### PR DESCRIPTION
This PR fixes and simplifies gate conditions that were too laxists (non_pad_non_mask on rules unrelated to masking) or too restrictive (not_last_two_rows which complicates padding rows). This uses the concept of "is_continue" instead of "not_last", meaning not last AND active.

Also add constraints on the front mask.