### PR TITLE
[opt] reduce the cost of min_num_rows_block in poseidon_circuit

### DIFF
--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -457,7 +457,7 @@ impl<
         let exp = ExpCircuit::min_num_rows_block(block);
         let mod_exp = ModExpCircuit::min_num_rows_block(block);
         let pi = PiCircuit::min_num_rows_block(block);
-        let poseidon = (0, 0); //PoseidonCircuit::min_num_rows_block(block);
+        let poseidon = PoseidonCircuit::min_num_rows_block(block);
         let sig = SigCircuit::min_num_rows_block(block);
         let ecc = EccCircuit::<Fr, 9>::min_num_rows_block(block);
         #[cfg(feature = "zktrie")]


### PR DESCRIPTION
This PR handle issue #647 . Instead of turn the smt trace into mpt proof and grep hash traces from it, it use informations inside smt trace to estimate the hash entries generated from mpt. For code hash, the estimation of hash entries is trivial.

Following table showed the estimation of mpt hash entries from test traces, comparing to actually calculating them:

| traces set | calculated | estimation |
| ---------- | ------------ | ----------- |
|  erc20 | 711 | 727 |
| sushi | 1054 | 1077 |
| nft | 491 | 503 |
| dao | 837 | 850 |
|uniswap | 2380 | 2426 |
|uniswap-multi| 5263 | 5304 |

The result is satisified with only small over estimation. And the cost is also limited: it only increase the test time from 17.41s to 17.49s in multi-uniswapv2 traces, and no observable divergence on test time (>0.01s) in any other test traces (with maxium test time < 4s)

