### PR TITLE
Copy: remove LtChip

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -391,6 +391,7 @@ pub struct CopyEvent {
     /// Represents the start address at the source of the copy event.
     pub src_addr: u64,
     /// Represents the end address at the source of the copy event.
+    /// It must be `src_addr_end >= src_addr`.
     pub src_addr_end: u64,
     /// Represents the source type.
     pub src_type: CopyDataType,

--- a/gadgets/src/is_zero.rs
+++ b/gadgets/src/is_zero.rs
@@ -43,6 +43,16 @@ impl<F: Field> IsZeroConfig<F> {
         self.is_zero_expression.clone()
     }
 
+    /// Returns the is_zero expression from inputs, at any rotation where q_enable=1.
+    pub fn expr_at(
+        &self,
+        meta: &mut VirtualCells<'_, F>,
+        at: Rotation,
+        value: Expression<F>,
+    ) -> Expression<F> {
+        1.expr() - value * meta.query_advice(self.value_inv, at)
+    }
+
     /// Annotates columns of this gadget embedded within a circuit region.
     pub fn annotate_columns_in_region(&self, region: &mut Region<F>, prefix: &str) {
         [(self.value_inv, "GADGETS_IS_ZERO_inverse_witness")]

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -37,7 +37,6 @@ use halo2_proofs::plonk::SecondPhase;
 
 use itertools::Itertools;
 use keccak256::plain::Keccak;
-use log::trace;
 use std::array;
 use strum_macros::{EnumCount, EnumIter};
 
@@ -1506,7 +1505,8 @@ impl CopyTable {
         copy_event: &CopyEvent,
         challenges: Challenges<Value<F>>,
     ) -> Vec<(CopyDataType, CopyTableRow<F>, CopyCircuitRow<F>)> {
-        trace!("assignments CopyEvent challenge  {challenges:?} ");
+        assert!(copy_event.src_addr_end >= copy_event.src_addr);
+
         let mut assignments = Vec::new();
         // rlc_acc
         let rlc_acc = {


### PR DESCRIPTION
`LtChip` is not used correctly because the `diff` bytes are not range-checked. Also it costs a lookup.

- Add support for any rotation in IsEqual.
- Replace the LessThan chip with IsEqual chip.
- Add constraints on `is_pad`.
- Fix an incorrect rotation of `is_pad`.
- A bit of formatting around `is_last` and `is_pad`.

This only works if `src_addr_end >= src_addr`, which is the case for all opcodes.