### PR TITLE
memory_opt_pad: replace LtChip with a simple column

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -346,6 +346,16 @@ pub enum NumberOrHash {
 }
 
 /// Represents all bytes related in one copy event.
+///
+/// - When the source is memory, `bytes` is the memory content, including masked areas. The
+///   destination data is the non-masked bytes.
+/// - When only the destination is memory or log, `bytes` is the memory content to write, including
+///   masked areas. The source data is the non-masked bytes.
+/// - When both source and destination are memory or log, it is `aux_bytes` that holds the
+///   destination memory.
+///
+/// Additionally, when the destination is memory, `bytes_write_prev` holds the memory content
+/// *before* the write.
 #[derive(Clone, Debug)]
 pub struct CopyBytes {
     /// Represents the list of (bytes, is_code, mask) copied during this copy event


### PR DESCRIPTION
1. Replace non_pad_non_mask LtChip with a column and a constraint.
2. Remove incorrect constraint that does nothing (effectively mask=0 or mask=1).
3. When is_pad, the value is not zero because it may still be involved in a memory lookup. Instead, it is replaced by 0 in RLC calculations.