### PR TITLE
[Fix] Set l1fee to zero for l1msg

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -478,7 +478,7 @@ impl<'a> CircuitInputBuilder {
         let mut tx = self.new_tx(eth_tx, !geth_trace.failed)?;
 
         // Sanity check for transaction L1 fee.
-        let tx_l1_fee = tx.l1_fee();
+        let tx_l1_fee = if tx.tx_type.is_l1_msg() {0} else {tx.l1_fee()};
         if tx_l1_fee != geth_trace.l1_fee {
             log::error!(
                 "Mismatch tx_l1_fee: calculated = {}, real = {}",

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -478,7 +478,11 @@ impl<'a> CircuitInputBuilder {
         let mut tx = self.new_tx(eth_tx, !geth_trace.failed)?;
 
         // Sanity check for transaction L1 fee.
-        let tx_l1_fee = if tx.tx_type.is_l1_msg() {0} else {tx.l1_fee()};
+        let tx_l1_fee = if tx.tx_type.is_l1_msg() {
+            0
+        } else {
+            tx.l1_fee()
+        };
         if tx_l1_fee != geth_trace.l1_fee {
             log::error!(
                 "Mismatch tx_l1_fee: calculated = {}, real = {}",

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -945,6 +945,13 @@ pub fn gen_end_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
 
 // Add 3 RW read operations for transaction L1 fee.
 fn gen_tx_l1_fee_ops(state: &mut CircuitInputStateRef, exec_step: &mut ExecStep) {
+
+    // for l1 message, no need to add rw op
+    if state.tx.tx_type.is_l1_msg() {
+        assert_eq!(state.tx.l1_fee(), 0, "L1 fee is 0 for L1 msg");
+        return;
+    }
+
     let tx_id = state.tx_ctx.id();
 
     let base_fee = Word::from(state.tx.l1_fee.base_fee);

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -945,7 +945,6 @@ pub fn gen_end_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
 
 // Add 3 RW read operations for transaction L1 fee.
 fn gen_tx_l1_fee_ops(state: &mut CircuitInputStateRef, exec_step: &mut ExecStep) {
-
     // for l1 message, no need to add rw op
     if state.tx.tx_type.is_l1_msg() {
         assert_eq!(state.tx.l1_fee(), 0, "L1 fee is 0 for L1 msg");

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -947,7 +947,6 @@ pub fn gen_end_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
 fn gen_tx_l1_fee_ops(state: &mut CircuitInputStateRef, exec_step: &mut ExecStep) {
     // for l1 message, no need to add rw op
     if state.tx.tx_type.is_l1_msg() {
-        assert_eq!(state.tx.l1_fee(), 0, "L1 fee is 0 for L1 msg");
         return;
     }
 

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -934,7 +934,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         self.is_coinbase_warm
             .assign(region, offset, Value::known(F::from(is_coinbase_warm)))?;
 
-        let tx_l1_fee = tx.l1_fee.tx_l1_fee(tx.tx_data_gas_cost).0;
+        let tx_l1_fee = if tx.tx_type.is_l1_msg() {0} else {tx.l1_fee.tx_l1_fee(tx.tx_data_gas_cost).0};
         let tx_l2_fee = tx.gas_price * tx.gas;
         if tx_fee != tx_l2_fee + tx_l1_fee {
             log::error!(

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 use bus_mapping::circuit_input_builder::CopyDataType;
-use eth_types::{Address, Field, ToLittleEndian, ToScalar, U256};
+use eth_types::{Address, Field, ToLittleEndian, ToScalar, U256, geth_types::TxType::L1Msg};
 use ethers_core::utils::{get_contract_address, keccak256, rlp::RlpStream};
 use gadgets::util::{expr_from_bytes, not, or, Expr};
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -42,6 +42,8 @@ use gadgets::util::select;
 #[derive(Clone, Debug)]
 pub(crate) struct BeginTxGadget<F> {
     tx_id: Cell<F>,
+    tx_type: Cell<F>,
+    tx_is_l1msg: IsEqualGadget<F>,
     tx_nonce: Cell<F>,
     tx_gas: Cell<F>,
     tx_gas_price: Word<F>,
@@ -99,7 +101,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         let tx_id = cb.query_cell();
 
-        let [tx_nonce, tx_gas, tx_caller_address, tx_callee_address, tx_is_create, tx_call_data_length, tx_call_data_gas_cost, tx_data_gas_cost] =
+        let [tx_nonce, tx_gas, tx_caller_address, tx_callee_address, tx_is_create, tx_call_data_length, tx_call_data_gas_cost, tx_data_gas_cost, tx_type] =
             [
                 TxContextFieldTag::Nonce,
                 TxContextFieldTag::Gas,
@@ -109,10 +111,19 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 TxContextFieldTag::CallDataLength,
                 TxContextFieldTag::CallDataGasCost,
                 TxContextFieldTag::TxDataGasCost,
+                TxContextFieldTag::TxType,
             ]
             .map(|field_tag| cb.tx_context(tx_id.expr(), field_tag, None));
 
-        let tx_l1_fee = TxL1FeeGadget::construct(cb, tx_id.expr(), tx_data_gas_cost.expr());
+        let tx_is_l1msg = IsEqualGadget::construct(cb, tx_type.expr(), (L1Msg as u64).expr());
+        let tx_l1_fee = cb.condition(not::expr(tx_is_l1msg.expr()), |cb|TxL1FeeGadget::construct(cb, tx_id.expr(), tx_data_gas_cost.expr()));
+        cb.condition(tx_is_l1msg.expr(), |cb|{
+            cb.require_zero(
+                "l1fee is 0 for l1msg",
+                tx_data_gas_cost.expr(),
+            );
+        });
+        let tx_l1_fee_rw_delta = select::expr(tx_is_l1msg.expr(), 0.expr(), tx_l1_fee.rw_delta());
 
         cb.call_context_lookup(
             1.expr(),
@@ -438,7 +449,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write CallContext CodeHash
                 rw_counter: Delta(
                     22.expr()
-                        + tx_l1_fee.rw_delta()
+                        + tx_l1_fee_rw_delta.expr()
                         + transfer_with_gas_fee.rw_delta()
                         + SHANGHAI_RW_DELTA.expr()
                         + PRECOMPILE_COUNT.expr(),
@@ -494,7 +505,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - a TransferWithGasFeeGadget
                 rw_counter: Delta(
                     7.expr()
-                        + tx_l1_fee.rw_delta()
+                        + tx_l1_fee_rw_delta.expr()
                         + transfer_with_gas_fee.rw_delta()
                         + SHANGHAI_RW_DELTA.expr()
                         + PRECOMPILE_COUNT.expr()
@@ -547,7 +558,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     //   - a TransferWithGasFeeGadget
                     rw_counter: Delta(
                         8.expr()
-                            + tx_l1_fee.rw_delta()
+                            + tx_l1_fee_rw_delta.expr()
                             + transfer_with_gas_fee.rw_delta()
                             + SHANGHAI_RW_DELTA.expr()
                             + PRECOMPILE_COUNT.expr(),
@@ -619,7 +630,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     //   - Write CallContext CodeHash
                     rw_counter: Delta(
                         21.expr()
-                            + tx_l1_fee.rw_delta()
+                            + tx_l1_fee_rw_delta.expr()
                             + transfer_with_gas_fee.rw_delta()
                             + SHANGHAI_RW_DELTA.expr()
                             + PRECOMPILE_COUNT.expr(),
@@ -638,6 +649,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         Self {
             tx_id,
+            tx_type,
+            tx_is_l1msg,
             tx_nonce,
             tx_gas,
             tx_gas_price,
@@ -727,6 +740,10 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
+        self.tx_type
+            .assign(region, offset, Value::known(F::from(tx.tx_type as u64)))?;
+        self.tx_is_l1msg
+            .assign(region, offset, F::from(tx.tx_type as u64), F::from(L1Msg as u64))?;
         self.tx_nonce
             .assign(region, offset, Value::known(F::from(tx.nonce)))?;
         self.tx_gas

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -938,6 +938,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             .assign(region, offset, Value::known(F::from(is_coinbase_warm)))?;
 
         let tx_l1_fee = if tx.tx_type.is_l1_msg() {
+            log::trace!("tx is l1msg and l1 fee is 0");
             0
         } else {
             tx.l1_fee.tx_l1_fee(tx.tx_data_gas_cost).0

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -177,6 +177,8 @@ pub enum TxFieldTag {
     TxHash,
     /// The block number in which this tx is included.
     BlockNumber,
+    /// TxType: Type of the transaction
+    TxType,
 }
 impl_expr!(TxFieldTag);
 

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -175,10 +175,10 @@ pub enum TxFieldTag {
     TxHashRLC,
     /// TxHash: Hash of the transaction with the signature
     TxHash,
+    /// TxType: Type of the transaction
+    TxType,    
     /// The block number in which this tx is included.
     BlockNumber,
-    /// TxType: Type of the transaction
-    TxType,
 }
 impl_expr!(TxFieldTag);
 

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -176,7 +176,7 @@ pub enum TxFieldTag {
     /// TxHash: Hash of the transaction with the signature
     TxHash,
     /// TxType: Type of the transaction
-    TxType,    
+    TxType,
     /// The block number in which this tx is included.
     BlockNumber,
 }

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -73,7 +73,7 @@ use eth_types::geth_types::{
 use gadgets::comparator::{ComparatorChip, ComparatorConfig, ComparatorInstruction};
 
 /// Number of rows of one tx occupies in the fixed part of tx table
-pub const TX_LEN: usize = 22;
+pub const TX_LEN: usize = 23;
 /// Offset of TxHash tag in the tx table
 pub const TX_HASH_OFFSET: usize = 21;
 /// Offset of ChainID tag in the tx table
@@ -272,6 +272,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         is_tx_tag!(is_sign_hash, TxSignHash);
         is_tx_tag!(is_hash, TxHash);
         is_tx_tag!(is_block_num, BlockNumber);
+        is_tx_tag!(is_tx_type, TxType);
 
         // testing if value is zero for tags
         let value_is_zero = IsZeroChip::configure(
@@ -358,6 +359,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                 (is_data(meta), Null),
                 (is_block_num(meta), Null),
                 (is_chain_id_expr(meta), Null),
+                (is_tx_type(meta), Null),
             ];
 
             cb.require_boolean(
@@ -374,6 +376,14 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                     usize::from(L1Msg).expr(),
                 ],
             );
+
+            cb.condition(is_tx_type(meta), |cb|{
+                cb.require_equal(
+                    "associated tx type to tag",
+                    meta.query_advice(tx_type, Rotation::cur()),
+                    meta.query_advice(tx_table.value, Rotation::cur()),
+                );
+            });
 
             cb.require_equal(
                 "associated rlp_tag",
@@ -1826,6 +1836,12 @@ impl<F: Field> TxCircuit<F> {
                                     })
                             }),
                         ),
+                        (
+                            TxFieldTag::TxType,
+                            None,
+                            None,
+                            Value::known(F::from(tx.tx_type as u64)),
+                        ),                        
                         (
                             BlockNumber,
                             None,

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -377,7 +377,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                 ],
             );
 
-            cb.condition(is_tx_type(meta), |cb|{
+            cb.condition(is_tx_type(meta), |cb| {
                 cb.require_equal(
                     "associated tx type to tag",
                     meta.query_advice(tx_type, Rotation::cur()),
@@ -1841,7 +1841,7 @@ impl<F: Field> TxCircuit<F> {
                             None,
                             None,
                             Value::known(F::from(tx.tx_type as u64)),
-                        ),                        
+                        ),
                         (
                             BlockNumber,
                             None,

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -301,10 +301,16 @@ impl Transaction {
             ],
             [
                 Value::known(F::from(self.id as u64)),
+                Value::known(F::from(TxContextFieldTag::TxType as u64)),
+                Value::known(F::zero()),
+                Value::known(F::from(self.tx_type as u64)),
+            ],            
+            [
+                Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::BlockNumber as u64)),
                 Value::known(F::zero()),
                 Value::known(F::from(self.block_number)),
-            ],
+            ],            
         ];
 
         ret

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -304,13 +304,13 @@ impl Transaction {
                 Value::known(F::from(TxContextFieldTag::TxType as u64)),
                 Value::known(F::zero()),
                 Value::known(F::from(self.tx_type as u64)),
-            ],            
+            ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::BlockNumber as u64)),
                 Value::known(F::zero()),
                 Value::known(F::from(self.block_number)),
-            ],            
+            ],
         ];
 
         ret


### PR DESCRIPTION
This PR hanlde #706 by set l1 fee to 0 when the tx type is 'L1Msg', i.e. (`type = 126` in raw tx)

It induce a new tx field tag `tx_type` into tx table so evm circuit can make constraints against tx type