### PR TITLE
[don't-merge] Try to enable `test_aggregation_circuit`

### DIFF
--- a/aggregator/src/tests/aggregation.rs
+++ b/aggregator/src/tests/aggregation.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::mock_chunk::MockChunkCircuit;
 
-#[cfg(feature = "disable_proof_aggregation")]
+// #[cfg(feature = "disable_proof_aggregation")]
 #[test]
 fn test_aggregation_circuit() {
     env_logger::init();
@@ -22,7 +22,7 @@ fn test_aggregation_circuit() {
     // This set up requires one round of keccak for chunk's data hash
     let circuit = build_new_aggregation_circuit(2);
     let instance = circuit.instances();
-    let mock_prover = MockProver::<Fr>::run(19, &circuit, instance).unwrap();
+    let mock_prover = MockProver::<Fr>::run(25, &circuit, instance).unwrap();
     mock_prover.assert_satisfied_par();
 }
 


### PR DESCRIPTION
I suppose to use `MockProver` (for https://github.com/scroll-tech/scroll-prover/pull/160 tests), but it seems that this test case failed as:
```
thread 'tests::aggregation::test_aggregation_circuit' panicked at 'circuit was not satisfied', /home/ubuntu/.cargo/git/checkouts/halo2-189ea3cf7f17e3ad/aab39d5/halo2_proofs/src/dev.rs:1678:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test tests::aggregation::test_aggregation_circuit ... FAILED
```

Please correct me if I was wrong. Thanks.