### PR TITLE
constrain value=value_prev for mload

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -6,7 +6,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{
-                EVMConstraintBuilder, StepStateTransition,
+                ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
             from_bytes,
@@ -104,6 +104,20 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
             value_left_prev.expr(),
             None,
         );
+
+        // mload don't change value
+        cb.condition(is_mload.expr(), |cb| {
+            cb.require_equal(
+                "value_left = value_left_prev",
+                value_left.expr(),
+                value_left_prev.expr(),
+            );
+            cb.require_equal(
+                "value_right = value_right_prev",
+                value_right.expr(),
+                value_right_prev.expr(),
+            );
+        });
 
         cb.condition(is_mstore8.expr(), |cb| {
             // Check the byte that is written.

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -452,7 +452,7 @@ impl<F: Field> MemoryWordAddress<F> {
         self.slot.expr()
     }
 
-    // also seen as addr_left
+    // also seen as addr_right
     pub(crate) fn addr_right(&self) -> Expression<F> {
         self.slot.expr() + 32.expr()
     }
@@ -467,7 +467,9 @@ impl<F: Field> MemoryWordAddress<F> {
             .try_into()
             .unwrap();
 
+        println!("address_bytes {:?}", address_bytes);
         for (i, bit) in self.address_first_bits.iter().enumerate() {
+            println!("address_first_bits {} , {}", i, (address >> i) & 1);
             bit.assign(region, offset, Value::known(F::from((address >> i) & 1)))?;
         }
 
@@ -515,7 +517,7 @@ impl<F: Field> MemoryMask<F> {
 
         // Compute 2**shift. As a binary number, it looks like this (example shift=4):
         //   00001000000000000000000000000000
-        let two_pow_shift = Self::make_two_pow(shift_bits);
+        let two_pow_shift: Expression<F> = Self::make_two_pow(shift_bits);
 
         let expect = select::expr(
             is_mstore8,

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -467,9 +467,7 @@ impl<F: Field> MemoryWordAddress<F> {
             .try_into()
             .unwrap();
 
-        println!("address_bytes {:?}", address_bytes);
         for (i, bit) in self.address_first_bits.iter().enumerate() {
-            println!("address_first_bits {} , {}", i, (address >> i) & 1);
             bit.assign(region, offset, Value::known(F::from((address >> i) & 1)))?;
         }
 
@@ -517,7 +515,7 @@ impl<F: Field> MemoryMask<F> {
 
         // Compute 2**shift. As a binary number, it looks like this (example shift=4):
         //   00001000000000000000000000000000
-        let two_pow_shift: Expression<F> = Self::make_two_pow(shift_bits);
+        let two_pow_shift = Self::make_two_pow(shift_bits);
 
         let expect = select::expr(
             is_mstore8,


### PR DESCRIPTION
### Description

mload don't change value , constrain value=value_prev .
### Issue Link

[_link issue here_]

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

