### PR TITLE
fix: add derived `Debug` to CompressionCircuit

### DIFF
--- a/aggregator/src/compression/circuit.rs
+++ b/aggregator/src/compression/circuit.rs
@@ -37,7 +37,7 @@ use super::config::CompressionConfig;
 ///
 /// It re-exposes same public inputs from the input snark.
 /// All this circuit does is to reduce the proof size.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CompressionCircuit {
     pub(crate) svk: KzgSuccinctVerifyingKey<G1Affine>,
     pub(crate) snark: SnarkWitness,


### PR DESCRIPTION
### Description

Suppose to [save Verifier in OnceCell](https://github.com/scroll-tech/scroll-prover/blob/main/ffi/src/verify.rs#L6) which needs Debug in scroll-prover.

Related scroll-prover PR https://github.com/scroll-tech/scroll-prover/pull/178