### PR TITLE
fix: upgrade `snark-verifier` for `verify_evm_calldata`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,7 +4505,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#6eeba7783d337e0964d0d89de3d4ee8a7856fde6"
+source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#f8bdcbee60348e5c996c04f19ff30522e6b276b0"
 dependencies = [
  "bytes",
  "ethereum-types 0.14.1",
@@ -4529,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "snark-verifier-sdk"
 version = "0.0.1"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#6eeba7783d337e0964d0d89de3d4ee8a7856fde6"
+source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#f8bdcbee60348e5c996c04f19ff30522e6b276b0"
 dependencies = [
  "bincode",
  "env_logger 0.10.0",


### PR DESCRIPTION
### Description

Upgrade `snark-verifier` to make same version with scroll-prover (for [verify_evm_calldata](https://github.com/scroll-tech/snark-verifier/pull/19)).