### PR TITLE
Fix finding 11 : use length for rlc in rlp table

### DIFF
--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -2060,6 +2060,10 @@ pub struct RlpFsmRlpTable {
     pub rlp_tag: Column<Advice>,
     /// The actual value of the current tag being decoded.
     pub tag_value: Column<Advice>,
+    /// RLC of the tag's big-endian bytes
+    pub tag_bytes_rlc: Column<Advice>,
+    /// The actual length of bytes of the current tag being decoded.
+    pub tag_length: Column<Advice>,
     /// Whether or not the row emits an output value.
     pub is_output: Column<Advice>,
     /// Whether or not the current tag's value was nil.
@@ -2074,6 +2078,8 @@ impl<F: Field> LookupTable<F> for RlpFsmRlpTable {
             self.format.into(),
             self.rlp_tag.into(),
             self.tag_value.into(),
+            self.tag_bytes_rlc.into(),
+            self.tag_length.into(),
             self.is_output.into(),
             self.is_none.into(),
         ]
@@ -2086,6 +2092,8 @@ impl<F: Field> LookupTable<F> for RlpFsmRlpTable {
             String::from("format"),
             String::from("rlp_tag"),
             String::from("tag_value_acc"),
+            String::from("tag_bytes_rlc"),
+            String::from("tag_length"),
             String::from("is_output"),
             String::from("is_none"),
         ]
@@ -2101,6 +2109,8 @@ impl RlpFsmRlpTable {
             format: meta.advice_column(),
             rlp_tag: meta.advice_column(),
             tag_value: meta.advice_column_in(SecondPhase),
+            tag_bytes_rlc: meta.advice_column_in(SecondPhase),
+            tag_length: meta.advice_column(),
             is_output: meta.advice_column(),
             is_none: meta.advice_column(),
         }
@@ -2154,6 +2164,16 @@ impl RlpFsmRlpTable {
                             Value::known(F::from(usize::from(row.rlp_tag) as u64)),
                         ),
                         ("tag_value", self.tag_value.into(), row.tag_value),
+                        (
+                            "tag_bytes_rlc",
+                            self.tag_bytes_rlc.into(),
+                            row.tag_bytes_rlc,
+                        ),
+                        (
+                            "tag_length",
+                            self.tag_length.into(),
+                            Value::known(F::from(row.tag_length as u64)),
+                        ),
                         ("is_output", self.is_output.into(), Value::known(F::one())),
                         (
                             "is_none",

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -195,7 +195,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         // tag, rlp_tag, tx_type, is_none
         let tx_type = meta.advice_column();
         let rlp_tag = meta.advice_column();
-        let tx_value_rlc = meta.advice_column();
+        let tx_value_rlc = meta.advice_column_in(SecondPhase);
         let tx_value_length = meta.advice_column();
         let is_none = meta.advice_column();
         let tag_bits = BinaryNumberChip::configure(meta, q_enable, Some(tx_table.tag.into()));

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -64,6 +64,7 @@ use crate::{
     table::{BlockContextFieldTag::CumNumTxs, TxFieldTag::ChainID},
     util::rlc_be_bytes,
     witness::{
+        rlp_fsm::ByteSize,
         Format::{L1MsgHash, TxHashEip155, TxHashPreEip155, TxSignEip155, TxSignPreEip155},
         RlpTag::{GasCost, Len, Null, RLC},
         Tag::TxType as RLPTxType,
@@ -1747,7 +1748,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.nonce.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some((64 - tx.nonce.leading_zeros() + 7) / 8),
+                            Some(tx.nonce.byte_size()),
                             Value::known(F::from(tx.nonce)),
                         ),
                         (
@@ -1758,7 +1759,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.gas.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some((64 - tx.gas.leading_zeros() + 7) / 8),
+                            Some(tx.gas.byte_size()),
                             Value::known(F::from(tx.gas)),
                         ),
                         (
@@ -1769,7 +1770,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.gas_price.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some((256 - tx.gas_price.leading_zeros() + 7) / 8),
+                            Some(tx.gas_price.byte_size()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.gas_price.to_le_bytes(), challenge)),
@@ -1782,7 +1783,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.caller_address.to_fixed_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some(20),
+                            Some(tx.caller_address.byte_size()),
                             Value::known(tx.caller_address.to_scalar().expect("tx.from too big")),
                         ),
                         (
@@ -1792,7 +1793,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(tx.callee_address.map_or(Value::known(F::zero()), |callee| {
                                 rlc_be_bytes(&callee.to_fixed_bytes(), challenges.keccak_input())
                             })),
-                            Some(tx.callee_address.map_or(0, |_| 20)),
+                            Some(tx.callee_address.byte_size()),
                             Value::known(
                                 tx.callee_address
                                     .unwrap_or(Address::zero())
@@ -1816,7 +1817,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.value.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some((256 - tx.value.leading_zeros() + 7) / 8),
+                            Some(tx.value.byte_size()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.value.to_le_bytes(), challenge)),
@@ -1826,7 +1827,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::Data.into()),
                             Some(tx.call_data.is_empty()),
                             Some(rlc_be_bytes(&tx.call_data, challenges.keccak_input())),
-                            Some(tx.call_data.len() as u32),
+                            Some(tx.call_data.byte_size()),
                             rlc_be_bytes(&tx.call_data, challenges.keccak_input()),
                         ),
                         (
@@ -1861,7 +1862,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.chain_id.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some((64 - tx.chain_id.leading_zeros() + 7) / 8),
+                            Some(tx.chain_id.byte_size()),
                             Value::known(F::from(tx.chain_id)),
                         ),
                         (
@@ -1869,7 +1870,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::SigV.into()),
                             Some(tx.v.is_zero()),
                             Some(rlc_be_bytes(&tx.v.to_be_bytes(), challenges.keccak_input())),
-                            Some((64 - tx.v.leading_zeros() + 7) / 8),
+                            Some(tx.v.byte_size()),
                             Value::known(F::from(tx.v)),
                         ),
                         (
@@ -1877,7 +1878,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::SigR.into()),
                             Some(tx.r.is_zero()),
                             Some(rlc_be_bytes(&tx.r.to_be_bytes(), challenges.keccak_input())),
-                            Some((256 - tx.r.leading_zeros() + 7) / 8),
+                            Some(tx.r.byte_size()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.r.to_le_bytes(), challenge)),
@@ -1887,7 +1888,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::SigS.into()),
                             Some(tx.s.is_zero()),
                             Some(rlc_be_bytes(&tx.s.to_be_bytes(), challenges.keccak_input())),
-                            Some((256 - tx.s.leading_zeros() + 7) / 8),
+                            Some(tx.s.byte_size()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.s.to_le_bytes(), challenge)),
@@ -1897,7 +1898,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             None,
-                            Some((64 - rlp_unsigned_tx_be_bytes.len().leading_zeros() + 7) / 8),
+                            Some(rlp_unsigned_tx_be_bytes.len().byte_size()),
                             Value::known(F::from(rlp_unsigned_tx_be_bytes.len() as u64)),
                         ),
                         (
@@ -1918,7 +1919,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             None,
-                            Some((64 - rlp_signed_tx_be_bytes.len().leading_zeros() + 7) / 8),
+                            Some(rlp_signed_tx_be_bytes.len().byte_size()),
                             Value::known(F::from(rlp_signed_tx_be_bytes.len() as u64)),
                         ),
                         (

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -24,7 +24,9 @@ use crate::{
     witness::{rlp_fsm::Tag, RlpTag, Transaction},
 };
 use bus_mapping::circuit_input_builder::keccak_inputs_sign_verify;
-use eth_types::{sign_types::SignData, Address, Field, ToAddress, ToLittleEndian, ToScalar};
+use eth_types::{
+    sign_types::SignData, Address, Field, ToAddress, ToBigEndian, ToLittleEndian, ToScalar,
+};
 use gadgets::{
     binary_number::{BinaryNumberChip, BinaryNumberConfig},
     is_equal::{IsEqualChip, IsEqualConfig, IsEqualInstruction},
@@ -56,6 +58,7 @@ use halo2_proofs::plonk::FirstPhase as SecondPhase;
 #[cfg(not(feature = "onephase"))]
 use halo2_proofs::plonk::SecondPhase;
 use halo2_proofs::plonk::{Fixed, TableColumn};
+use itertools::Itertools;
 
 use crate::{
     table::{BlockContextFieldTag::CumNumTxs, TxFieldTag::ChainID},
@@ -105,6 +108,8 @@ pub struct TxCircuitConfig<F: Field> {
     rlp_tag: Column<Advice>,
     // Whether tag's RLP-encoded value is 0x80 = rlp([])
     is_none: Column<Advice>,
+    tx_value_length: Column<Advice>,
+    tx_value_rlc: Column<Advice>,
 
     u16_table: TableColumn,
 
@@ -189,6 +194,8 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         // tag, rlp_tag, tx_type, is_none
         let tx_type = meta.advice_column();
         let rlp_tag = meta.advice_column();
+        let tx_value_rlc = meta.advice_column();
+        let tx_value_length = meta.advice_column();
         let is_none = meta.advice_column();
         let tag_bits = BinaryNumberChip::configure(meta, q_enable, Some(tx_table.tag.into()));
         let tx_type_bits = BinaryNumberChip::configure(meta, q_enable, Some(tx_type.into()));
@@ -630,6 +637,8 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
             meta,
             q_enable,
             rlp_tag,
+            tx_value_rlc,
+            tx_value_length,
             tx_type_bits,
             is_none,
             &lookup_conditions,
@@ -875,6 +884,8 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
             tx_type_bits,
             rlp_tag,
             is_none,
+            tx_value_rlc,
+            tx_value_length,
             u16_table,
             tx_id_is_zero,
             value_is_zero,
@@ -907,6 +918,8 @@ impl<F: Field> TxCircuitConfig<F> {
         meta: &mut ConstraintSystem<F>,
         q_enable: Column<Fixed>,
         rlp_tag: Column<Advice>,
+        tx_value_rlc: Column<Advice>,
+        tx_value_length: Column<Advice>,
         tx_type_bits: BinaryNumberConfig<TxType, 3>,
         is_none: Column<Advice>,
         lookup_conditions: &HashMap<LookupCondition, Column<Advice>>,
@@ -1017,6 +1030,8 @@ impl<F: Field> TxCircuitConfig<F> {
                 hash_format,
                 RLPTxType.expr(),
                 tag_value,
+                meta.query_advice(tx_value_rlc, Rotation::cur()),
+                meta.query_advice(tx_value_length, Rotation::cur()),
                 1.expr(), // is_output = true
                 0.expr(), // is_none = false
             ];
@@ -1050,11 +1065,13 @@ impl<F: Field> TxCircuitConfig<F> {
                 sign_format,
                 rlp_tag,
                 meta.query_advice(tx_table.value, Rotation::cur()),
+                meta.query_advice(tx_value_rlc, Rotation::cur()),
+                meta.query_advice(tx_value_length, Rotation::cur()),
                 1.expr(), // is_output = true
                 is_none,
             ]
             .into_iter()
-            .zip(rlp_table.table_exprs(meta).into_iter()) // tag_length_eq_one is the 6th column in rlp table
+            .zip_eq(rlp_table.table_exprs(meta).into_iter()) // tag_length_eq_one is the 6th column in rlp table
             .map(|(arg, table)| (enable.clone() * arg, table))
             .collect()
         });
@@ -1086,11 +1103,13 @@ impl<F: Field> TxCircuitConfig<F> {
                 hash_format,
                 rlp_tag,
                 meta.query_advice(tx_table.value, Rotation::cur()),
+                meta.query_advice(tx_value_rlc, Rotation::cur()),
+                meta.query_advice(tx_value_length, Rotation::cur()),
                 1.expr(), // is_output = true
                 is_none,
             ]
             .into_iter()
-            .zip(rlp_table.table_exprs(meta).into_iter())
+            .zip_eq(rlp_table.table_exprs(meta).into_iter())
             .map(|(arg, table)| (enable.clone() * arg, table))
             .collect()
         });
@@ -1205,6 +1224,8 @@ impl<F: Field> TxCircuitConfig<F> {
         tx_id_next: usize,
         tag: TxFieldTag,
         value: Value<F>,
+        be_bytes_rlc: Option<Value<F>>,
+        be_bytes_length: Option<u32>,
         rlp_tag: Option<RlpTag>,
         is_none: Option<bool>,
         is_padding_tx: Option<bool>,
@@ -1235,6 +1256,18 @@ impl<F: Field> TxCircuitConfig<F> {
             self.is_none,
             *offset,
             || Value::known(F::from(is_none.unwrap_or(false) as u64)),
+        )?;
+        region.assign_advice(
+            || "value_be_bytes_rlc",
+            self.tx_value_rlc,
+            *offset,
+            || be_bytes_rlc.map_or(Value::known(F::zero()), |rlc| rlc),
+        )?;
+        region.assign_advice(
+            || "value_be_bytes_length",
+            self.tx_value_length,
+            *offset,
+            || Value::known(F::from(be_bytes_length.unwrap_or(0) as u64)),
         )?;
 
         // assign to lookup condition columns
@@ -1667,6 +1700,8 @@ impl<F: Field> TxCircuit<F> {
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )?;
 
                 // Assign all tx fields except for call data
@@ -1700,24 +1735,39 @@ impl<F: Field> TxCircuit<F> {
                         })
                     };
                     log::debug!("calldata len: {}", tx.call_data.len());
-                    for (tag, rlp_tag, is_none, value) in [
+                    for (tag, rlp_tag, is_none, be_bytes_rlc, be_bytes_length, value) in [
                         // need to be in same order as that tx table load function uses
                         (
                             Nonce,
                             Some(Tag::Nonce.into()),
                             Some(tx.nonce == 0),
+                            Some(rlc_be_bytes(
+                                &tx.nonce.to_be_bytes(),
+                                challenges.keccak_input(),
+                            )),
+                            Some((64 - tx.nonce.leading_zeros() + 7) / 8),
                             Value::known(F::from(tx.nonce)),
                         ),
                         (
                             Gas,
                             Some(Tag::Gas.into()),
                             Some(tx.gas == 0),
+                            Some(rlc_be_bytes(
+                                &tx.gas.to_be_bytes(),
+                                challenges.keccak_input(),
+                            )),
+                            Some((64 - tx.gas.leading_zeros() + 7) / 8),
                             Value::known(F::from(tx.gas)),
                         ),
                         (
                             GasPrice,
                             Some(Tag::GasPrice.into()),
                             Some(tx.gas_price.is_zero()),
+                            Some(rlc_be_bytes(
+                                &tx.gas_price.to_be_bytes(),
+                                challenges.keccak_input(),
+                            )),
+                            Some((256 - tx.gas_price.leading_zeros() + 7) / 8),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.gas_price.to_le_bytes(), challenge)),
@@ -1726,12 +1776,21 @@ impl<F: Field> TxCircuit<F> {
                             CallerAddress,
                             Some(Tag::Sender.into()),
                             None,
+                            Some(rlc_be_bytes(
+                                &tx.caller_address.to_fixed_bytes(),
+                                challenges.keccak_input(),
+                            )),
+                            Some(20),
                             Value::known(tx.caller_address.to_scalar().expect("tx.from too big")),
                         ),
                         (
                             CalleeAddress,
                             Some(Tag::To.into()),
                             Some(tx.callee_address.is_none()),
+                            Some(tx.callee_address.map_or(Value::known(F::zero()), |callee| {
+                                rlc_be_bytes(&callee.to_fixed_bytes(), challenges.keccak_input())
+                            })),
+                            Some(tx.callee_address.map_or(0, |_| 20)),
                             Value::known(
                                 tx.callee_address
                                     .unwrap_or(Address::zero())
@@ -1743,12 +1802,19 @@ impl<F: Field> TxCircuit<F> {
                             IsCreate,
                             None,
                             None,
+                            None,
+                            None,
                             Value::known(F::from(tx.is_create as u64)),
                         ),
                         (
                             TxFieldTag::Value,
                             Some(Tag::Value.into()),
                             Some(tx.value.is_zero()),
+                            Some(rlc_be_bytes(
+                                &tx.value.to_be_bytes(),
+                                challenges.keccak_input(),
+                            )),
+                            Some((256 - tx.value.leading_zeros() + 7) / 8),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.value.to_le_bytes(), challenge)),
@@ -1757,10 +1823,14 @@ impl<F: Field> TxCircuit<F> {
                             CallDataRLC,
                             Some(Tag::Data.into()),
                             Some(tx.call_data.is_empty()),
+                            Some(rlc_be_bytes(&tx.call_data, challenges.keccak_input())),
+                            Some(tx.call_data.len() as u32),
                             rlc_be_bytes(&tx.call_data, challenges.keccak_input()),
                         ),
                         (
                             CallDataLength,
+                            None,
+                            None,
                             None,
                             None,
                             Value::known(F::from(tx.call_data.len() as u64)),
@@ -1769,25 +1839,43 @@ impl<F: Field> TxCircuit<F> {
                             CallDataGasCost,
                             None,
                             None,
+                            None,
+                            None,
                             Value::known(F::from(tx.call_data_gas_cost)),
                         ),
                         (
                             TxDataGasCost,
                             Some(GasCost),
                             None,
+                            None,
+                            None,
                             Value::known(F::from(tx.tx_data_gas_cost)),
                         ),
-                        (ChainID, None, None, Value::known(F::from(tx.chain_id))),
+                        (
+                            ChainID,
+                            None,
+                            None,
+                            Some(rlc_be_bytes(
+                                &tx.chain_id.to_be_bytes(),
+                                challenges.keccak_input(),
+                            )),
+                            Some((64 - tx.chain_id.leading_zeros() + 7) / 8),
+                            Value::known(F::from(tx.chain_id)),
+                        ),
                         (
                             SigV,
                             Some(Tag::SigV.into()),
                             Some(tx.v.is_zero()),
+                            Some(rlc_be_bytes(&tx.v.to_be_bytes(), challenges.keccak_input())),
+                            Some((64 - tx.v.leading_zeros() + 7) / 8),
                             Value::known(F::from(tx.v)),
                         ),
                         (
                             SigR,
                             Some(Tag::SigR.into()),
                             Some(tx.r.is_zero()),
+                            Some(rlc_be_bytes(&tx.r.to_be_bytes(), challenges.keccak_input())),
+                            Some((256 - tx.r.leading_zeros() + 7) / 8),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.r.to_le_bytes(), challenge)),
@@ -1796,6 +1884,8 @@ impl<F: Field> TxCircuit<F> {
                             SigS,
                             Some(Tag::SigS.into()),
                             Some(tx.s.is_zero()),
+                            Some(rlc_be_bytes(&tx.s.to_be_bytes(), challenges.keccak_input())),
+                            Some((256 - tx.s.leading_zeros() + 7) / 8),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.s.to_le_bytes(), challenge)),
@@ -1804,29 +1894,37 @@ impl<F: Field> TxCircuit<F> {
                             TxSignLength,
                             Some(Len),
                             Some(false),
+                            None,
+                            None,
                             Value::known(F::from(rlp_unsigned_tx_be_bytes.len() as u64)),
                         ),
                         (
                             TxSignRLC,
                             Some(RLC),
                             Some(false),
+                            None,
+                            None,
                             challenges.keccak_input().map(|rand| {
                                 rlp_unsigned_tx_be_bytes
                                     .iter()
                                     .fold(F::zero(), |acc, byte| acc * rand + F::from(*byte as u64))
                             }),
                         ),
-                        (TxSignHash, None, None, tx_sign_hash),
+                        (TxSignHash, None, None, None, None, tx_sign_hash),
                         (
                             TxHashLength,
                             Some(Len),
                             Some(false),
+                            None,
+                            None,
                             Value::known(F::from(rlp_signed_tx_be_bytes.len() as u64)),
                         ),
                         (
                             TxHashRLC,
                             Some(RLC),
                             Some(false),
+                            None,
+                            None,
                             challenges.keccak_input().map(|rand| {
                                 rlp_signed_tx_be_bytes
                                     .iter()
@@ -1835,6 +1933,8 @@ impl<F: Field> TxCircuit<F> {
                         ),
                         (
                             TxFieldTag::TxHash,
+                            None,
+                            None,
                             None,
                             None,
                             challenges.evm_word().map(|challenge| {
@@ -1848,6 +1948,8 @@ impl<F: Field> TxCircuit<F> {
                         ),
                         (
                             BlockNumber,
+                            None,
+                            None,
                             None,
                             None,
                             Value::known(F::from(tx.block_number)),
@@ -1876,6 +1978,8 @@ impl<F: Field> TxCircuit<F> {
                             tx_id_next, // tx_id_next
                             tag,
                             value,
+                            be_bytes_rlc,
+                            be_bytes_length,
                             rlp_tag,
                             is_none,
                             Some(is_padding_tx),
@@ -1930,6 +2034,8 @@ impl<F: Field> TxCircuit<F> {
                             tx_id_next, // tx_id_next
                             CallData,
                             Value::known(F::from(*byte as u64)),
+                            None,
+                            None,
                             None,
                             None,
                             None,

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -1023,6 +1023,8 @@ impl<F: Field> TxCircuitConfig<F> {
             let enable = and::expr([meta.query_fixed(q_enable, Rotation::cur()), is_l1_msg(meta)]);
             let hash_format = L1MsgHash.expr();
             let tag_value = 0x7E.expr();
+            let tag_bytes_rlc = 0x7E.expr();
+            let tag_length = 1.expr();
 
             let input_exprs = vec![
                 1.expr(), // q_enable = true
@@ -1030,8 +1032,8 @@ impl<F: Field> TxCircuitConfig<F> {
                 hash_format,
                 RLPTxType.expr(),
                 tag_value,
-                meta.query_advice(tx_value_rlc, Rotation::cur()),
-                meta.query_advice(tx_value_length, Rotation::cur()),
+                tag_bytes_rlc,
+                tag_length,
                 1.expr(), // is_output = true
                 0.expr(), // is_none = false
             ];
@@ -1895,7 +1897,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             None,
-                            None,
+                            Some((64 - rlp_unsigned_tx_be_bytes.len().leading_zeros() + 7) / 8),
                             Value::known(F::from(rlp_unsigned_tx_be_bytes.len() as u64)),
                         ),
                         (
@@ -1916,7 +1918,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             None,
-                            None,
+                            Some((64 - rlp_signed_tx_be_bytes.len().leading_zeros() + 7) / 8),
                             Value::known(F::from(rlp_signed_tx_be_bytes.len() as u64)),
                         ),
                         (

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -64,7 +64,7 @@ use crate::{
     table::{BlockContextFieldTag::CumNumTxs, TxFieldTag::ChainID},
     util::rlc_be_bytes,
     witness::{
-        rlp_fsm::ByteSize,
+        rlp_fsm::ValueTagLength,
         Format::{L1MsgHash, TxHashEip155, TxHashPreEip155, TxSignEip155, TxSignPreEip155},
         RlpTag::{GasCost, Len, Null, RLC},
         Tag::TxType as RLPTxType,
@@ -1748,7 +1748,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.nonce.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some(tx.nonce.byte_size()),
+                            Some(tx.nonce.tag_length()),
                             Value::known(F::from(tx.nonce)),
                         ),
                         (
@@ -1759,7 +1759,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.gas.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some(tx.gas.byte_size()),
+                            Some(tx.gas.tag_length()),
                             Value::known(F::from(tx.gas)),
                         ),
                         (
@@ -1770,7 +1770,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.gas_price.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some(tx.gas_price.byte_size()),
+                            Some(tx.gas_price.tag_length()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.gas_price.to_le_bytes(), challenge)),
@@ -1783,7 +1783,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.caller_address.to_fixed_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some(tx.caller_address.byte_size()),
+                            Some(tx.caller_address.tag_length()),
                             Value::known(tx.caller_address.to_scalar().expect("tx.from too big")),
                         ),
                         (
@@ -1793,7 +1793,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(tx.callee_address.map_or(Value::known(F::zero()), |callee| {
                                 rlc_be_bytes(&callee.to_fixed_bytes(), challenges.keccak_input())
                             })),
-                            Some(tx.callee_address.byte_size()),
+                            Some(tx.callee_address.tag_length()),
                             Value::known(
                                 tx.callee_address
                                     .unwrap_or(Address::zero())
@@ -1817,7 +1817,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.value.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some(tx.value.byte_size()),
+                            Some(tx.value.tag_length()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.value.to_le_bytes(), challenge)),
@@ -1827,7 +1827,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::Data.into()),
                             Some(tx.call_data.is_empty()),
                             Some(rlc_be_bytes(&tx.call_data, challenges.keccak_input())),
-                            Some(tx.call_data.byte_size()),
+                            Some(tx.call_data.tag_length()),
                             rlc_be_bytes(&tx.call_data, challenges.keccak_input()),
                         ),
                         (
@@ -1862,7 +1862,7 @@ impl<F: Field> TxCircuit<F> {
                                 &tx.chain_id.to_be_bytes(),
                                 challenges.keccak_input(),
                             )),
-                            Some(tx.chain_id.byte_size()),
+                            Some(tx.chain_id.tag_length()),
                             Value::known(F::from(tx.chain_id)),
                         ),
                         (
@@ -1870,7 +1870,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::SigV.into()),
                             Some(tx.v.is_zero()),
                             Some(rlc_be_bytes(&tx.v.to_be_bytes(), challenges.keccak_input())),
-                            Some(tx.v.byte_size()),
+                            Some(tx.v.tag_length()),
                             Value::known(F::from(tx.v)),
                         ),
                         (
@@ -1878,7 +1878,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::SigR.into()),
                             Some(tx.r.is_zero()),
                             Some(rlc_be_bytes(&tx.r.to_be_bytes(), challenges.keccak_input())),
-                            Some(tx.r.byte_size()),
+                            Some(tx.r.tag_length()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.r.to_le_bytes(), challenge)),
@@ -1888,7 +1888,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Tag::SigS.into()),
                             Some(tx.s.is_zero()),
                             Some(rlc_be_bytes(&tx.s.to_be_bytes(), challenges.keccak_input())),
-                            Some(tx.s.byte_size()),
+                            Some(tx.s.tag_length()),
                             challenges
                                 .evm_word()
                                 .map(|challenge| rlc(tx.s.to_le_bytes(), challenge)),
@@ -1898,7 +1898,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             None,
-                            Some(rlp_unsigned_tx_be_bytes.len().byte_size()),
+                            Some(rlp_unsigned_tx_be_bytes.len().tag_length()),
                             Value::known(F::from(rlp_unsigned_tx_be_bytes.len() as u64)),
                         ),
                         (
@@ -1919,7 +1919,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             None,
-                            Some(rlp_signed_tx_be_bytes.len().byte_size()),
+                            Some(rlp_signed_tx_be_bytes.len().tag_length()),
                             Value::known(F::from(rlp_signed_tx_be_bytes.len() as u64)),
                         ),
                         (

--- a/zkevm-circuits/src/witness/rlp_fsm.rs
+++ b/zkevm-circuits/src/witness/rlp_fsm.rs
@@ -5,51 +5,51 @@ use strum_macros::EnumIter;
 
 use crate::util::Challenges;
 
-pub(crate) trait ByteSize {
-    fn byte_size(&self) -> u32;
+pub(crate) trait ValueTagLength {
+    fn tag_length(&self) -> u32;
 }
 
-impl ByteSize for u64 {
-    fn byte_size(&self) -> u32 {
+impl ValueTagLength for u64 {
+    fn tag_length(&self) -> u32 {
         // note that 0_u64 is encoded as [0x80] in RLP
         // see the relevant code at https://github.com/paritytech/parity-common/blob/master/rlp/src/impls.rs#L208
         (64 - self.leading_zeros() + 7) / 8
     }
 }
 
-impl ByteSize for usize {
-    fn byte_size(&self) -> u32 {
+impl ValueTagLength for usize {
+    fn tag_length(&self) -> u32 {
         // usize is treated as same as u64
-        (*self as u64).byte_size()
+        (*self as u64).tag_length()
     }
 }
 
-impl ByteSize for U256 {
-    fn byte_size(&self) -> u32 {
+impl ValueTagLength for U256 {
+    fn tag_length(&self) -> u32 {
         // note that U256::zero() is encoded as [0x80] in RLP
         // see the relevant code at https://github.com/paritytech/parity-common/blob/impl-rlp-v0.3.0/primitive-types/src/lib.rs#L117
         (256 - self.leading_zeros() + 7) / 8
     }
 }
 
-impl ByteSize for H160 {
-    fn byte_size(&self) -> u32 {
+impl ValueTagLength for H160 {
+    fn tag_length(&self) -> u32 {
         20
     }
 }
 
-impl ByteSize for Option<Address> {
-    fn byte_size(&self) -> u32 {
+impl ValueTagLength for Option<Address> {
+    fn tag_length(&self) -> u32 {
         if self.is_none() {
             0
         } else {
-            self.unwrap().byte_size()
+            self.unwrap().tag_length()
         }
     }
 }
 
-impl ByteSize for Vec<u8> {
-    fn byte_size(&self) -> u32 {
+impl ValueTagLength for Vec<u8> {
+    fn tag_length(&self) -> u32 {
         self.len() as u32
     }
 }

--- a/zkevm-circuits/src/witness/rlp_fsm.rs
+++ b/zkevm-circuits/src/witness/rlp_fsm.rs
@@ -511,6 +511,12 @@ pub struct RlpTable<F: FieldExt> {
     pub rlp_tag: RlpTag,
     /// The tag's value
     pub tag_value: Value<F>,
+    /// RLC of the tag's big-endian bytes
+    pub tag_bytes_rlc: Value<F>,
+    /// Length of the tag's big-endian bytes
+    /// Note that we use (tag_bytes_rlc, tag_length) to identify
+    /// the tag's dynamic-sized big-endian bytes
+    pub tag_length: usize,
     /// If current row is for output
     pub is_output: bool,
     /// If current tag's value is None.
@@ -536,8 +542,6 @@ pub struct StateMachine<F: FieldExt> {
     pub byte_value: u8,
     /// The index of the actual bytes of tag
     pub tag_idx: usize,
-    /// The length of the actual bytes of tag
-    pub tag_length: usize,
     /// The accumulated value of bytes up to `tag_idx` of tag
     /// In most cases, RlpTable.tag_value == StateMachine.tag_value_acc.
     /// However, for RlpTag::Len, we have
@@ -581,4 +585,5 @@ pub(crate) struct SmState<F: Field> {
     pub(crate) tag_idx: usize,
     pub(crate) tag_length: usize,
     pub(crate) tag_value_acc: Value<F>,
+    pub(crate) tag_bytes_rlc: Value<F>,
 }

--- a/zkevm-circuits/src/witness/rlp_fsm.rs
+++ b/zkevm-circuits/src/witness/rlp_fsm.rs
@@ -13,7 +13,7 @@ impl ByteSize for u64 {
     fn byte_size(&self) -> u32 {
         // note that 0_u64 is encoded as [0x80] in RLP
         // see the relevant code at https://github.com/paritytech/parity-common/blob/master/rlp/src/impls.rs#L208
-        ((std::mem::size_of::<u64>() as u32 - self.leading_zeros()) + 7) / 8
+        (64 - self.leading_zeros() + 7) / 8
     }
 }
 
@@ -28,13 +28,13 @@ impl ByteSize for U256 {
     fn byte_size(&self) -> u32 {
         // note that U256::zero() is encoded as [0x80] in RLP
         // see the relevant code at https://github.com/paritytech/parity-common/blob/impl-rlp-v0.3.0/primitive-types/src/lib.rs#L117
-        ((std::mem::size_of::<U256>() as u32 - self.leading_zeros()) + 7) / 8
+        (256 - self.leading_zeros() + 7) / 8
     }
 }
 
 impl ByteSize for H160 {
     fn byte_size(&self) -> u32 {
-        std::mem::size_of::<H160>() as u32
+        20
     }
 }
 
@@ -43,10 +43,7 @@ impl ByteSize for Option<Address> {
         if self.is_none() {
             0
         } else {
-            let size = self.unwrap().byte_size();
-            assert_eq!(size, 20);
-
-            size
+            self.unwrap().byte_size()
         }
     }
 }

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -454,7 +454,7 @@ impl Transaction {
                             assert!(!cur.tag.is_list());
                             is_output = true;
                             cur.tag_value_acc = Value::known(F::from(byte_value as u64));
-                            cur.tag_bytes_rlc = cur.tag_value_acc.clone();
+                            cur.tag_bytes_rlc = cur.tag_value_acc;
                             cur.tag_length = 1;
 
                             // state transitions
@@ -499,6 +499,7 @@ impl Transaction {
                                 rlp_tag = RlpTag::Len;
                             }
                             cur.tag_value_acc = Value::known(F::from(u64::from(byte_value - 0xc0)));
+                            cur.tag_length = 1;
 
                             // state transitions
                             let num_bytes_of_new_list = usize::from(byte_value - 0xc0);
@@ -658,7 +659,9 @@ impl Transaction {
                 RlpTag::Null => unreachable!("Null is not used"),
             };
             let (tag_bytes_rlc, tag_length) = match rlp_tag {
-                RlpTag::Len | RlpTag::RLC | RlpTag::GasCost => (Value::known(F::zero()), 0),
+                // Len | RLC | GasCost are just meta-info extracted from keccak input bytes
+                RlpTag::Len => (Value::known(F::zero()), cur.tag_length),
+                RlpTag::RLC | RlpTag::GasCost => (Value::known(F::zero()), 0),
                 RlpTag::Tag(_) => (cur.tag_bytes_rlc, cur.tag_length),
                 RlpTag::Null => unreachable!("Null is not used"),
             };


### PR DESCRIPTION
### Description

This pr add two more columns in the RLP table to fix the finding 11 in the [Zellic / Kalos Audit Report](https://hackmd.io/4XuxkwHERa6AIPQ6tr2QAg#Finding-11-RLP-Circuit-%E2%80%9CImportance%E2%80%9D-High).
1. be_bytes_rlc
2. be_bytes_length

Then we also need to change the lookup arguments (into RLP table) in tx circuit.

### Issue Link

The tx's fields are decoded from tx hash and then encoded into tx sign. Previously, we use field's accumulated value to copy big-endian bytes around. But this has one critical vulnerability in which field of type `u64` can have different big-endian bytes whose value is same. 

For example, `1_u64 = [1] = [0, 1] = [0, 0, 1] = ... `. This will cause the msg_hash can be manipulated by an malicious prover. To fix that, we can add `RLC(be_bytes)` in the RLP table in addition to the old `tag_value_acc = LC(be_bytes)`. 

However, this alone still has another vulnerability. We can have append arbitrary number of zeros in the end of be_bytes and still have same RLC. To fix this, we add `length(be_bytes)` in the RLP table too.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update