### PR TITLE
Fix: lost tx_type when doing type conversion

### DIFF
--- a/bus-mapping/src/circuit_input_builder/transaction.rs
+++ b/bus-mapping/src/circuit_input_builder/transaction.rs
@@ -253,6 +253,7 @@ impl From<&Transaction> for geth_types::Transaction {
             gas_tip_cap: tx.gas_tip_cap,
             rlp_unsigned_bytes: tx.rlp_unsigned_bytes.clone(),
             rlp_bytes: tx.rlp_bytes.clone(),
+            tx_type: tx.tx_type,
             ..Default::default()
         }
     }

--- a/eth-types/src/geth_types.rs
+++ b/eth-types/src/geth_types.rs
@@ -58,10 +58,16 @@ impl TxType {
             Some(x) if x == U64::from(1) => Self::Eip2930,
             Some(x) if x == U64::from(2) => Self::Eip2930,
             Some(x) if x == U64::from(0x7e) => Self::L1Msg,
-            _ => match tx.v.as_u64() {
-                0 | 1 | 27 | 28 => Self::PreEip155,
-                _ => Self::Eip155,
-            },
+            _ => {
+                if tx.v.is_zero() && tx.r.is_zero() && tx.s.is_zero() {
+                    Self::L1Msg
+                } else {
+                    match tx.v.as_u64() {
+                        0 | 1 | 27 | 28 => Self::PreEip155,
+                        _ => Self::Eip155,
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Description

The tx_type info is lost during the type conversion between `bus_mapping::circuit_input_builder::Transaction` and `eth_types::geth_types::Transaction`. 

Moreover, when we received a `ethers_core::Transaction` whose `transaction_type` is not properly set (i.e. it's set to `None`), and if v = 0 it does not guarantee that this tx must be `PreEip155` tx. Because L1Msg also have v = 0 in this case.

Therefore we need to check if (v, r, s) = (0, 0, 0), then tx is of type `L1Msg`.

### Issue Link

This pr should fix the https://github.com/scroll-tech/scroll-prover/pull/190 issue.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
