### PR TITLE
memory_opt_rlc: simplify rlc_acc check

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -346,6 +346,16 @@ pub enum NumberOrHash {
 }
 
 /// Represents all bytes related in one copy event.
+///
+/// - When the source is memory, `bytes` is the memory content, including masked areas. The
+///   destination data is the non-masked bytes.
+/// - When only the destination is memory or log, `bytes` is the memory content to write, including
+///   masked areas. The source data is the non-masked bytes.
+/// - When both source and destination are memory or log, it is `aux_bytes` that holds the
+///   destination memory.
+///
+/// Additionally, when the destination is memory, `bytes_write_prev` holds the memory content
+/// *before* the write.
 #[derive(Clone, Debug)]
 pub struct CopyBytes {
     /// Represents the list of (bytes, is_code, mask) copied during this copy event

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1701,11 +1701,11 @@ impl CopyTable {
                     ),
                     (
                         match (copy_event.src_type, copy_event.dst_type) {
+                            (CopyDataType::Precompile(_), _) => rlc_acc,
+                            (_, CopyDataType::Precompile(_)) => rlc_acc,
                             (CopyDataType::Memory, CopyDataType::Bytecode) => rlc_acc,
                             (CopyDataType::TxCalldata, CopyDataType::Bytecode) => rlc_acc,
                             (_, CopyDataType::RlcAcc) => rlc_acc,
-                            (CopyDataType::Memory, CopyDataType::Precompile(_)) => rlc_acc,
-                            (CopyDataType::Precompile(_), CopyDataType::Memory) => rlc_acc,
                             _ => Value::known(F::zero()),
                         },
                         "rlc_acc",

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1483,7 +1483,7 @@ pub struct CopyTable {
 }
 
 type CopyTableRow<F> = [(Value<F>, &'static str); 9];
-type CopyCircuitRow<F> = [(Value<F>, &'static str); 11];
+type CopyCircuitRow<F> = [(Value<F>, &'static str); 10];
 
 impl CopyTable {
     /// Construct a new CopyTable
@@ -1522,19 +1522,16 @@ impl CopyTable {
                 .map(|(value, _, _)| *value)
                 .collect::<Vec<u8>>();
 
-            trace!("rlc_acc bytes are {values:?}");
             challenges
                 .keccak_input()
                 .map(|keccak_input| rlc::value(values.iter().rev(), keccak_input))
         };
 
-        trace!("rlc_acc of bytecode bytes {rlc_acc:?} ");
         let mut value_word_read_rlc = Value::known(F::zero());
         let mut value_word_write_rlc = Value::known(F::zero());
         let mut value_word_write_rlc_prev = Value::known(F::zero());
-        let mut value_acc = Value::known(F::zero());
-        let mut copy_rlc_read = Value::known(F::zero());
-        let mut copy_rlc_write = Value::known(F::zero());
+        let mut src_value_acc = Value::known(F::zero());
+        let mut dst_value_acc = Value::known(F::zero());
 
         let full_length = copy_event.copy_bytes.bytes.len();
 
@@ -1606,14 +1603,21 @@ impl CopyTable {
             };
 
             let is_mask = Value::known(if copy_step.mask { F::one() } else { F::zero() });
-            // assume copy events bytes is already word aligned for copy steps.
-            // only change by skip 32
+
+            let addr = if is_read_step { src_addr } else { dst_addr };
+            let is_pad = is_read_step && addr >= copy_event.src_addr_end;
+
+            let value = Value::known(F::from(copy_step.value as u64));
+            let value_or_pad = if is_pad {
+                Value::known(F::zero())
+            } else {
+                value
+            };
 
             if is_read_step {
                 if !copy_step.mask {
                     src_front_mask = false;
-                    copy_rlc_read = copy_rlc_read * challenges.evm_word()
-                        + Value::known(F::from(copy_step.value as u64));
+                    src_value_acc = src_value_acc * challenges.keccak_input() + value_or_pad;
                 }
                 if (step_idx / 2) % 32 == 0 {
                     // reset
@@ -1624,7 +1628,7 @@ impl CopyTable {
             } else {
                 if !copy_step.mask {
                     dst_front_mask = false;
-                    copy_rlc_write = copy_rlc_write * challenges.evm_word()
+                    dst_value_acc = dst_value_acc * challenges.keccak_input()
                         + Value::known(F::from(copy_step.value as u64));
                 }
                 if (step_idx / 2) % 32 == 0 {
@@ -1634,7 +1638,6 @@ impl CopyTable {
                 }
                 value_word_write_rlc = value_word_write_rlc * challenges.evm_word()
                     + Value::known(F::from(copy_step.value as u64));
-                // use value_prev.
                 value_word_write_rlc_prev = value_word_write_rlc_prev * challenges.evm_word()
                     + Value::known(F::from(copy_step.prev_value.unwrap_or(0u8) as u64));
             }
@@ -1655,19 +1658,8 @@ impl CopyTable {
 
             // bytes_left (final padding word length )
             let bytes_left = u64::try_from(full_length * 2 - step_idx).unwrap() / 2;
-            // value
-            let value = Value::known(F::from(copy_step.value as u64));
 
             let word_index = (step_idx as u64 / 2) % 32;
-
-            // value_acc
-            if is_read_step && !copy_step.mask {
-                value_acc = value_acc * challenges.keccak_input() + value;
-            }
-
-            // is_pad
-            let addr = if is_read_step { src_addr } else { dst_addr };
-            let is_pad = Value::known(F::from(is_read_step && addr >= copy_event.src_addr_end));
 
             // is_code
             let is_code = Value::known(copy_step.is_code.map_or(F::zero(), |v| F::from(v)));
@@ -1740,14 +1732,13 @@ impl CopyTable {
                     ),
                     (
                         if is_read_step {
-                            copy_rlc_read
+                            src_value_acc
                         } else {
-                            copy_rlc_write
+                            dst_value_acc
                         },
-                        "copy_rlc",
+                        "value_acc",
                     ),
-                    (value_acc, "value_acc"),
-                    (is_pad, "is_pad"),
+                    (Value::known(F::from(is_pad)), "is_pad"),
                     (is_code, "is_code"),
                     (is_mask, "mask"),
                     (


### PR DESCRIPTION
1. Combine all the checks of `rlc_acc` into one.
2. Copy `value_acc` when not updated.
3. `rlc_acc_read` and `rlc_acc_write` are replaced with `value_acc`.
4. Constrain the initial `value_acc`.