### PR TITLE
`EcPairing` EVM Circuit Gadget

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -38,7 +38,7 @@ use ethers_providers::JsonRpcClient;
 pub use execution::{
     CopyBytes, CopyDataType, CopyEvent, CopyEventStepsBuilder, CopyStep, EcAddOp, EcMulOp,
     EcPairingOp, ExecState, ExecStep, ExpEvent, ExpStep, NumberOrHash, PrecompileEvent,
-    PrecompileEvents, N_PAIRING_PER_OP,
+    PrecompileEvents, N_BYTES_PER_PAIR, N_PAIRING_PER_OP,
 };
 use hex::decode_to_slice;
 

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -38,7 +38,7 @@ use ethers_providers::JsonRpcClient;
 pub use execution::{
     CopyBytes, CopyDataType, CopyEvent, CopyEventStepsBuilder, CopyStep, EcAddOp, EcMulOp,
     EcPairingOp, ExecState, ExecStep, ExpEvent, ExpStep, NumberOrHash, PrecompileEvent,
-    PrecompileEvents,
+    PrecompileEvents, N_PAIRING_PER_OP,
 };
 use hex::decode_to_slice;
 

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -1060,6 +1060,9 @@ impl EcMulOp {
 /// call are < 4, we append (G1::infinity, G2::generator) until we have the required no. of inputs.
 pub const N_PAIRING_PER_OP: usize = 4;
 
+/// The number of bytes taken to represent a pair (G1, G2).
+pub const N_BYTES_PER_PAIR: usize = 192;
+
 /// EcPairing operation
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EcPairingOp {

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -1061,7 +1061,7 @@ impl EcMulOp {
 pub const N_PAIRING_PER_OP: usize = 4;
 
 /// EcPairing operation
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EcPairingOp {
     /// tuples of G1 and G2 points.
     pub inputs: [(G1Affine, G2Affine); N_PAIRING_PER_OP],

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
@@ -19,7 +19,7 @@ pub(crate) fn handle(
     });
 
     let aux_data = EcAddAuxData::new(&input_bytes, &output_bytes);
-    exec_step.aux_data = Some(PrecompileAuxData::EcAdd(aux_data));
+    exec_step.aux_data = Some(PrecompileAuxData::EcAdd(Ok(aux_data)));
 
     let ec_add_op = EcAddOp::new_from_bytes(&input_bytes, &output_bytes);
     state.push_precompile_event(PrecompileEvent::EcAdd(ec_add_op));

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
@@ -1,14 +1,12 @@
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, EcAddOp, ExecStep, PrecompileEvent},
+    circuit_input_builder::{EcAddOp, PrecompileEvent},
     precompile::{EcAddAuxData, PrecompileAuxData},
 };
 
-pub(crate) fn handle(
+pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
-    state: &mut CircuitInputStateRef,
-    exec_step: &mut ExecStep,
-) {
+) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 128], |mut bytes| {
         bytes.resize(128, 0u8);
         bytes
@@ -19,8 +17,10 @@ pub(crate) fn handle(
     });
 
     let aux_data = EcAddAuxData::new(&input_bytes, &output_bytes);
-    exec_step.aux_data = Some(PrecompileAuxData::EcAdd(Ok(aux_data)));
-
     let ec_add_op = EcAddOp::new_from_bytes(&input_bytes, &output_bytes);
-    state.push_precompile_event(PrecompileEvent::EcAdd(ec_add_op));
+
+    (
+        Some(PrecompileEvent::EcAdd(ec_add_op)),
+        Some(PrecompileAuxData::EcAdd(Ok(aux_data))),
+    )
 }

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
@@ -19,7 +19,7 @@ pub(crate) fn handle(
     });
 
     let aux_data = EcMulAuxData::new(&input_bytes, &output_bytes);
-    exec_step.aux_data = Some(PrecompileAuxData::EcMul(aux_data));
+    exec_step.aux_data = Some(PrecompileAuxData::EcMul(Ok(aux_data)));
 
     let ec_mul_op = EcMulOp::new_from_bytes(&input_bytes, &output_bytes);
     state.push_precompile_event(PrecompileEvent::EcMul(ec_mul_op));

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
@@ -1,14 +1,12 @@
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, EcMulOp, ExecStep, PrecompileEvent},
+    circuit_input_builder::{EcMulOp, PrecompileEvent},
     precompile::{EcMulAuxData, PrecompileAuxData},
 };
 
-pub(crate) fn handle(
+pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
-    state: &mut CircuitInputStateRef,
-    exec_step: &mut ExecStep,
-) {
+) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 96], |mut bytes| {
         bytes.resize(96, 0u8);
         bytes
@@ -19,8 +17,10 @@ pub(crate) fn handle(
     });
 
     let aux_data = EcMulAuxData::new(&input_bytes, &output_bytes);
-    exec_step.aux_data = Some(PrecompileAuxData::EcMul(Ok(aux_data)));
-
     let ec_mul_op = EcMulOp::new_from_bytes(&input_bytes, &output_bytes);
-    state.push_precompile_event(PrecompileEvent::EcMul(ec_mul_op));
+
+    (
+        Some(PrecompileEvent::EcMul(ec_mul_op)),
+        Some(PrecompileAuxData::EcMul(Ok(aux_data))),
+    )
 }

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
@@ -1,0 +1,104 @@
+use halo2_proofs::halo2curves::{
+    bn256::{G1Affine, G2Affine},
+    group::cofactor::CofactorCurveAffine,
+    serde::SerdeObject,
+};
+use itertools::Itertools;
+
+use crate::{
+    circuit_input_builder::{
+        CircuitInputStateRef, EcPairingOp, ExecStep, PrecompileEvent, N_PAIRING_PER_OP,
+    },
+    precompile::{EcPairingAuxData, EcPairingError, PrecompileAuxData, PrecompileError},
+};
+
+const N_BYTES_PER_PAIR: usize = 192;
+
+pub(crate) fn handle(
+    input_bytes: Option<Vec<u8>>,
+    output_bytes: Option<Vec<u8>>,
+    state: &mut CircuitInputStateRef,
+    exec_step: &mut ExecStep,
+) {
+    // assertions.
+    let output_bytes = output_bytes.expect("precompile should return at least 0 on failure");
+    debug_assert_eq!(output_bytes.len(), 32, "ecPairing returns EVM word: 1 or 0");
+    let pairing_check = output_bytes[31];
+    debug_assert!(
+        pairing_check == 1 || pairing_check == 0,
+        "ecPairing returns 1 or 0"
+    );
+    debug_assert_eq!(output_bytes.iter().take(31).sum::<u8>(), 0);
+    debug_assert_eq!(input_bytes.is_none(), pairing_check == 1);
+
+    // aux data: Result<Box<PrecompileAuxData>, PrecompileError>
+    let aux_data = if let Some(input) = input_bytes {
+        // if input bytes provided.
+        if input.len() % N_BYTES_PER_PAIR != 0 || input.len() > N_PAIRING_PER_OP * N_BYTES_PER_PAIR
+        {
+            // if number of bytes provided were not what we expected.
+            Err(PrecompileError::EcPairing(EcPairingError::InvalidInputSize))
+        } else {
+            // process input bytes.
+            let res_pairs = input
+                .chunks_exact(N_BYTES_PER_PAIR)
+                .map(|chunk| {
+                    // process 192 bytes chunk at a time.
+                    // process g1.
+                    let g1_bytes = std::iter::empty()
+                        .chain(chunk[0x00..0x20].iter().rev())
+                        .chain(chunk[0x20..0x40].iter().rev())
+                        .cloned()
+                        .collect_vec();
+                    let g1 = G1Affine::from_raw_bytes(g1_bytes.as_slice());
+                    // process g2.
+                    let g2_bytes = std::iter::empty()
+                        .chain(chunk[0x40..0x60].iter().rev())
+                        .chain(chunk[0x60..0x80].iter().rev())
+                        .chain(chunk[0x80..0xA0].iter().rev())
+                        .chain(chunk[0xA0..0xC0].iter().rev())
+                        .cloned()
+                        .collect_vec();
+                    let g2 = G2Affine::from_raw_bytes(g2_bytes.as_slice());
+                    g1.zip(g2)
+                        .ok_or(PrecompileError::EcPairing(EcPairingError::NotOnCurve))
+                })
+                .collect::<Result<Vec<(G1Affine, G2Affine)>, PrecompileError>>();
+            if let Ok(mut pairs) = res_pairs {
+                // pad with placeholder pairs.
+                pairs.resize(
+                    N_PAIRING_PER_OP,
+                    (G1Affine::identity(), G2Affine::generator()),
+                );
+                Ok(Box::new(EcPairingAuxData(EcPairingOp {
+                    inputs: <[_; N_PAIRING_PER_OP]>::try_from(pairs)
+                        .expect("pairs.len() <= N_PAIRING_PER_OP"),
+                    output: 1.into(),
+                })))
+            } else {
+                Err(PrecompileError::EcPairing(EcPairingError::NotOnCurve))
+            }
+        }
+    } else {
+        // TODO: take care of insufficient gas here?
+        // if no input bytes.
+        let ec_pairing_op = EcPairingOp {
+            inputs: [
+                (G1Affine::identity(), G2Affine::generator()),
+                (G1Affine::identity(), G2Affine::generator()),
+                (G1Affine::identity(), G2Affine::generator()),
+                (G1Affine::identity(), G2Affine::generator()),
+            ],
+            output: 1.into(),
+        };
+        Ok(Box::new(EcPairingAuxData(ec_pairing_op)))
+    };
+
+    // update step and state.
+    // TODO: for now the ECC sub-circuit only handles OK cases. Once we verify invalidity of inputs
+    // as well, we will also push the Err cases.
+    if let Ok(ref data) = aux_data {
+        state.push_precompile_event(PrecompileEvent::EcPairing(Box::new(data.0.clone())));
+    }
+    exec_step.aux_data = Some(PrecompileAuxData::EcPairing(aux_data));
+}

--- a/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
@@ -5,16 +5,14 @@ use eth_types::{
 use halo2_proofs::halo2curves::secp256k1::Fq;
 
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, ExecStep, PrecompileEvent},
+    circuit_input_builder::PrecompileEvent,
     precompile::{EcrecoverAuxData, PrecompileAuxData},
 };
 
-pub(crate) fn handle(
+pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
-    state: &mut CircuitInputStateRef,
-    exec_step: &mut ExecStep,
-) {
+) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 128], |mut bytes| {
         bytes.resize(128, 0u8);
         bytes
@@ -44,19 +42,22 @@ pub(crate) fn handle(
                 msg_hash: Fq::from_bytes(&aux_data.msg_hash.to_be_bytes()).unwrap(),
             };
             assert_eq!(aux_data.recovered_addr, sign_data.get_addr());
-            state.push_precompile_event(PrecompileEvent::Ecrecover(sign_data));
+            (
+                Some(PrecompileEvent::Ecrecover(sign_data)),
+                Some(PrecompileAuxData::Ecrecover(Ok(aux_data))),
+            )
         } else {
             log::warn!(
                 "could not recover pubkey. ecrecover aux_data={:?}",
                 aux_data
             );
+            (None, Some(PrecompileAuxData::Ecrecover(Ok(aux_data))))
         }
     } else {
         log::warn!(
             "invalid recoveryId for ecrecover. sig_v={:?}",
             aux_data.sig_v
         );
+        (None, Some(PrecompileAuxData::Ecrecover(Ok(aux_data))))
     }
-
-    exec_step.aux_data = Some(PrecompileAuxData::Ecrecover(Ok(aux_data)));
 }

--- a/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
@@ -58,5 +58,5 @@ pub(crate) fn handle(
         );
     }
 
-    exec_step.aux_data = Some(PrecompileAuxData::Ecrecover(aux_data));
+    exec_step.aux_data = Some(PrecompileAuxData::Ecrecover(Ok(aux_data)));
 }

--- a/bus-mapping/src/evm/opcodes/precompiles/mod.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/mod.rs
@@ -9,10 +9,12 @@ use crate::{
 
 mod ec_add;
 mod ec_mul;
+mod ec_pairing;
 mod ecrecover;
 
 use ec_add::handle as handle_ec_add;
 use ec_mul::handle as handle_ec_mul;
+use ec_pairing::handle as handle_ec_pairing;
 use ecrecover::handle as handle_ecrecover;
 
 type InOutRetData = (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>);
@@ -39,6 +41,9 @@ pub fn gen_associated_ops(
         }
         PrecompileCalls::Bn128Mul => {
             handle_ec_mul(input_bytes, output_bytes, state, &mut exec_step)
+        }
+        PrecompileCalls::Bn128Pairing => {
+            handle_ec_pairing(input_bytes, output_bytes, state, &mut exec_step)
         }
         _ => {}
     }

--- a/bus-mapping/src/evm/opcodes/precompiles/mod.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/mod.rs
@@ -12,10 +12,10 @@ mod ec_mul;
 mod ec_pairing;
 mod ecrecover;
 
-use ec_add::handle as handle_ec_add;
-use ec_mul::handle as handle_ec_mul;
-use ec_pairing::handle as handle_ec_pairing;
-use ecrecover::handle as handle_ecrecover;
+use ec_add::opt_data as opt_data_ec_add;
+use ec_mul::opt_data as opt_data_ec_mul;
+use ec_pairing::opt_data as opt_data_ec_pairing;
+use ecrecover::opt_data as opt_data_ecrecover;
 
 type InOutRetData = (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>);
 
@@ -32,21 +32,19 @@ pub fn gen_associated_ops(
 
     common_call_ctx_reads(state, &mut exec_step, &call);
 
-    match precompile {
-        PrecompileCalls::Ecrecover => {
-            handle_ecrecover(input_bytes, output_bytes, state, &mut exec_step)
-        }
-        PrecompileCalls::Bn128Add => {
-            handle_ec_add(input_bytes, output_bytes, state, &mut exec_step)
-        }
-        PrecompileCalls::Bn128Mul => {
-            handle_ec_mul(input_bytes, output_bytes, state, &mut exec_step)
-        }
-        PrecompileCalls::Bn128Pairing => {
-            handle_ec_pairing(input_bytes, output_bytes, state, &mut exec_step)
-        }
-        _ => {}
+    let (opt_event, aux_data) = match precompile {
+        PrecompileCalls::Ecrecover => opt_data_ecrecover(input_bytes, output_bytes),
+        PrecompileCalls::Bn128Add => opt_data_ec_add(input_bytes, output_bytes),
+        PrecompileCalls::Bn128Mul => opt_data_ec_mul(input_bytes, output_bytes),
+        PrecompileCalls::Bn128Pairing => opt_data_ec_pairing(input_bytes, output_bytes),
+        PrecompileCalls::Identity => (None, None),
+        _ => unimplemented!("precompile {:?} unsupported", precompile),
+    };
+
+    if let Some(event) = opt_event {
+        state.push_precompile_event(event);
     }
+    exec_step.aux_data = aux_data;
 
     Ok(exec_step)
 }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -203,7 +203,7 @@ use opcode_not::NotGadget;
 use origin::OriginGadget;
 use pc::PcGadget;
 use pop::PopGadget;
-use precompiles::{EcAddGadget, EcMulGadget, EcrecoverGadget, IdentityGadget};
+use precompiles::{EcAddGadget, EcMulGadget, EcPairingGadget, EcrecoverGadget, IdentityGadget};
 use push::PushGadget;
 use return_revert::ReturnRevertGadget;
 use returndatacopy::ReturnDataCopyGadget;
@@ -355,8 +355,7 @@ pub(crate) struct ExecutionConfig<F> {
     precompile_modexp_gadget: Box<BasePrecompileGadget<F, { ExecutionState::PrecompileBigModExp }>>,
     precompile_bn128add_gadget: Box<EcAddGadget<F>>,
     precompile_bn128mul_gadget: Box<EcMulGadget<F>>,
-    precompile_bn128pairing_gadget:
-        Box<BasePrecompileGadget<F, { ExecutionState::PrecompileBn256Pairing }>>,
+    precompile_bn128pairing_gadget: Box<EcPairingGadget<F>>,
     precompile_blake2f_gadget: Box<BasePrecompileGadget<F, { ExecutionState::PrecompileBlake2f }>>,
 }
 

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_add.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_add.rs
@@ -127,7 +127,7 @@ impl<F: Field> ExecutionGadget<F> for EcAddGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        if let Some(PrecompileAuxData::EcAdd(aux_data)) = &step.aux_data {
+        if let Some(PrecompileAuxData::EcAdd(Ok(aux_data))) = &step.aux_data {
             let keccak_rand = region.challenges().keccak_input();
             for (col, word_value) in [
                 (&self.point_p_x_rlc, aux_data.p_x),

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_mul.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_mul.rs
@@ -193,7 +193,7 @@ impl<F: Field> ExecutionGadget<F> for EcMulGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        if let Some(PrecompileAuxData::EcMul(aux_data)) = &step.aux_data {
+        if let Some(PrecompileAuxData::EcMul(Ok(aux_data))) = &step.aux_data {
             for (col, is_zero_gadget, word_value) in [
                 (&self.point_p_x_rlc, &self.p_x_is_zero, aux_data.p_x),
                 (&self.point_p_y_rlc, &self.p_y_is_zero, aux_data.p_y),

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -1,0 +1,196 @@
+use bus_mapping::precompile::PrecompileCalls;
+use eth_types::Field;
+use gadgets::util::{and, not, or, Expr};
+use halo2_proofs::plonk::Error;
+
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        util::{
+            common_gadget::RestoreContextGadget,
+            constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+            math_gadget::{IsZeroGadget, LtGadget},
+            CachedRegion, Cell,
+        },
+    },
+    table::CallContextFieldTag,
+    witness::{Block, Call, ExecStep, Transaction},
+};
+
+/// Note: input_len ∈ { 0, 192, 384, 576, 768 } if valid.
+///
+/// Note: input bytes are padded to 768 bytes within our zkEVM implementation to standardise a
+/// pairing operation, such that each pairing op has 4 pairs: [(G1, G2); 4].
+#[derive(Clone, Debug)]
+pub struct EcPairingGadget<F> {
+    // Random linear combination of input bytes to the precompile ecPairing.
+    input_rlc: Cell<F>,
+    // Boolean output from the ecPairing call, denoting whether or not the pairing check was
+    // successful.
+    output: Cell<F>,
+
+    // Verify invalidity of input bytes. We basically check `or(1, 2)` where:
+    // 1. input_len > 4 * 192
+    // 2. input_len % 192 != 0
+    input_is_zero: IsZeroGadget<F>,
+    input_lt_769: LtGadget<F, 2>,
+    input_mod_192: Cell<F>,
+    input_mod_192_lt: LtGadget<F, 1>,
+    input_mod_192_is_zero: IsZeroGadget<F>,
+
+    is_success: Cell<F>,
+    callee_address: Cell<F>,
+    caller_id: Cell<F>,
+    call_data_offset: Cell<F>,
+    call_data_length: Cell<F>,
+    return_data_offset: Cell<F>,
+    return_data_length: Cell<F>,
+    restore_context: RestoreContextGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
+    const NAME: &'static str = "EC_PAIRING";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::PrecompileBn256Pairing;
+
+    fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
+        let (input_rlc, output) = (cb.query_cell_phase2(), cb.query_bool());
+
+        let [is_success, callee_address, caller_id, call_data_offset, call_data_length, return_data_offset, return_data_length] =
+            [
+                CallContextFieldTag::IsSuccess,
+                CallContextFieldTag::CalleeAddress,
+                CallContextFieldTag::CallerId,
+                CallContextFieldTag::CallDataOffset,
+                CallContextFieldTag::CallDataLength,
+                CallContextFieldTag::ReturnDataOffset,
+                CallContextFieldTag::ReturnDataLength,
+            ]
+            .map(|tag| cb.call_context(None, tag));
+
+        cb.precompile_info_lookup(
+            cb.execution_state().as_u64().expr(),
+            callee_address.expr(),
+            cb.execution_state().precompile_base_gas_cost().expr(),
+        );
+
+        // validate successful call to the precompile ecPairing.
+        cb.condition(is_success.expr(), |cb| {
+            // Covers the following cases:
+            // 1. successful pairing check (where input_rlc == 0).
+            // 2. successful pairing check (where input_rlc != 0).
+            // 3. unsuccessful pairing check.
+            cb.ecc_table_lookup(
+                u64::from(PrecompileCalls::Bn128Pairing).expr(),
+                0.expr(),
+                0.expr(),
+                0.expr(),
+                0.expr(),
+                // TODO: manage padding of input bytes.
+                input_rlc.expr(),
+                output.expr(),
+                0.expr(),
+            );
+
+            cb.require_in_set(
+                "input_len ∈ { 0, 192, 384, 576, 768 } if valid",
+                call_data_length.expr(),
+                vec![0.expr(), 192.expr(), 384.expr(), 576.expr(), 768.expr()],
+            );
+        });
+
+        // helpers for validating len(input).
+        let input_is_zero =
+            IsZeroGadget::construct(cb, "ecPairing(call_data_length)", call_data_length.expr());
+        let input_lt_769 = LtGadget::construct(cb, call_data_length.expr(), 769.expr());
+        let (input_mod_192, input_mod_192_lt) = cb.condition(
+            // if len(input) > 0
+            // if len(input) <= 768
+            and::expr([not::expr(input_is_zero.expr()), input_lt_769.expr()]),
+            |cb| {
+                // r == len(input) % 192
+                let input_mod_192 = cb.query_byte();
+                // r < 192
+                let input_mod_192_lt = LtGadget::construct(cb, input_mod_192.expr(), 192.expr());
+                cb.require_equal("len(input) % 192 < 192", input_mod_192_lt.expr(), 1.expr());
+                // q == len(input) // 192
+                let input_div_192 = cb.query_cell();
+                cb.require_in_set(
+                    "len(input) // 192 ∈ { 0, 1, 2, 3 }",
+                    input_div_192.expr(),
+                    vec![0.expr(), 1.expr(), 2.expr(), 3.expr()],
+                );
+
+                // q * 192 + r == call_data_length
+                cb.require_equal(
+                    "q * 192 + r == len(input)",
+                    input_div_192.expr() * 192.expr() + input_mod_192.expr(),
+                    call_data_length.expr(),
+                );
+
+                (input_mod_192, input_mod_192_lt)
+            },
+        );
+        let input_mod_192_is_zero = IsZeroGadget::construct(
+            cb,
+            "ecPairing(call_data_length % 192)",
+            input_mod_192.expr(),
+        );
+
+        // validate failed call to the precompile ecPairing.
+        cb.condition(not::expr(is_success.expr()), |cb| {
+            cb.require_zero("if ecPairing call fails: output == 0", output.expr());
+
+            // Failure could be because of the following reasons:
+            // 1. Invalid number of bytes supplied to the precompile ecPairing.
+            // 2. TODO: If a deserialized point is not on the respective curves (G1 or G2).
+            cb.require_true(
+                "if ecPairing fails: or(invalid_input_len, point_not_on_curve) == true",
+                or::expr([not::expr(input_mod_192_is_zero.expr()), false.expr()]),
+            );
+        });
+
+        let restore_context = RestoreContextGadget::construct(
+            cb,
+            is_success.expr(),
+            0.expr(),
+            0.expr(),
+            0.expr(),
+            0.expr(),
+            0.expr(),
+        );
+
+        Self {
+            input_rlc,
+            output,
+
+            input_is_zero,
+            input_lt_769,
+            input_mod_192,
+            input_mod_192_lt,
+            input_mod_192_is_zero,
+
+            is_success,
+            callee_address,
+            caller_id,
+            call_data_offset,
+            call_data_length,
+            return_data_offset,
+            return_data_length,
+            restore_context,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        _region: &mut CachedRegion<'_, '_, F>,
+        _offset: usize,
+        _block: &Block<F>,
+        _transaction: &Transaction,
+        _call: &Call,
+        _step: &ExecStep,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
@@ -125,7 +125,7 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        if let Some(PrecompileAuxData::Ecrecover(aux_data)) = &step.aux_data {
+        if let Some(PrecompileAuxData::Ecrecover(Ok(aux_data))) = &step.aux_data {
             let recovered = !aux_data.recovered_addr.is_zero();
             self.recovered
                 .assign(region, offset, Value::known(F::from(recovered as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/mod.rs
@@ -24,6 +24,9 @@ pub use ecrecover::EcrecoverGadget;
 mod ec_mul;
 pub use ec_mul::EcMulGadget;
 
+mod ec_pairing;
+pub use ec_pairing::EcPairingGadget;
+
 mod identity;
 pub use identity::IdentityGadget;
 


### PR DESCRIPTION
### Description

EVM Circuit Gadget for `EcPairing` precompile verification.

The `EcPairingGadget`, unlike the `EcAddGadget` or `EcMulGadget`, is designed to be capable of handling valid as well as invalid inputs supplied to the precompile call. So if the call fails (`CallContext::IsSuccess == false`), we should be able to validate the following:
```rust
cb.require_true(
    "ecPairing: possible reasons for failure",
    or::expr([
        // 1. len(inputs) > 4 * 192
        // 2. len(inputs) % 192 != 0
        // 3. any point not on curve (G1 / G2)
    ]),
);
```

### Issue Link

Closes #596 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update