### PR TITLE
fix TOB-SCROLL-6: replace debug_assert

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -234,7 +234,7 @@ impl<F: Field> BaseConstraintBuilder<F> {
         condition: Expression<F>,
         constraint: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        debug_assert!(
+        assert!(
             self.condition.is_none(),
             "Nested condition is not supported"
         );
@@ -246,7 +246,7 @@ impl<F: Field> BaseConstraintBuilder<F> {
 
     pub(crate) fn validate_degree(&self, degree: usize, name: &'static str) {
         if self.max_degree > 0 {
-            debug_assert!(
+            assert!(
                 degree <= self.max_degree,
                 "Expression {} degree too high: {} > {}",
                 name,
@@ -1470,7 +1470,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         // We need to subtract IMPLICIT_DEGREE from MAX_DEGREE because all expressions
         // will be multiplied by state selector and q_step/q_step_first
         // selector.
-        debug_assert!(
+        assert!(
             degree <= MAX_DEGREE - IMPLICIT_DEGREE,
             "Expression {} degree too high: {} > {}",
             name,


### PR DESCRIPTION
### Description
fix TOB-SCROLL-6: replace debug_assert with assert to ensure important checking in release mode

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



This PR contains:
- replace debug_assert in three places
