### PR TITLE
Add conversion from witness `Block` to `ChunkHash`

### DIFF
--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -30,7 +30,7 @@ pub struct BatchHash {
 impl BatchHash {
     /// Build Batch hash from an ordered list of #MAX_AGG_SNARKS of chunks.
     #[allow(dead_code)]
-    pub(crate) fn construct(chunks_with_padding: &[ChunkHash]) -> Self {
+    pub fn construct(chunks_with_padding: &[ChunkHash]) -> Self {
         assert_eq!(
             chunks_with_padding.len(),
             MAX_AGG_SNARKS,

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -21,7 +21,9 @@ mod util;
 mod tests;
 
 pub use aggregation::*;
+pub use batch::BatchHash;
 pub use chunk::ChunkHash;
 pub use compression::*;
+pub use constants::MAX_AGG_SNARKS;
 pub(crate) use constants::*;
 pub use param::*;


### PR DESCRIPTION
### Summary

1. Add conversion from Block to ChunkHash.
2. Make some structs public.