### PR TITLE
`EcPairing` EVM Circuit Gadget (Valid Inputs)

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -37,8 +37,8 @@ use ethers_core::{
 use ethers_providers::JsonRpcClient;
 pub use execution::{
     CopyBytes, CopyDataType, CopyEvent, CopyEventStepsBuilder, CopyStep, EcAddOp, EcMulOp,
-    EcPairingOp, ExecState, ExecStep, ExpEvent, ExpStep, NumberOrHash, PrecompileEvent,
-    PrecompileEvents, N_BYTES_PER_PAIR, N_PAIRING_PER_OP,
+    EcPairingOp, EcPairingPair, ExecState, ExecStep, ExpEvent, ExpStep, NumberOrHash,
+    PrecompileEvent, PrecompileEvents, N_BYTES_PER_PAIR, N_PAIRING_PER_OP,
 };
 use hex::decode_to_slice;
 

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -38,7 +38,7 @@ use ethers_providers::JsonRpcClient;
 pub use execution::{
     CopyBytes, CopyDataType, CopyEvent, CopyEventStepsBuilder, CopyStep, EcAddOp, EcMulOp,
     EcPairingOp, ExecState, ExecStep, ExpEvent, ExpStep, NumberOrHash, PrecompileEvent,
-    PrecompileEvents,
+    PrecompileEvents, N_BYTES_PER_PAIR, N_PAIRING_PER_OP,
 };
 use hex::decode_to_slice;
 
@@ -116,7 +116,7 @@ impl Default for CircuitsParams {
             max_inner_blocks: 64,
             // TODO: Check whether this value is correct or we should increase/decrease based on
             // this lib tests
-            max_copy_rows: 1000,
+            max_copy_rows: 2000,
             max_mpt_rows: 1000,
             max_exp_steps: 1000,
             max_bytecode: 512,

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -1111,7 +1111,12 @@ impl EcPairingPair {
         Self { g1_point, g2_point }
     }
 
-    /// Padding pair for ECC circuit.
+    /// Padding pair for ECC circuit. The pairing check is done with a constant number
+    /// `N_PAIRING_PER_OP` of (G1, G2) pairs. The ECC circuit under the hood uses halo2-lib to
+    /// compute the multi-miller loop, which allows `(G1::Infinity, G2::Generator)` pair to skip
+    /// the loop for that pair. So in case the EVM inputs are less than `N_PAIRING_PER_OP` we pad
+    /// the ECC Circuit inputs by this pair. Any EVM input of `(G1::Infinity, G2)` or
+    /// `(G1, G2::Infinity)` is also transformed into `(G1::Infinity, G2::Generator)`.
     pub fn ecc_padding() -> Self {
         Self {
             g1_point: G1Affine::identity(),
@@ -1119,7 +1124,9 @@ impl EcPairingPair {
         }
     }
 
-    /// Padding pair for EVM circuit.
+    /// Padding pair for EVM circuit. The pairing check is done with a constant number
+    /// `N_PAIRING_PER_OP` of (G1, G2) pairs. In case EVM inputs are less in number, we pad them
+    /// with `(G1::Infinity, G2::Infinity)` for simplicity.
     pub fn evm_padding() -> Self {
         Self {
             g1_point: G1Affine::identity(),

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
@@ -1,14 +1,12 @@
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, EcAddOp, ExecStep, PrecompileEvent},
+    circuit_input_builder::{EcAddOp, PrecompileEvent},
     precompile::{EcAddAuxData, PrecompileAuxData},
 };
 
-pub(crate) fn handle(
+pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
-    state: &mut CircuitInputStateRef,
-    exec_step: &mut ExecStep,
-) {
+) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 128], |mut bytes| {
         bytes.resize(128, 0u8);
         bytes
@@ -19,8 +17,10 @@ pub(crate) fn handle(
     });
 
     let aux_data = EcAddAuxData::new(&input_bytes, &output_bytes);
-    exec_step.aux_data = Some(PrecompileAuxData::EcAdd(aux_data));
-
     let ec_add_op = EcAddOp::new_from_bytes(&input_bytes, &output_bytes);
-    state.push_precompile_event(PrecompileEvent::EcAdd(ec_add_op));
+
+    (
+        Some(PrecompileEvent::EcAdd(ec_add_op)),
+        Some(PrecompileAuxData::EcAdd(aux_data)),
+    )
 }

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
@@ -1,14 +1,12 @@
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, EcMulOp, ExecStep, PrecompileEvent},
+    circuit_input_builder::{EcMulOp, PrecompileEvent},
     precompile::{EcMulAuxData, PrecompileAuxData},
 };
 
-pub(crate) fn handle(
+pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
-    state: &mut CircuitInputStateRef,
-    exec_step: &mut ExecStep,
-) {
+) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 96], |mut bytes| {
         bytes.resize(96, 0u8);
         bytes
@@ -19,8 +17,10 @@ pub(crate) fn handle(
     });
 
     let aux_data = EcMulAuxData::new(&input_bytes, &output_bytes);
-    exec_step.aux_data = Some(PrecompileAuxData::EcMul(aux_data));
-
     let ec_mul_op = EcMulOp::new_from_bytes(&input_bytes, &output_bytes);
-    state.push_precompile_event(PrecompileEvent::EcMul(ec_mul_op));
+
+    (
+        Some(PrecompileEvent::EcMul(ec_mul_op)),
+        Some(PrecompileAuxData::EcMul(aux_data)),
+    )
 }

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
@@ -1,0 +1,109 @@
+use eth_types::{ToLittleEndian, U256};
+use halo2_proofs::halo2curves::{
+    bn256::{Fq, Fq2, G1Affine, G2Affine},
+    group::cofactor::CofactorCurveAffine,
+};
+
+use crate::{
+    circuit_input_builder::{EcPairingOp, PrecompileEvent, N_BYTES_PER_PAIR, N_PAIRING_PER_OP},
+    precompile::{EcPairingAuxData, PrecompileAuxData},
+};
+
+pub(crate) fn opt_data(
+    input_bytes: Option<Vec<u8>>,
+    output_bytes: Option<Vec<u8>>,
+) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
+    // assertions.
+    let output_bytes = output_bytes.expect("precompile should return at least 0 on failure");
+    debug_assert_eq!(output_bytes.len(), 32, "ecPairing returns EVM word: 1 or 0");
+    let pairing_check = output_bytes[31];
+    debug_assert!(
+        pairing_check == 1 || pairing_check == 0,
+        "ecPairing returns 1 or 0"
+    );
+    debug_assert_eq!(output_bytes.iter().take(31).sum::<u8>(), 0);
+    if input_bytes.is_none() {
+        debug_assert_eq!(pairing_check, 1);
+    }
+
+    let aux_data = if let Some(input) = input_bytes {
+        debug_assert!(
+            input.len() % N_BYTES_PER_PAIR == 0
+                && input.len() <= N_PAIRING_PER_OP * N_BYTES_PER_PAIR
+        );
+        // process input bytes.
+        let mut pairs = input
+            .chunks_exact(N_BYTES_PER_PAIR)
+            .map(|chunk| {
+                // process 192 bytes chunk at a time.
+                // process g1.
+                let g1 = {
+                    let g1_x =
+                        Fq::from_bytes(&U256::from_big_endian(&chunk[0x00..0x20]).to_le_bytes())
+                            .unwrap();
+                    let g1_y =
+                        Fq::from_bytes(&U256::from_big_endian(&chunk[0x20..0x40]).to_le_bytes())
+                            .unwrap();
+                    G1Affine { x: g1_x, y: g1_y }
+                };
+                // process g2.
+                let g2 = {
+                    let g2_x1 =
+                        Fq::from_bytes(&U256::from_big_endian(&chunk[0x40..0x60]).to_le_bytes())
+                            .unwrap();
+                    let g2_x2 =
+                        Fq::from_bytes(&U256::from_big_endian(&chunk[0x60..0x80]).to_le_bytes())
+                            .unwrap();
+                    let g2_y1 =
+                        Fq::from_bytes(&U256::from_big_endian(&chunk[0x80..0xA0]).to_le_bytes())
+                            .unwrap();
+                    let g2_y2 =
+                        Fq::from_bytes(&U256::from_big_endian(&chunk[0xA0..0xC0]).to_le_bytes())
+                            .unwrap();
+                    G2Affine {
+                        x: Fq2 {
+                            c0: g2_x1,
+                            c1: g2_x2,
+                        },
+                        y: Fq2 {
+                            c0: g2_y1,
+                            c1: g2_y2,
+                        },
+                    }
+                };
+                if g1.is_identity().into() && g2.is_identity().into() {
+                    (g1, G2Affine::generator(), true)
+                } else {
+                    (g1, g2, true)
+                }
+            })
+            .collect::<Vec<(G1Affine, G2Affine, bool)>>();
+        // pad with placeholder pairs.
+        pairs.resize(
+            N_PAIRING_PER_OP,
+            (G1Affine::identity(), G2Affine::generator(), false),
+        );
+        EcPairingAuxData(EcPairingOp {
+            inputs: <[_; N_PAIRING_PER_OP]>::try_from(pairs)
+                .expect("pairs.len() <= N_PAIRING_PER_OP"),
+            output: pairing_check.into(),
+        })
+    } else {
+        // if no input bytes.
+        let ec_pairing_op = EcPairingOp {
+            inputs: [
+                (G1Affine::identity(), G2Affine::generator(), false),
+                (G1Affine::identity(), G2Affine::generator(), false),
+                (G1Affine::identity(), G2Affine::generator(), false),
+                (G1Affine::identity(), G2Affine::generator(), false),
+            ],
+            output: pairing_check.into(),
+        };
+        EcPairingAuxData(ec_pairing_op)
+    };
+
+    (
+        Some(PrecompileEvent::EcPairing(Box::new(aux_data.0.clone()))),
+        Some(PrecompileAuxData::EcPairing(Box::new(aux_data))),
+    )
+}

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -4,7 +4,7 @@ use eth_types::{evm_types::GasCost, Address, ToBigEndian, Word};
 use revm_precompile::{Precompile, Precompiles};
 use strum::EnumIter;
 
-use crate::circuit_input_builder::EcMulOp;
+use crate::circuit_input_builder::{EcMulOp, EcPairingOp};
 
 /// Check if address is a precompiled or not.
 pub fn is_precompiled(address: &Address) -> bool {
@@ -236,6 +236,10 @@ impl EcMulAuxData {
     }
 }
 
+/// Auxiliary data for EcPairing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EcPairingAuxData(pub EcPairingOp);
+
 /// Auxiliary data attached to an internal state for precompile verification.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PrecompileAuxData {
@@ -245,6 +249,8 @@ pub enum PrecompileAuxData {
     EcAdd(EcAddAuxData),
     /// EcMul.
     EcMul(EcMulAuxData),
+    /// EcPairing.
+    EcPairing(Box<EcPairingAuxData>),
 }
 
 impl Default for PrecompileAuxData {

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -19,6 +19,8 @@ use halo2_proofs::{
 };
 use mock::{test_ctx::helpers::account_0_code_account_1_no_code, TestContext, MOCK_ACCOUNTS};
 
+const K: u32 = 20;
+
 #[test]
 fn copy_circuit_unusable_rows() {
     assert_eq!(
@@ -29,7 +31,6 @@ fn copy_circuit_unusable_rows() {
 
 /// Test copy circuit from copy events and test data
 pub fn test_copy_circuit<F: Field>(
-    k: u32,
     copy_events: Vec<CopyEvent>,
     max_copy_rows: usize,
     external_data: ExternalData,
@@ -37,17 +38,13 @@ pub fn test_copy_circuit<F: Field>(
     let circuit =
         CopyCircuit::<F>::new_with_external_data(copy_events, max_copy_rows, external_data);
 
-    let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
+    let prover = MockProver::<F>::run(K, &circuit, vec![]).unwrap();
     prover.verify_par()
 }
 
 /// Test copy circuit with the provided block witness
-pub fn test_copy_circuit_from_block<F: Field>(
-    k: u32,
-    block: Block<F>,
-) -> Result<(), Vec<VerifyFailure>> {
+pub fn test_copy_circuit_from_block<F: Field>(block: Block<F>) -> Result<(), Vec<VerifyFailure>> {
     test_copy_circuit::<F>(
-        k,
         block.copy_events,
         block.circuits_params.max_copy_rows,
         ExternalData {
@@ -308,56 +305,56 @@ fn gen_return_data() -> CircuitInputBuilder {
 fn copy_circuit_valid_calldatacopy() {
     let builder = gen_calldatacopy_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(10, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
 fn copy_circuit_valid_codecopy() {
     let builder = gen_codecopy_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(10, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
 fn copy_circuit_valid_returndatacopy() {
     let builder = gen_returndatacopy_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(10, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
 fn copy_circuit_valid_extcodecopy() {
     let builder = gen_extcodecopy_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(14, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
 fn copy_circuit_valid_sha3() {
     let builder = gen_sha3_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(14, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
 fn copy_circuit_valid_tx_log() {
     let builder = gen_tx_log_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(10, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
 fn copy_circuit_valid_create() {
     let builder = gen_create_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(10, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
 fn copy_circuit_valid_return() {
     let builder = gen_return_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(10, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]
@@ -373,7 +370,7 @@ fn copy_circuit_invalid_calldatacopy() {
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
     assert_error_matches(
-        test_copy_circuit_from_block(10, block),
+        test_copy_circuit_from_block(block),
         vec!["Memory word lookup", "Tx calldata lookup"],
     );
 }
@@ -391,7 +388,7 @@ fn copy_circuit_invalid_codecopy() {
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
     assert_error_matches(
-        test_copy_circuit_from_block(10, block),
+        test_copy_circuit_from_block(block),
         vec!["Memory word lookup", "Bytecode lookup"],
     );
 }
@@ -409,7 +406,7 @@ fn copy_circuit_invalid_extcodecopy() {
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
     assert_error_matches(
-        test_copy_circuit_from_block(14, block),
+        test_copy_circuit_from_block(block),
         vec!["Memory word lookup", "Bytecode lookup"],
     );
 }
@@ -427,7 +424,7 @@ fn copy_circuit_invalid_sha3() {
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
 
     assert_error_matches(
-        test_copy_circuit_from_block(14, block),
+        test_copy_circuit_from_block(block),
         vec!["Memory word lookup"],
     );
 }
@@ -443,7 +440,7 @@ fn copy_circuit_invalid_tx_log() {
             .wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    let result = test_copy_circuit_from_block(10, block);
+    let result = test_copy_circuit_from_block(block);
 
     let errors = result.expect_err("result is not an error");
     errors
@@ -485,7 +482,7 @@ fn copy_circuit_precompile_call() {
         .handle_block(&block.eth_block, &block.geth_traces)
         .unwrap();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-    assert_eq!(test_copy_circuit_from_block(10, block), Ok(()));
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
 
 #[test]

--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -520,12 +520,12 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         op: &EcPairingOp,
     ) -> EcPairingAssigned<F> {
         let g1s = op
-            .inputs
+            .pairs
             .iter()
-            .map(|i| {
-                let (x_cells, y_cells) = self.decompose_g1(i.0);
+            .map(|pair| {
+                let (x_cells, y_cells) = self.decompose_g1(pair.g1_point);
                 let decomposed = G1Decomposed {
-                    ec_point: pairing_chip.load_private_g1(ctx, Value::known(i.0)),
+                    ec_point: pairing_chip.load_private_g1(ctx, Value::known(pair.g1_point)),
                     x_cells: x_cells.clone(),
                     y_cells: y_cells.clone(),
                 };
@@ -545,12 +545,13 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
             })
             .collect_vec();
         let g2s = op
-            .inputs
+            .pairs
             .iter()
-            .map(|i| {
-                let [x_c0_cells, x_c1_cells, y_c0_cells, y_c1_cells] = self.decompose_g2(i.1);
+            .map(|pair| {
+                let [x_c0_cells, x_c1_cells, y_c0_cells, y_c1_cells] =
+                    self.decompose_g2(pair.g2_point);
                 let decomposed = G2Decomposed {
-                    ec_point: pairing_chip.load_private_g2(ctx, Value::known(i.1)),
+                    ec_point: pairing_chip.load_private_g2(ctx, Value::known(pair.g2_point)),
                     x_c0_cells: x_c0_cells.clone(),
                     x_c1_cells: x_c1_cells.clone(),
                     y_c0_cells: y_c0_cells.clone(),

--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -584,14 +584,21 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
             .collect_vec();
 
         // RLC over the entire input bytes.
-        let input_cells = std::iter::empty()
-            .chain(g1s.iter().map(|g1| g1.decomposed.x_cells.clone()))
-            .chain(g1s.iter().map(|g1| g1.decomposed.y_cells.clone()))
-            .chain(g2s.iter().map(|g2| g2.decomposed.x_c0_cells.clone()))
-            .chain(g2s.iter().map(|g2| g2.decomposed.x_c1_cells.clone()))
-            .chain(g2s.iter().map(|g2| g2.decomposed.y_c0_cells.clone()))
-            .chain(g2s.iter().map(|g2| g2.decomposed.y_c1_cells.clone()))
-            .flatten()
+        let input_cells = g1s
+            .iter()
+            .zip_eq(g2s.iter())
+            .flat_map(|(g1, g2)| {
+                std::iter::empty()
+                    .chain(g1.decomposed.x_cells.iter().rev())
+                    .chain(g1.decomposed.y_cells.iter().rev())
+                    .chain(g2.decomposed.x_c0_cells.iter().rev())
+                    .chain(g2.decomposed.x_c1_cells.iter().rev())
+                    .chain(g2.decomposed.y_c0_cells.iter().rev())
+                    .chain(g2.decomposed.y_c1_cells.iter().rev())
+                    .cloned()
+                    .rev()
+                    .collect::<Vec<QuantumCell<F>>>()
+            })
             .collect::<Vec<QuantumCell<F>>>();
         let input_rlc = pairing_chip.fp_chip.range.gate.inner_product(
             ctx,

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -3,7 +3,9 @@ use std::{
     ops::{Add, Mul, Neg},
 };
 
-use bus_mapping::circuit_input_builder::{EcAddOp, EcMulOp, EcPairingOp, PrecompileEcParams};
+use bus_mapping::circuit_input_builder::{
+    EcAddOp, EcMulOp, EcPairingOp, EcPairingPair, PrecompileEcParams,
+};
 use eth_types::Field;
 use halo2_proofs::{
     arithmetic::Field as ArithmeticField,
@@ -78,13 +80,13 @@ impl GenRand for EcPairingOp {
         let point_c = G1Affine::from(G1Affine::generator() * alpha * beta);
         let point_d = G2Affine::generator();
         Self {
-            inputs: [
-                (point_p_negated, point_q, true),
-                (point_s, point_t, true),
-                (point_a_negated, point_b, true),
-                (point_c, point_d, true),
+            pairs: [
+                EcPairingPair::new(point_p_negated, point_q),
+                EcPairingPair::new(point_s, point_t),
+                EcPairingPair::new(point_a_negated, point_b),
+                EcPairingPair::new(point_c, point_d),
             ],
-            output: 1u64.into(),
+            output: eth_types::U256::one(),
         }
     }
 }

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -79,10 +79,10 @@ impl GenRand for EcPairingOp {
         let point_d = G2Affine::generator();
         Self {
             inputs: [
-                (point_p_negated, point_q),
-                (point_s, point_t),
-                (point_a_negated, point_b),
-                (point_c, point_d),
+                (point_p_negated, point_q, true),
+                (point_s, point_t, true),
+                (point_a_negated, point_b, true),
+                (point_c, point_d, true),
             ],
             output: 1u64.into(),
         }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -203,7 +203,7 @@ use opcode_not::NotGadget;
 use origin::OriginGadget;
 use pc::PcGadget;
 use pop::PopGadget;
-use precompiles::{EcAddGadget, EcMulGadget, EcrecoverGadget, IdentityGadget};
+use precompiles::{EcAddGadget, EcMulGadget, EcPairingGadget, EcrecoverGadget, IdentityGadget};
 use push::PushGadget;
 use return_revert::ReturnRevertGadget;
 use returndatacopy::ReturnDataCopyGadget;
@@ -355,8 +355,7 @@ pub(crate) struct ExecutionConfig<F> {
     precompile_modexp_gadget: Box<BasePrecompileGadget<F, { ExecutionState::PrecompileBigModExp }>>,
     precompile_bn128add_gadget: Box<EcAddGadget<F>>,
     precompile_bn128mul_gadget: Box<EcMulGadget<F>>,
-    precompile_bn128pairing_gadget:
-        Box<BasePrecompileGadget<F, { ExecutionState::PrecompileBn256Pairing }>>,
+    precompile_bn128pairing_gadget: Box<EcPairingGadget<F>>,
     precompile_blake2f_gadget: Box<BasePrecompileGadget<F, { ExecutionState::PrecompileBlake2f }>>,
 }
 

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -130,6 +130,57 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
             + ecc_circuit_input_rlcs[2].expr() * rand_pow_192.expr()
             + ecc_circuit_input_rlcs[3].expr();
 
+        // Equality checks for EVM input bytes to ecPairing call.
+        cb.condition(n_pairs_cmp.value_equals(0usize), |cb| {
+            cb.require_zero("ecPairing: evm_input_rlc == 0", evm_input_rlc.expr());
+        });
+        cb.condition(n_pairs_cmp.value_equals(1usize), |cb| {
+            cb.require_equal(
+                "ecPairing: evm_input_rlc for 1 pair",
+                evm_input_rlc.expr(),
+                evm_input_g1_rlc[0].expr() * rand_pow_128.expr() + evm_input_g2_rlc[0].expr(),
+            );
+        });
+        cb.condition(n_pairs_cmp.value_equals(2usize), |cb| {
+            cb.require_equal(
+                "ecPairing: evm_input_rlc for 2 pairs",
+                evm_input_rlc.expr(),
+                (evm_input_g1_rlc[0].expr() * rand_pow_128.expr() + evm_input_g2_rlc[0].expr())
+                    * rand_pow_192.expr()
+                    + evm_input_g1_rlc[1].expr() * rand_pow_128.expr()
+                    + evm_input_g2_rlc[1].expr(),
+            );
+        });
+        cb.condition(n_pairs_cmp.value_equals(3usize), |cb| {
+            cb.require_equal(
+                "ecPairing: evm_input_rlc for 3 pairs",
+                evm_input_rlc.expr(),
+                (evm_input_g1_rlc[0].expr() * rand_pow_128.expr() + evm_input_g2_rlc[0].expr())
+                    * rand_pow_384.expr()
+                    + (evm_input_g1_rlc[1].expr() * rand_pow_128.expr()
+                        + evm_input_g2_rlc[1].expr())
+                        * rand_pow_192.expr()
+                    + evm_input_g1_rlc[2].expr() * rand_pow_128.expr()
+                    + evm_input_g2_rlc[2].expr(),
+            );
+        });
+        cb.condition(n_pairs_cmp.value_equals(4usize), |cb| {
+            cb.require_equal(
+                "ecPairing: evm_input_rlc for 4 pairs",
+                evm_input_rlc.expr(),
+                (evm_input_g1_rlc[0].expr() * rand_pow_128.expr() + evm_input_g2_rlc[0].expr())
+                    * rand_pow_576.expr()
+                    + (evm_input_g1_rlc[1].expr() * rand_pow_128.expr()
+                        + evm_input_g2_rlc[1].expr())
+                        * rand_pow_384.expr()
+                    + (evm_input_g1_rlc[2].expr() * rand_pow_128.expr()
+                        + evm_input_g2_rlc[2].expr())
+                        * rand_pow_192.expr()
+                    + evm_input_g1_rlc[3].expr() * rand_pow_128.expr()
+                    + evm_input_g2_rlc[3].expr(),
+            );
+        });
+
         // validate successful call to the precompile ecPairing.
         cb.condition(is_success.expr(), |cb| {
             // Covers the following cases:
@@ -146,9 +197,6 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                 output.expr(),
                 0.expr(),
             );
-            cb.condition(n_pairs_cmp.value_equals(0usize), |cb| {
-                cb.require_zero("ecPairing: evm_input_rlc == 0", evm_input_rlc.expr());
-            });
             cb.require_equal(
                 "ecPairing: n_pairs * N_BYTES_PER_PAIR == call_data_length",
                 n_pairs.expr() * N_BYTES_PER_PAIR.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -1,0 +1,397 @@
+use bus_mapping::{
+    circuit_input_builder::{EcPairingOp, N_BYTES_PER_PAIR, N_PAIRING_PER_OP},
+    precompile::{PrecompileAuxData, PrecompileCalls},
+};
+use eth_types::{Field, ToScalar};
+use gadgets::util::{not, select, Expr};
+use halo2_proofs::{circuit::Value, plonk::Error};
+
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        util::{
+            common_gadget::RestoreContextGadget,
+            constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+            math_gadget::BinaryNumberGadget,
+            rlc, CachedRegion, Cell,
+        },
+    },
+    table::CallContextFieldTag,
+    witness::{Block, Call, ExecStep, Transaction},
+};
+
+/// Note: input_len ∈ { 0, 192, 384, 576, 768 } if valid.
+///
+/// Note: input bytes are padded to 768 bytes within our zkEVM implementation to standardise a
+/// pairing operation, such that each pairing op has 4 pairs: [(G1, G2); 4].
+#[derive(Clone, Debug)]
+pub struct EcPairingGadget<F> {
+    // Random linear combination of input bytes to the precompile ecPairing call.
+    evm_input_rlc: Cell<F>,
+    // Boolean output from the ecPairing call, denoting whether or not the pairing check was
+    // successful.
+    output: Cell<F>,
+    /// Random linear combination of input bytes from the EcPairingOp operation.
+    input_rlc: Cell<F>,
+    /// Number of pairs provided through EVM input. Since a maximum of 4 pairs can be supplied from
+    /// EVM, we need 3 binary bits for a max value of [1, 0, 0].
+    n_pairs: Cell<F>,
+    n_pairs_cmp: BinaryNumberGadget<F, 3>,
+    /// Power of keccak randomness: r ^ k, where k == 768 - call_data_length.
+    pow_of_rand: Cell<F>,
+
+    is_success: Cell<F>,
+    callee_address: Cell<F>,
+    caller_id: Cell<F>,
+    call_data_offset: Cell<F>,
+    call_data_length: Cell<F>,
+    return_data_offset: Cell<F>,
+    return_data_length: Cell<F>,
+    restore_context: RestoreContextGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
+    const NAME: &'static str = "EC_PAIRING";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::PrecompileBn256Pairing;
+
+    fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
+        let (evm_input_rlc, output, input_rlc, n_pairs) = (
+            cb.query_cell_phase2(),
+            cb.query_bool(),
+            cb.query_cell_phase2(),
+            cb.query_cell(),
+        );
+        let n_pairs_cmp = BinaryNumberGadget::construct(cb, n_pairs.expr());
+        let pow_of_rand = cb.query_cell_phase2();
+
+        let [is_success, callee_address, caller_id, call_data_offset, call_data_length, return_data_offset, return_data_length] =
+            [
+                CallContextFieldTag::IsSuccess,
+                CallContextFieldTag::CalleeAddress,
+                CallContextFieldTag::CallerId,
+                CallContextFieldTag::CallDataOffset,
+                CallContextFieldTag::CallDataLength,
+                CallContextFieldTag::ReturnDataOffset,
+                CallContextFieldTag::ReturnDataLength,
+            ]
+            .map(|tag| cb.call_context(None, tag));
+
+        cb.precompile_info_lookup(
+            cb.execution_state().as_u64().expr(),
+            callee_address.expr(),
+            cb.execution_state().precompile_base_gas_cost().expr(),
+        );
+
+        // validate successful call to the precompile ecPairing.
+        cb.condition(is_success.expr(), |cb| {
+            // Covers the following cases:
+            // 1. successful pairing check (where input_rlc == 0).
+            // 2. successful pairing check (where input_rlc != 0).
+            // 3. unsuccessful pairing check.
+            cb.ecc_table_lookup(
+                u64::from(PrecompileCalls::Bn128Pairing).expr(),
+                0.expr(),
+                0.expr(),
+                0.expr(),
+                0.expr(),
+                input_rlc.expr(),
+                output.expr(),
+                0.expr(),
+            );
+
+            let rlc_pad4 = rlc::expr(
+                &EcPairingOp::padded_pairs_exprs::<F, 4>(),
+                cb.challenges().keccak_input(),
+            );
+            let rlc_pad3 = rlc::expr(
+                &EcPairingOp::padded_pairs_exprs::<F, 3>(),
+                cb.challenges().keccak_input(),
+            );
+            let rlc_pad2 = rlc::expr(
+                &EcPairingOp::padded_pairs_exprs::<F, 2>(),
+                cb.challenges().keccak_input(),
+            );
+            let rlc_pad1 = rlc::expr(
+                &EcPairingOp::padded_pairs_exprs::<F, 1>(),
+                cb.challenges().keccak_input(),
+            );
+            let rlc_pad0 = 0.expr();
+            let exponent = select::expr(
+                n_pairs_cmp.value_equals(0usize),
+                768.expr(),
+                select::expr(
+                    n_pairs_cmp.value_equals(1usize),
+                    576.expr(),
+                    select::expr(
+                        n_pairs_cmp.value_equals(2usize),
+                        384.expr(),
+                        select::expr(n_pairs_cmp.value_equals(3usize), 192.expr(), 0.expr()),
+                    ),
+                ),
+            );
+            let padding = select::expr(
+                n_pairs_cmp.value_equals(0usize),
+                rlc_pad4,
+                select::expr(
+                    n_pairs_cmp.value_equals(1usize),
+                    rlc_pad3,
+                    select::expr(
+                        n_pairs_cmp.value_equals(2usize),
+                        rlc_pad2,
+                        select::expr(n_pairs_cmp.value_equals(3usize), rlc_pad1, rlc_pad0),
+                    ),
+                ),
+            );
+            // r ^ exp == pow_of_rand, where exp == 768 - call_data_length.
+            // Note: check only if exp < 768.
+            cb.condition(not::expr(n_pairs_cmp.value_equals(0usize)), |cb| {
+                cb.pow_of_rand_lookup(exponent, pow_of_rand.expr());
+            });
+            cb.condition(n_pairs_cmp.value_equals(0usize), |cb| {
+                cb.require_zero("ecPairing: evm_input_rlc == 0", evm_input_rlc.expr());
+            });
+
+            cb.require_equal(
+                "ecPairing: evm_input_rlc * pow_of_rand + padding == input_rlc",
+                evm_input_rlc.expr() * pow_of_rand.expr() + padding,
+                input_rlc.expr(),
+            );
+            cb.require_equal(
+                "ecPairing: n_pairs * N_BYTES_PER_PAIR == call_data_length",
+                n_pairs.expr() * N_BYTES_PER_PAIR.expr(),
+                call_data_length.expr(),
+            );
+
+            cb.require_in_set(
+                "ecPairing: input_len ∈ { 0, 192, 384, 576, 768 }",
+                call_data_length.expr(),
+                vec![0.expr(), 192.expr(), 384.expr(), 576.expr(), 768.expr()],
+            );
+        });
+
+        let restore_context = RestoreContextGadget::construct(
+            cb,
+            is_success.expr(),
+            0.expr(),
+            0.expr(),
+            0.expr(),
+            0.expr(),
+            0.expr(),
+        );
+
+        Self {
+            evm_input_rlc,
+            output,
+            input_rlc,
+            n_pairs,
+            n_pairs_cmp,
+            pow_of_rand,
+
+            is_success,
+            callee_address,
+            caller_id,
+            call_data_offset,
+            call_data_length,
+            return_data_offset,
+            return_data_length,
+            restore_context,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _transaction: &Transaction,
+        call: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        if let Some(PrecompileAuxData::EcPairing(aux_data)) = &step.aux_data {
+            let keccak_rand = region.challenges().keccak_input();
+            self.evm_input_rlc.assign(
+                region,
+                offset,
+                keccak_rand.map(|r| rlc::value(aux_data.0.to_evm_bytes_be().iter().rev(), r)),
+            )?;
+            self.output.assign(
+                region,
+                offset,
+                Value::known(
+                    aux_data
+                        .0
+                        .output
+                        .to_scalar()
+                        .expect("ecPairing: output in {0, 1}"),
+                ),
+            )?;
+            self.input_rlc.assign(
+                region,
+                offset,
+                keccak_rand.map(|r| rlc::value(aux_data.0.to_bytes_be().iter().rev(), r)),
+            )?;
+            let n_pairs = aux_data.0.n_evm_pairs();
+            self.n_pairs
+                .assign(region, offset, Value::known(F::from(n_pairs as u64)))?;
+            self.n_pairs_cmp.assign(region, offset, n_pairs)?;
+            let n_padded_bytes = (N_PAIRING_PER_OP - n_pairs) * N_BYTES_PER_PAIR;
+            let pow_of_rand = if n_padded_bytes > 0 {
+                keccak_rand.map(|r| r.pow(&[n_padded_bytes as u64, 0, 0, 0]))
+            } else {
+                Value::known(F::one())
+            };
+            self.pow_of_rand.assign(region, offset, pow_of_rand)?;
+        }
+
+        self.is_success.assign(
+            region,
+            offset,
+            Value::known(F::from(u64::from(call.is_success))),
+        )?;
+        self.callee_address.assign(
+            region,
+            offset,
+            Value::known(call.code_address.unwrap().to_scalar().unwrap()),
+        )?;
+        self.caller_id
+            .assign(region, offset, Value::known(F::from(call.caller_id as u64)))?;
+        self.call_data_offset.assign(
+            region,
+            offset,
+            Value::known(F::from(call.call_data_offset)),
+        )?;
+        self.call_data_length.assign(
+            region,
+            offset,
+            Value::known(F::from(call.call_data_length)),
+        )?;
+        self.return_data_offset.assign(
+            region,
+            offset,
+            Value::known(F::from(call.return_data_offset)),
+        )?;
+        self.return_data_length.assign(
+            region,
+            offset,
+            Value::known(F::from(call.return_data_length)),
+        )?;
+
+        self.restore_context
+            .assign(region, offset, block, call, step, 7)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bus_mapping::{
+        evm::{OpcodeId, PrecompileCallArgs},
+        precompile::PrecompileCalls,
+    };
+    use eth_types::{bytecode, word, ToWord};
+    use itertools::Itertools;
+    use mock::TestContext;
+    use rayon::iter::{ParallelBridge, ParallelIterator};
+
+    use crate::test_util::CircuitTestBuilder;
+
+    lazy_static::lazy_static! {
+        static ref TEST_VECTOR: Vec<PrecompileCallArgs> = {
+            vec![
+                PrecompileCallArgs {
+                    name: "ecPairing (valid): empty calldata",
+                    setup_code: bytecode! {},
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x00.into(),
+                    ret_offset: 0x00.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    ..Default::default()
+                },
+                PrecompileCallArgs {
+                    name: "ecPairing (pairing true): 2 pairs",
+                    setup_code: bytecode! {
+                        // G1_x1
+                        PUSH32(word!("0x2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da"))
+                        PUSH1(0x00)
+                        MSTORE
+                        // G1_y1
+                        PUSH32(word!("0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6"))
+                        PUSH1(0x20)
+                        MSTORE
+                        // G2_x11
+                        PUSH32(word!("0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc"))
+                        PUSH1(0x40)
+                        MSTORE
+                        // G2_x12
+                        PUSH32(word!("0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9"))
+                        PUSH1(0x60)
+                        MSTORE
+                        // G2_y11
+                        PUSH32(word!("0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90"))
+                        PUSH1(0x80)
+                        MSTORE
+                        // G2_y12
+                        PUSH32(word!("0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e"))
+                        PUSH1(0xA0)
+                        MSTORE
+                        // G1_x2
+                        PUSH32(word!("0x0000000000000000000000000000000000000000000000000000000000000001"))
+                        PUSH1(0xC0)
+                        MSTORE
+                        // G1_y2
+                        PUSH32(word!("0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45"))
+                        PUSH1(0xE0)
+                        MSTORE
+                        // G2_x21
+                        PUSH32(word!("0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4"))
+                        PUSH2(0x100)
+                        MSTORE
+                        // G2_x22
+                        PUSH32(word!("0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7"))
+                        PUSH2(0x120)
+                        MSTORE
+                        // G2_y21
+                        PUSH32(word!("0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2"))
+                        PUSH2(0x140)
+                        MSTORE
+                        // G2_y22
+                        PUSH32(word!("0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc"))
+                        PUSH2(0x160)
+                        MSTORE
+                    },
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x180.into(),
+                    ret_offset: 0x180.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    ..Default::default()
+                },
+            ]
+        };
+    }
+
+    #[test]
+    fn precompile_ec_pairing_test() {
+        let call_kinds = vec![
+            OpcodeId::CALL,
+            OpcodeId::STATICCALL,
+            OpcodeId::DELEGATECALL,
+            OpcodeId::CALLCODE,
+        ];
+
+        TEST_VECTOR
+            .iter()
+            .cartesian_product(&call_kinds)
+            .par_bridge()
+            .for_each(|(test_vector, &call_kind)| {
+                let bytecode = test_vector.with_call_op(call_kind);
+
+                CircuitTestBuilder::new_from_test_ctx(
+                    TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
+                )
+                .run();
+            })
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -1,10 +1,13 @@
 use bus_mapping::{
-    circuit_input_builder::{EcPairingOp, N_BYTES_PER_PAIR, N_PAIRING_PER_OP},
+    circuit_input_builder::{EcPairingPair, N_BYTES_PER_PAIR, N_PAIRING_PER_OP},
     precompile::{PrecompileAuxData, PrecompileCalls},
 };
 use eth_types::{Field, ToScalar};
-use gadgets::util::{not, select, Expr};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use gadgets::util::{or, select, Expr};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 use crate::{
     evm_circuit::{
@@ -13,7 +16,7 @@ use crate::{
         util::{
             common_gadget::RestoreContextGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            math_gadget::BinaryNumberGadget,
+            math_gadget::{BinaryNumberGadget, IsZeroGadget},
             rlc, CachedRegion, Cell,
         },
     },
@@ -32,14 +35,17 @@ pub struct EcPairingGadget<F> {
     // Boolean output from the ecPairing call, denoting whether or not the pairing check was
     // successful.
     output: Cell<F>,
-    /// Random linear combination of input bytes from the EcPairingOp operation.
-    input_rlc: Cell<F>,
     /// Number of pairs provided through EVM input. Since a maximum of 4 pairs can be supplied from
     /// EVM, we need 3 binary bits for a max value of [1, 0, 0].
     n_pairs: Cell<F>,
     n_pairs_cmp: BinaryNumberGadget<F, 3>,
-    /// Power of keccak randomness: r ^ k, where k == 768 - call_data_length.
-    pow_of_rand: Cell<F>,
+    /// keccak_rand ^ 64.
+    rand_pow_64: Cell<F>,
+
+    evm_input_g1_rlc: [Cell<F>; N_PAIRING_PER_OP],
+    evm_input_g2_rlc: [Cell<F>; N_PAIRING_PER_OP],
+    is_g1_identity: [IsZeroGadget<F>; N_PAIRING_PER_OP],
+    is_g2_identity: [IsZeroGadget<F>; N_PAIRING_PER_OP],
 
     is_success: Cell<F>,
     callee_address: Cell<F>,
@@ -57,14 +63,18 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::PrecompileBn256Pairing;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let (evm_input_rlc, output, input_rlc, n_pairs) = (
-            cb.query_cell_phase2(),
-            cb.query_bool(),
-            cb.query_cell_phase2(),
-            cb.query_cell(),
-        );
+        let (evm_input_rlc, output, n_pairs) =
+            (cb.query_cell_phase2(), cb.query_bool(), cb.query_cell());
         let n_pairs_cmp = BinaryNumberGadget::construct(cb, n_pairs.expr());
-        let pow_of_rand = cb.query_cell_phase2();
+        let rand_pow_64 = cb.query_cell_phase2();
+        let (rand_pow_128, rand_pow_192, rand_pow_384, rand_pow_576) = {
+            let rand_pow_128 = rand_pow_64.expr() * rand_pow_64.expr();
+            let rand_pow_192 = rand_pow_128.expr() * rand_pow_64.expr();
+            let rand_pow_384 = rand_pow_192.expr() * rand_pow_192.expr();
+            let rand_pow_576 = rand_pow_384.expr() * rand_pow_192.expr();
+            (rand_pow_128, rand_pow_192, rand_pow_384, rand_pow_576)
+        };
+        cb.pow_of_rand_lookup(64.expr(), rand_pow_64.expr());
 
         let [is_success, callee_address, caller_id, call_data_offset, call_data_length, return_data_offset, return_data_length] =
             [
@@ -84,6 +94,42 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
             cb.execution_state().precompile_base_gas_cost().expr(),
         );
 
+        let evm_input_g1_rlc = array_init::array_init(|_| cb.query_cell_phase2());
+        let evm_input_g2_rlc = array_init::array_init(|_| cb.query_cell_phase2());
+        let is_g1_identity = evm_input_g1_rlc
+            .clone()
+            .map(|g1_rlc| IsZeroGadget::construct(cb, "ecPairing: is G1 zero", g1_rlc.expr()));
+        let is_g2_identity = evm_input_g2_rlc
+            .clone()
+            .map(|g2_rlc| IsZeroGadget::construct(cb, "ecPairing: is G2 zero", g2_rlc.expr()));
+
+        let padding_g1_g2_rlc = rlc::expr(
+            &EcPairingPair::ecc_padding()
+                .to_bytes_be()
+                .iter()
+                .rev()
+                .map(|i| i.expr())
+                .collect::<Vec<Expression<F>>>(),
+            cb.challenges().keccak_input(),
+        );
+        let ecc_circuit_input_rlcs = evm_input_g1_rlc
+            .clone()
+            .zip(is_g1_identity.clone())
+            .zip(evm_input_g2_rlc.clone().zip(is_g2_identity.clone()))
+            .map(|((g1_rlc, is_g1_identity), (g2_rlc, is_g2_identity))| {
+                select::expr(
+                    or::expr([is_g1_identity.expr(), is_g2_identity.expr()]),
+                    // rlc([G1::identity, G2::generator])
+                    padding_g1_g2_rlc.expr(),
+                    // rlc([g1, g2])
+                    g1_rlc.expr() * rand_pow_128.expr() + g2_rlc.expr(),
+                )
+            });
+        let ecc_circuit_input_rlc = ecc_circuit_input_rlcs[0].expr() * rand_pow_576.expr()
+            + ecc_circuit_input_rlcs[1].expr() * rand_pow_384.expr()
+            + ecc_circuit_input_rlcs[2].expr() * rand_pow_192.expr()
+            + ecc_circuit_input_rlcs[3].expr();
+
         // validate successful call to the precompile ecPairing.
         cb.condition(is_success.expr(), |cb| {
             // Covers the following cases:
@@ -96,74 +142,18 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                 0.expr(),
                 0.expr(),
                 0.expr(),
-                input_rlc.expr(),
+                ecc_circuit_input_rlc.expr(),
                 output.expr(),
                 0.expr(),
             );
-
-            let rlc_pad4 = rlc::expr(
-                &EcPairingOp::padded_pairs_exprs::<F, 4>(),
-                cb.challenges().keccak_input(),
-            );
-            let rlc_pad3 = rlc::expr(
-                &EcPairingOp::padded_pairs_exprs::<F, 3>(),
-                cb.challenges().keccak_input(),
-            );
-            let rlc_pad2 = rlc::expr(
-                &EcPairingOp::padded_pairs_exprs::<F, 2>(),
-                cb.challenges().keccak_input(),
-            );
-            let rlc_pad1 = rlc::expr(
-                &EcPairingOp::padded_pairs_exprs::<F, 1>(),
-                cb.challenges().keccak_input(),
-            );
-            let rlc_pad0 = 0.expr();
-            let exponent = select::expr(
-                n_pairs_cmp.value_equals(0usize),
-                768.expr(),
-                select::expr(
-                    n_pairs_cmp.value_equals(1usize),
-                    576.expr(),
-                    select::expr(
-                        n_pairs_cmp.value_equals(2usize),
-                        384.expr(),
-                        select::expr(n_pairs_cmp.value_equals(3usize), 192.expr(), 0.expr()),
-                    ),
-                ),
-            );
-            let padding = select::expr(
-                n_pairs_cmp.value_equals(0usize),
-                rlc_pad4,
-                select::expr(
-                    n_pairs_cmp.value_equals(1usize),
-                    rlc_pad3,
-                    select::expr(
-                        n_pairs_cmp.value_equals(2usize),
-                        rlc_pad2,
-                        select::expr(n_pairs_cmp.value_equals(3usize), rlc_pad1, rlc_pad0),
-                    ),
-                ),
-            );
-            // r ^ exp == pow_of_rand, where exp == 768 - call_data_length.
-            // Note: check only if exp < 768.
-            cb.condition(not::expr(n_pairs_cmp.value_equals(0usize)), |cb| {
-                cb.pow_of_rand_lookup(exponent, pow_of_rand.expr());
-            });
             cb.condition(n_pairs_cmp.value_equals(0usize), |cb| {
                 cb.require_zero("ecPairing: evm_input_rlc == 0", evm_input_rlc.expr());
             });
-
-            cb.require_equal(
-                "ecPairing: evm_input_rlc * pow_of_rand + padding == input_rlc",
-                evm_input_rlc.expr() * pow_of_rand.expr() + padding,
-                input_rlc.expr(),
-            );
             cb.require_equal(
                 "ecPairing: n_pairs * N_BYTES_PER_PAIR == call_data_length",
                 n_pairs.expr() * N_BYTES_PER_PAIR.expr(),
                 call_data_length.expr(),
             );
-
             cb.require_in_set(
                 "ecPairing: input_len ∈ { 0, 192, 384, 576, 768 }",
                 call_data_length.expr(),
@@ -184,10 +174,14 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
         Self {
             evm_input_rlc,
             output,
-            input_rlc,
             n_pairs,
             n_pairs_cmp,
-            pow_of_rand,
+            rand_pow_64,
+
+            evm_input_g1_rlc,
+            evm_input_g2_rlc,
+            is_g1_identity,
+            is_g2_identity,
 
             is_success,
             callee_address,
@@ -210,12 +204,26 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         if let Some(PrecompileAuxData::EcPairing(aux_data)) = &step.aux_data {
+            let n_pairs = (call.call_data_length as usize) / N_BYTES_PER_PAIR;
             let keccak_rand = region.challenges().keccak_input();
+
+            // Consider only call_data_length bytes for EVM input.
             self.evm_input_rlc.assign(
                 region,
                 offset,
-                keccak_rand.map(|r| rlc::value(aux_data.0.to_evm_bytes_be().iter().rev(), r)),
+                keccak_rand.map(|r| {
+                    rlc::value(
+                        aux_data
+                            .0
+                            .to_bytes_be()
+                            .iter()
+                            .take(call.call_data_length as usize)
+                            .rev(),
+                        r,
+                    )
+                }),
             )?;
+            // Pairing check output from ecPairing call.
             self.output.assign(
                 region,
                 offset,
@@ -227,22 +235,24 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                         .expect("ecPairing: output in {0, 1}"),
                 ),
             )?;
-            self.input_rlc.assign(
-                region,
-                offset,
-                keccak_rand.map(|r| rlc::value(aux_data.0.to_bytes_be().iter().rev(), r)),
-            )?;
-            let n_pairs = aux_data.0.n_evm_pairs();
+            // Number of pairs provided in the EVM call.
             self.n_pairs
                 .assign(region, offset, Value::known(F::from(n_pairs as u64)))?;
             self.n_pairs_cmp.assign(region, offset, n_pairs)?;
-            let n_padded_bytes = (N_PAIRING_PER_OP - n_pairs) * N_BYTES_PER_PAIR;
-            let pow_of_rand = if n_padded_bytes > 0 {
-                keccak_rand.map(|r| r.pow(&[n_padded_bytes as u64, 0, 0, 0]))
-            } else {
-                Value::known(F::one())
-            };
-            self.pow_of_rand.assign(region, offset, pow_of_rand)?;
+            // keccak_rand ^ 64.
+            self.rand_pow_64
+                .assign(region, offset, keccak_rand.map(|r| r.pow(&[64, 0, 0, 0])))?;
+            // G1, G2 points from EVM.
+            for i in 0..N_PAIRING_PER_OP {
+                let g1_bytes = aux_data.0.pairs[i].g1_bytes_be();
+                let g2_bytes = aux_data.0.pairs[i].g2_bytes_be();
+                let g1_rlc = keccak_rand.map(|r| rlc::value(g1_bytes.iter().rev(), r));
+                let g2_rlc = keccak_rand.map(|r| rlc::value(g2_bytes.iter().rev(), r));
+                self.evm_input_g1_rlc[i].assign(region, offset, g1_rlc)?;
+                self.is_g1_identity[i].assign_value(region, offset, g1_rlc)?;
+                self.evm_input_g2_rlc[i].assign(region, offset, g2_rlc)?;
+                self.is_g2_identity[i].assign_value(region, offset, g2_rlc)?;
+            }
         }
 
         self.is_success.assign(
@@ -289,7 +299,8 @@ mod test {
         evm::{OpcodeId, PrecompileCallArgs},
         precompile::PrecompileCalls,
     };
-    use eth_types::{bytecode, word, ToWord};
+    use eth_types::{bytecode, word, ToWord, Word};
+    use halo2_proofs::halo2curves::bn256::{G1Affine, G2Affine};
     use itertools::Itertools;
     use mock::TestContext;
     use rayon::iter::{ParallelBridge, ParallelIterator};
@@ -298,6 +309,7 @@ mod test {
 
     lazy_static::lazy_static! {
         static ref TEST_VECTOR: Vec<PrecompileCallArgs> = {
+            let mut rng = rand::thread_rng();
             vec![
                 PrecompileCallArgs {
                     name: "ecPairing (valid): empty calldata",
@@ -305,6 +317,16 @@ mod test {
                     call_data_offset: 0x00.into(),
                     call_data_length: 0x00.into(),
                     ret_offset: 0x00.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    ..Default::default()
+                },
+                PrecompileCallArgs {
+                    name: "ecPairing (valid): zero bytes",
+                    setup_code: bytecode! {},
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0xC0.into(),
+                    ret_offset: 0xC0.into(),
                     ret_size: 0x20.into(),
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()
@@ -364,6 +386,168 @@ mod test {
                     call_data_offset: 0x00.into(),
                     call_data_length: 0x180.into(),
                     ret_offset: 0x180.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    ..Default::default()
+                },
+                PrecompileCallArgs {
+                    name: "ecPairing (pairing true): 4 pairs with random G1s",
+                    setup_code: {
+                        let mut setup_code = bytecode! {
+                            // G1_x1
+                            PUSH32(word!("0x2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da"))
+                            PUSH1(0x00)
+                            MSTORE
+                            // G1_y1
+                            PUSH32(word!("0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6"))
+                            PUSH1(0x20)
+                            MSTORE
+                            // G2_x11
+                            PUSH32(word!("0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc"))
+                            PUSH1(0x40)
+                            MSTORE
+                            // G2_x12
+                            PUSH32(word!("0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9"))
+                            PUSH1(0x60)
+                            MSTORE
+                            // G2_y11
+                            PUSH32(word!("0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90"))
+                            PUSH1(0x80)
+                            MSTORE
+                            // G2_y12
+                            PUSH32(word!("0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e"))
+                            PUSH1(0xA0)
+                            MSTORE
+                            // G1_x2
+                            PUSH32(word!("0x0000000000000000000000000000000000000000000000000000000000000001"))
+                            PUSH1(0xC0)
+                            MSTORE
+                            // G1_y2
+                            PUSH32(word!("0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45"))
+                            PUSH1(0xE0)
+                            MSTORE
+                            // G2_x21
+                            PUSH32(word!("0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4"))
+                            PUSH2(0x100)
+                            MSTORE
+                            // G2_x22
+                            PUSH32(word!("0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7"))
+                            PUSH2(0x120)
+                            MSTORE
+                            // G2_y21
+                            PUSH32(word!("0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2"))
+                            PUSH2(0x140)
+                            MSTORE
+                            // G2_y22
+                            PUSH32(word!("0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc"))
+                            PUSH2(0x160)
+                            MSTORE
+                        };
+                        let mut memory_addr = 0x180;
+                        for _ in 0..2 {
+                            // G1::random
+                            let g1 = G1Affine::random(&mut rng);
+                            setup_code.push(32, Word::from_little_endian(&g1.x.to_bytes()));
+                            setup_code.push(2, memory_addr);
+                            memory_addr += 0x20;
+                            setup_code.write_op(OpcodeId::MSTORE);
+                            setup_code.push(32, Word::from_little_endian(&g1.y.to_bytes()));
+                            setup_code.push(2, memory_addr);
+                            memory_addr += 0x20;
+                            setup_code.write_op(OpcodeId::MSTORE);
+                            // G2::identity
+                            for _ in 0..4 {
+                                setup_code.push(1, 0x00);
+                                setup_code.push(2, memory_addr);
+                                memory_addr += 0x20;
+                                setup_code.write_op(OpcodeId::MSTORE);
+                            }
+                        }
+                        setup_code
+                    },
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x300.into(),
+                    ret_offset: 0x300.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    ..Default::default()
+                },
+                PrecompileCallArgs {
+                    name: "ecPairing (pairing true): 4 pairs with random G2s",
+                    setup_code: {
+                        let mut setup_code = bytecode! {
+                            // G1_x1
+                            PUSH32(word!("0x2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da"))
+                            PUSH1(0x00)
+                            MSTORE
+                            // G1_y1
+                            PUSH32(word!("0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6"))
+                            PUSH1(0x20)
+                            MSTORE
+                            // G2_x11
+                            PUSH32(word!("0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc"))
+                            PUSH1(0x40)
+                            MSTORE
+                            // G2_x12
+                            PUSH32(word!("0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9"))
+                            PUSH1(0x60)
+                            MSTORE
+                            // G2_y11
+                            PUSH32(word!("0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90"))
+                            PUSH1(0x80)
+                            MSTORE
+                            // G2_y12
+                            PUSH32(word!("0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e"))
+                            PUSH1(0xA0)
+                            MSTORE
+                            // G1_x2
+                            PUSH32(word!("0x0000000000000000000000000000000000000000000000000000000000000001"))
+                            PUSH1(0xC0)
+                            MSTORE
+                            // G1_y2
+                            PUSH32(word!("0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45"))
+                            PUSH1(0xE0)
+                            MSTORE
+                            // G2_x21
+                            PUSH32(word!("0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4"))
+                            PUSH2(0x100)
+                            MSTORE
+                            // G2_x22
+                            PUSH32(word!("0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7"))
+                            PUSH2(0x120)
+                            MSTORE
+                            // G2_y21
+                            PUSH32(word!("0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2"))
+                            PUSH2(0x140)
+                            MSTORE
+                            // G2_y22
+                            PUSH32(word!("0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc"))
+                            PUSH2(0x160)
+                            MSTORE
+                        };
+                        let mut memory_addr = 0x180;
+                        for _ in 0..2 {
+                            // G1::identity
+                            for _ in 0..2 {
+                                setup_code.push(1, 0x00);
+                                setup_code.push(2, memory_addr);
+                                memory_addr += 0x20;
+                                setup_code.write_op(OpcodeId::MSTORE);
+                            }
+                            // G2::random
+                            let g2 = G2Affine::random(&mut rng);
+                            for fq in [g2.x.c0, g2.x.c1, g2.y.c0, g2.y.c1].iter() {
+                                setup_code.push(32, Word::from_little_endian(&fq.to_bytes()));
+                                setup_code.push(2, memory_addr);
+                                memory_addr += 0x20;
+                                setup_code.write_op(OpcodeId::MSTORE);
+                            }
+                        }
+                        setup_code
+                    },
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x300.into(),
+                    ret_offset: 0x300.into(),
                     ret_size: 0x20.into(),
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/mod.rs
@@ -24,6 +24,9 @@ pub use ecrecover::EcrecoverGadget;
 mod ec_mul;
 pub use ec_mul::EcMulGadget;
 
+mod ec_pairing;
+pub use ec_pairing::EcPairingGadget;
+
 mod identity;
 pub use identity::IdentityGadget;
 

--- a/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
@@ -215,7 +215,20 @@ impl<F: Field> PrecompileGadget<F> {
                     r_x_rlc.expr() * r_pow_32 + r_y_rlc.expr(),
                 );
             }),
-            Box::new(|_cb| { /* Bn128Pairing */ }),
+            Box::new(|cb| {
+                let (evm_input_rlc, output) = (cb.query_cell_phase2(), cb.query_bool());
+                cb.require_equal(
+                    "input bytes (RLC) equality",
+                    padding_gadget.padded_rlc(),
+                    evm_input_rlc.expr(),
+                );
+                // RLC of output bytes always equals boolean result of pairing check.
+                cb.require_equal(
+                    "output bytes (RLC) equality",
+                    output_bytes_rlc.expr(),
+                    output.expr(),
+                );
+            }),
             Box::new(|_cb| { /* Blake2F */ }),
         ];
         cb.constrain_mutually_exclusive_next_step(conditions, next_states, constraints);

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -17,7 +17,7 @@ use crate::{
 use bus_mapping::{
     circuit_input_builder::{
         CopyDataType, CopyEvent, CopyStep, EcAddOp, EcMulOp, EcPairingOp, ExpEvent,
-        PrecompileEcParams,
+        PrecompileEcParams, N_BYTES_PER_PAIR, N_PAIRING_PER_OP,
     },
     precompile::PrecompileCalls,
 };
@@ -2503,7 +2503,7 @@ impl EccTable {
                 Value::known(F::zero()),
                 Value::known(F::zero()),
                 Value::known(F::zero()),
-                keccak_rand.map(|r| rlc::value(&pairing_op.to_bytes_le(), r)),
+                keccak_rand.map(|r| rlc::value(pairing_op.to_bytes_be().iter().rev(), r)),
                 Value::known(
                     pairing_op
                         .output
@@ -2610,7 +2610,8 @@ impl PowOfRandTable {
             || "power of randomness table",
             |mut region| {
                 let pows_of_rand =
-                    std::iter::successors(Some(Value::known(F::one())), |&v| Some(v * r)).take(128);
+                    std::iter::successors(Some(Value::known(F::one())), |&v| Some(v * r))
+                        .take(N_PAIRING_PER_OP * N_BYTES_PER_PAIR);
 
                 for (idx, pow_of_rand) in pows_of_rand.enumerate() {
                     region.assign_fixed(


### PR DESCRIPTION
### Description

Implements `EcPairingGadget` where inputs to the precompiled contract call are assumed to be "valid".

### Issue Link

#596 (partially)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update