### PR TITLE
Fix Zellic & Kalos finding 7

### DIFF
--- a/zkevm-circuits/src/rlp_circuit_fsm.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm.rs
@@ -950,6 +950,7 @@ impl<F: Field> RlpCircuitConfig<F> {
             let mut cb = BaseConstraintBuilder::default();
             let tag = tag_expr(meta);
 
+            constrain_eq!(meta, cb, state, DecodeTagStart.expr());
             constrain_eq!(meta, cb, byte_idx, 1.expr());
             cb.require_zero(
                 "tag == TxType or tag == BeginList",


### PR DESCRIPTION
### Description

This PR aims to fix the finding 7 in [Zellic / Kalos Audit Report](https://hackmd.io/4XuxkwHERa6AIPQ6tr2QAg#Finding-7-RLP-Circuit-%E2%80%9CImportance%E2%80%9D-High).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update