### PR TITLE
Avoid whole memory clone when generating copy steps

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1787,10 +1787,10 @@ impl<'a> CircuitInputStateRef<'a> {
 
         // Combine the write slot bytes.
         let bytes_to_copy = result[..copy_length].iter();
-        let write_slot_bytes: Vec<u8> = memory[dst_begin_slot..dst_addr as usize]
+        let write_slot_bytes: Vec<u8> = memory[dst_begin_slot..dst_addr]
             .iter()
             .chain(bytes_to_copy)
-            .chain(memory[dst_addr as usize + copy_length..dst_end_slot].iter())
+            .chain(memory[dst_addr + copy_length..dst_end_slot].iter())
             .cloned()
             .collect();
 

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1711,13 +1711,13 @@ impl<'a> CircuitInputStateRef<'a> {
         exec_step: &mut ExecStep,
         src_addr: u64,
         copy_length: u64,
-        caller_memory: &Memory,
     ) -> Result<CopyEventSteps, Error> {
         if copy_length == 0 {
             return Ok(vec![]);
         }
 
         let src_range = MemoryWordRange::align_range(src_addr, copy_length);
+        let caller_memory = &self.caller_ctx()?.memory;
         let calldata_slot_bytes = caller_memory.read_chunk(src_range);
 
         let copy_steps = CopyEventStepsBuilder::memory_range(src_range)

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1896,13 +1896,10 @@ impl<'a> CircuitInputStateRef<'a> {
             return Ok((vec![], vec![], vec![]));
         }
 
-        let src_addr = src_addr.into().0;
-        let dst_addr = dst_addr.into().0;
-
         let call_ctx = self.call_ctx_mut()?;
         let (src_range, dst_range, write_slot_bytes) = combine_copy_slot_bytes(
-            src_addr,
-            dst_addr,
+            src_addr.into().0,
+            dst_addr.into().0,
             copy_length,
             &call_ctx.return_data,
             &mut call_ctx.memory,

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -257,11 +257,10 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                 let precompile_call: PrecompileCalls = code_address.0[19].into();
 
                 // get the result of the precompile call.
-                let caller_ctx = state.caller_ctx()?;
-                let caller_memory = caller_ctx.memory.clone();
                 let (result, contract_gas_cost) = execute_precompiled(
                     &code_address,
                     if args_length != 0 {
+                        let caller_memory = &state.caller_ctx()?.memory;
                         &caller_memory.0[args_offset..args_offset + args_length]
                     } else {
                         &[]
@@ -361,7 +360,6 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         &mut exec_step,
                         call.call_data_offset,
                         n_input_bytes as u64,
-                        &caller_memory,
                     )?;
                     let input_bytes = copy_steps
                         .iter()

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -277,14 +277,6 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         caller_ctx_mut.memory.extend_at_least(ret_offset + length);
                     }
                 }
-                let updated_memory = {
-                    let mut updated_memory = state.caller_ctx()?.memory.clone();
-                    if length > 0 {
-                        updated_memory.0[ret_offset..ret_offset + length]
-                            .copy_from_slice(&result[..length]);
-                    }
-                    updated_memory
-                };
 
                 for (field, value) in [
                     (
@@ -427,7 +419,6 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             call.return_data_offset,
                             length,
                             &result,
-                            &updated_memory,
                         )?;
                     let returned_bytes = read_steps
                         .iter()

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -76,23 +76,13 @@ fn gen_copy_event(
         .unwrap_or(u64::MAX)
         .min(src_addr_end);
 
-    let call_ctx = state.call_ctx_mut()?;
-    let memory = &mut call_ctx.memory;
-    memory.extend_for_range(dst_offset, length.into());
-    let memory_updated = {
-        let mut memory_updated = memory.clone();
-        memory_updated.copy_from(dst_offset, code_offset, length.into(), &bytecode.to_vec());
-        memory_updated
-    };
-
     let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
         exec_step,
         &bytecode,
-        src_addr as usize,
-        dst_addr as usize,
-        src_addr_end as usize,
-        length as usize,
-        &memory_updated,
+        src_addr,
+        dst_addr,
+        src_addr_end,
+        length,
     )?;
 
     Ok(CopyEvent {

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -76,14 +76,8 @@ fn gen_copy_event(
         .unwrap_or(u64::MAX)
         .min(src_addr_end);
 
-    let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
-        exec_step,
-        &bytecode,
-        src_addr,
-        dst_addr,
-        src_addr_end,
-        length,
-    )?;
+    let (copy_steps, prev_bytes) =
+        state.gen_copy_steps_for_bytecode(exec_step, &bytecode, src_addr, dst_addr, length)?;
 
     Ok(CopyEvent {
         src_type: CopyDataType::Bytecode,

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -133,23 +133,13 @@ fn gen_copy_event(
         .unwrap_or(u64::MAX)
         .min(src_addr_end);
 
-    let call_ctx = state.call_ctx_mut()?;
-    let memory = &mut call_ctx.memory;
-    memory.extend_for_range(dst_offset, length.into());
-    let memory_updated = {
-        let mut memory_updated = memory.clone();
-        memory_updated.copy_from(dst_offset, code_offset, length.into(), &bytecode.to_vec());
-        memory_updated
-    };
-
     let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
         exec_step,
         &bytecode,
-        src_addr as usize,
-        dst_addr as usize,
-        src_addr_end as usize,
-        length as usize,
-        &memory_updated,
+        src_addr,
+        dst_addr,
+        src_addr_end,
+        length,
     )?;
 
     Ok(CopyEvent {

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -133,14 +133,8 @@ fn gen_copy_event(
         .unwrap_or(u64::MAX)
         .min(src_addr_end);
 
-    let (copy_steps, prev_bytes) = state.gen_copy_steps_for_bytecode(
-        exec_step,
-        &bytecode,
-        src_addr,
-        dst_addr,
-        src_addr_end,
-        length,
-    )?;
+    let (copy_steps, prev_bytes) =
+        state.gen_copy_steps_for_bytecode(exec_step, &bytecode, src_addr, dst_addr, length)?;
 
     Ok(CopyEvent {
         src_addr,

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -87,16 +87,6 @@ fn gen_copy_event(
     let data_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?;
 
-    let call_ctx = state.call_ctx_mut()?;
-    let memory = &mut call_ctx.memory;
-    memory.extend_for_range(dst_addr, length);
-
-    let memory_updated = {
-        let mut memory_updated = memory.clone();
-        memory_updated.copy_from(dst_addr, data_offset, length, &call_ctx.return_data);
-        memory_updated
-    };
-
     let (dst_addr, data_offset, length) =
         (dst_addr.low_u64(), data_offset.as_u64(), length.as_u64());
 
@@ -107,14 +97,8 @@ fn gen_copy_event(
         last_callee_return_data_offset + last_callee_return_data_length,
     );
 
-    let (read_steps, write_steps, prev_bytes) = state.gen_copy_steps_for_return_data(
-        exec_step,
-        src_addr,
-        src_addr_end,
-        dst_addr,
-        length,
-        &memory_updated,
-    )?;
+    let (read_steps, write_steps, prev_bytes) =
+        state.gen_copy_steps_for_return_data(exec_step, src_addr, dst_addr, length)?;
 
     Ok(CopyEvent {
         src_type: CopyDataType::Memory,

--- a/eth-types/src/bytecode.rs
+++ b/eth-types/src/bytecode.rs
@@ -19,6 +19,12 @@ pub struct BytecodeElement {
     pub is_code: bool,
 }
 
+impl From<BytecodeElement> for u8 {
+    fn from(element: BytecodeElement) -> Self {
+        element.value
+    }
+}
+
 /// EVM Bytecode
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Bytecode {

--- a/eth-types/src/evm_types.rs
+++ b/eth-types/src/evm_types.rs
@@ -10,7 +10,7 @@ pub mod opcode_ids;
 pub mod stack;
 pub mod storage;
 
-pub use memory::{Memory, MemoryAddress};
+pub use memory::{Memory, MemoryAddress, MemoryRef};
 pub use opcode_ids::OpcodeId;
 pub use stack::{Stack, StackAddress};
 pub use storage::Storage;

--- a/eth-types/src/evm_types/memory.rs
+++ b/eth-types/src/evm_types/memory.rs
@@ -303,21 +303,7 @@ impl Memory {
     /// Reads an chunk of memory[offset..offset+length]. Zeros will be padded if
     /// index out of range.
     pub fn read_chunk(&self, range: impl Into<MemoryRange>) -> Vec<u8> {
-        let range = range.into();
-        let start_offset = range.start.0;
-        let length = range.length().0;
-        let chunk = if self.0.len() < start_offset {
-            &[]
-        } else {
-            &self.0[start_offset..]
-        };
-        let chunk = if chunk.len() < length {
-            // Expand chunk to expected size
-            chunk.iter().cloned().pad_using(length, |_| 0).collect()
-        } else {
-            chunk[..length].to_vec()
-        };
-        chunk
+        MemoryRef::from(self).read_chunk(range)
     }
 
     /// Write a chunk of memory[offset..offset+length]. If any data is written out-of-bound, it must
@@ -407,6 +393,37 @@ impl Memory {
     #[inline(always)]
     pub fn align_length(len: usize) -> usize {
         (len + 31) / 32 * 32
+    }
+}
+
+/// Reference of the EVM memory
+pub struct MemoryRef<'a>(pub &'a [u8]);
+
+impl<'a> From<&'a Memory> for MemoryRef<'a> {
+    fn from(memory: &'a Memory) -> Self {
+        MemoryRef(&memory.0)
+    }
+}
+
+impl<'a> MemoryRef<'a> {
+    /// Reads an chunk of memory[offset..offset+length]. Zeros will be padded if
+    /// index out of range.
+    pub fn read_chunk(&self, range: impl Into<MemoryRange>) -> Vec<u8> {
+        let range = range.into();
+        let start_offset = range.start.0;
+        let length = range.length().0;
+        let chunk = if self.0.len() < start_offset {
+            &[]
+        } else {
+            &self.0[start_offset..]
+        };
+        let chunk = if chunk.len() < length {
+            // Expand chunk to expected size
+            chunk.iter().cloned().pad_using(length, |_| 0).collect()
+        } else {
+            chunk[..length].to_vec()
+        };
+        chunk
     }
 }
 

--- a/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
+++ b/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
@@ -10,6 +10,7 @@ use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Expression, Fixed, V
 
 use crate::evm_circuit::util::constraint_builder::{BaseConstraintBuilder, ConstrainBuilderCommon};
 
+#[allow(clippy::too_many_arguments)]
 pub fn constrain_tag<F: Field>(
     meta: &mut ConstraintSystem<F>,
     q_enable: Column<Fixed>,
@@ -136,6 +137,7 @@ pub fn constrain_forward_parameters<F: Field>(
 
 /// Verify that when and after the address reaches the limit src_addr_end, zero-padding is enabled.
 /// Return (is_pad, is_pad at NEXT_STEP).
+#[allow(clippy::too_many_arguments)]
 pub fn constrain_is_pad<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,
@@ -287,6 +289,7 @@ pub fn constrain_masked_value<F: Field>(
 }
 
 /// Calculate the RLC of the non-masked data.
+#[allow(clippy::too_many_arguments)]
 pub fn constrain_value_rlc<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,
@@ -338,6 +341,7 @@ pub fn constrain_value_rlc<F: Field>(
 }
 
 /// Verify the rlc_acc field of the copy event against the value_acc of the data.
+#[allow(clippy::too_many_arguments)]
 pub fn constrain_event_rlc_acc<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,
@@ -392,6 +396,7 @@ pub fn constrain_event_rlc_acc<F: Field>(
 }
 
 /// Calculate the RLC of data within each word.
+#[allow(clippy::too_many_arguments)]
 pub fn constrain_word_rlc<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,
@@ -513,6 +518,7 @@ pub fn constrain_address<F: Field>(
 }
 
 /// Update the RW counter and verify that all RWs requested by the event are consumed.
+#[allow(clippy::too_many_arguments)]
 pub fn constrain_rw_counter<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,


### PR DESCRIPTION
### Summary

- Replace whole memory-clone with combining source data and destination memory to slot bytes. Main logic is implemented in a common function [combine_copy_slot_bytes](https://github.com/scroll-tech/zkevm-circuits/blob/7763eddec4cd3083144263bf40a99fd080fa22c3/bus-mapping/src/circuit_input_builder/input_state_ref.rs#L2048).

- Update callop, calldatacopy, codecopy, extcodecopy and returndatacopy in bus-mapping.