### PR TITLE
fix: small upgrade snark-verifier to make `verify_evm_calldata` public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,7 +4505,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#f8bdcbee60348e5c996c04f19ff30522e6b276b0"
+source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#12c306ec57849921e690221b10b8a08189868d4a"
 dependencies = [
  "bytes",
  "ethereum-types 0.14.1",
@@ -4529,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "snark-verifier-sdk"
 version = "0.0.1"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#f8bdcbee60348e5c996c04f19ff30522e6b276b0"
+source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#12c306ec57849921e690221b10b8a08189868d4a"
 dependencies = [
  "bincode",
  "env_logger 0.10.0",


### PR DESCRIPTION
### Description

Miss to make verify_evm_calldata public.
Related snark-verifier PR https://github.com/scroll-tech/snark-verifier/pull/20.