### PR TITLE
[Fix] caller account not exist in l1msg

### DIFF
--- a/bus-mapping/src/circuit_input_builder/transaction.rs
+++ b/bus-mapping/src/circuit_input_builder/transaction.rs
@@ -361,8 +361,15 @@ impl Transaction {
             }
         );
 
-        let l1_fee = TxL1Fee::get_current_values_from_state_db(sdb);
-        let l1_fee_committed = TxL1Fee::get_committed_values_from_state_db(sdb);
+        let tx_type = TxType::get_tx_type(eth_tx);
+        let (l1_fee, l1_fee_committed) = if tx_type.is_l1_msg() {
+            Default::default()
+        } else {
+            (
+                TxL1Fee::get_current_values_from_state_db(sdb),
+                TxL1Fee::get_committed_values_from_state_db(sdb),
+            )
+        };
 
         log::debug!(
             "l1_fee: {:?}, l1_fee_committed: {:?}",
@@ -373,7 +380,7 @@ impl Transaction {
         Ok(Self {
             block_num: eth_tx.block_number.unwrap().as_u64(),
             hash: eth_tx.hash,
-            tx_type: TxType::get_tx_type(eth_tx),
+            tx_type,
             rlp_bytes: eth_tx.rlp().to_vec(),
             rlp_unsigned_bytes: get_rlp_unsigned(eth_tx),
             nonce: eth_tx.nonce.as_u64(),

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -487,35 +487,37 @@ pub fn gen_begin_tx_ops(
         // create it here
         let caller_acc = state.sdb.get_account(&caller_address).1.clone();
 
-        state.account_read(&mut exec_step, 
-            caller_address, 
-            AccountField::CodeHash, 
+        state.account_read(
+            &mut exec_step,
+            caller_address,
+            AccountField::CodeHash,
             caller_acc.code_hash_read().to_word(),
         );
 
         if caller_acc.is_empty() {
             log::info!("create account for {:?} inside l1msg tx", caller_address);
 
-            // notice the op is not reversible, since the nonce increasing is 
+            // notice the op is not reversible, since the nonce increasing is
             // inreversible
-            state.account_write(&mut exec_step, 
-                caller_address, 
-                AccountField::CodeHash, 
-                caller_acc.code_hash.to_word(), 
+            state.account_write(
+                &mut exec_step,
+                caller_address,
+                AccountField::CodeHash,
+                caller_acc.code_hash.to_word(),
                 Word::zero(),
             )?;
 
             #[cfg(feature = "scroll")]
             {
-                state.account_write(&mut exec_step, 
-                    caller_address, 
-                    AccountField::KeccakCodeHash, 
-                    caller_acc.keccak_code_hash.to_word(), 
+                state.account_write(
+                    &mut exec_step,
+                    caller_address,
+                    AccountField::KeccakCodeHash,
+                    caller_acc.keccak_code_hash.to_word(),
                     Word::zero(),
                 )?;
-            }            
+            }
         }
-
     } else {
         // else, add 3 RW read operations for transaction L1 fee.
         gen_tx_l1_fee_ops(state, &mut exec_step);
@@ -528,7 +530,6 @@ pub fn gen_begin_tx_ops(
     // + for non-scroll l1-msg tx:
     //   * caller existed: 1 (read codehash)
     //   * caller not existed: 2 (read codehash and create account)
-    
 
     for (field, value) in [
         (CallContextField::TxId, state.tx_ctx.id().into()),
@@ -997,7 +998,6 @@ pub fn gen_end_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
 
 // Add 3 RW read operations for transaction L1 fee.
 fn gen_tx_l1_fee_ops(state: &mut CircuitInputStateRef, exec_step: &mut ExecStep) {
-
     let tx_id = state.tx_ctx.id();
 
     let base_fee = Word::from(state.tx.l1_fee.base_fee);

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -477,8 +477,58 @@ pub fn gen_begin_tx_ops(
     let mut exec_step = state.new_begin_tx_step();
     let call = state.call()?.clone();
 
-    // Add 3 RW read operations for transaction L1 fee.
-    gen_tx_l1_fee_ops(state, &mut exec_step);
+    let caller_address = call.caller_address;
+
+    if state.tx.tx_type.is_l1_msg() {
+        // for l1 message, no need to add rw op, but we must check
+        // caller for its existent status
+
+        // notice the caller must existed after a l1msg tx, so we
+        // create it here
+        let caller_acc = state.sdb.get_account(&caller_address).1.clone();
+
+        state.account_read(&mut exec_step, 
+            caller_address, 
+            AccountField::CodeHash, 
+            caller_acc.code_hash_read().to_word(),
+        );
+
+        if caller_acc.is_empty() {
+            log::info!("create account for {:?} inside l1msg tx", caller_address);
+
+            // notice the op is not reversible, since the nonce increasing is 
+            // inreversible
+            state.account_write(&mut exec_step, 
+                caller_address, 
+                AccountField::CodeHash, 
+                caller_acc.code_hash.to_word(), 
+                Word::zero(),
+            )?;
+
+            #[cfg(feature = "scroll")]
+            {
+                state.account_write(&mut exec_step, 
+                    caller_address, 
+                    AccountField::KeccakCodeHash, 
+                    caller_acc.keccak_code_hash.to_word(), 
+                    Word::zero(),
+                )?;
+            }            
+        }
+
+    } else {
+        // else, add 3 RW read operations for transaction L1 fee.
+        gen_tx_l1_fee_ops(state, &mut exec_step);
+    }
+    // the rw delta before is:
+    // + for non-l1 msg tx: 3 (rw for fee oracle contrace)
+    // + for scroll l1-msg tx:
+    //   * caller existed: 1 (read codehash)
+    //   * caller not existed: 3 (read codehash and create account)
+    // + for non-scroll l1-msg tx:
+    //   * caller existed: 1 (read codehash)
+    //   * caller not existed: 2 (read codehash and create account)
+    
 
     for (field, value) in [
         (CallContextField::TxId, state.tx_ctx.id().into()),
@@ -496,7 +546,6 @@ pub fn gen_begin_tx_ops(
     }
 
     // Increase caller's nonce
-    let caller_address = call.caller_address;
     let mut nonce_prev = state.sdb.get_account(&caller_address).1.nonce;
     debug_assert!(nonce_prev <= state.tx.nonce.into());
     while nonce_prev < state.tx.nonce.into() {
@@ -948,10 +997,6 @@ pub fn gen_end_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
 
 // Add 3 RW read operations for transaction L1 fee.
 fn gen_tx_l1_fee_ops(state: &mut CircuitInputStateRef, exec_step: &mut ExecStep) {
-    // for l1 message, no need to add rw op
-    if state.tx.tx_type.is_l1_msg() {
-        return;
-    }
 
     let tx_id = state.tx_ctx.id();
 

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -110,7 +110,6 @@ impl Account {
             self.code_hash
         }
     }
-    
 }
 
 /// In-memory key-value database that represents the Ethereum State Trie.

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -99,6 +99,18 @@ impl Account {
             && self.code_hash.eq(&CodeDB::empty_code_hash())
             && self.code_size.is_zero()
     }
+
+    /// Return the expected read code hash, i.e. in
+    /// empty (non-existed) account it is expected
+    /// to be 0
+    pub fn code_hash_read(&self) -> Hash {
+        if self.is_empty() {
+            Hash::zero()
+        } else {
+            self.code_hash
+        }
+    }
+    
 }
 
 /// In-memory key-value database that represents the Ethereum State Trie.

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -5,7 +5,7 @@ use crate::{
         step::ExecutionState,
         util::{
             and,
-            common_gadget::{TransferWithGasFeeGadget, TxL1FeeGadget},
+            common_gadget::{TransferWithGasFeeGadget, TxL1FeeGadget, TxL1MsgGadget},
             constraint_builder::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
                 Transition::{Delta, To},
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 use bus_mapping::circuit_input_builder::CopyDataType;
-use eth_types::{geth_types::TxType::L1Msg, Address, Field, ToLittleEndian, ToScalar, U256};
+use eth_types::{Address, Field, ToLittleEndian, ToScalar, U256};
 use ethers_core::utils::{get_contract_address, keccak256, rlp::RlpStream};
 use gadgets::util::{expr_from_bytes, not, or, Expr};
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -42,8 +42,6 @@ use gadgets::util::select;
 #[derive(Clone, Debug)]
 pub(crate) struct BeginTxGadget<F> {
     tx_id: Cell<F>,
-    tx_type: Cell<F>,
-    tx_is_l1msg: IsEqualGadget<F>,
     tx_nonce: Cell<F>,
     tx_gas: Cell<F>,
     tx_gas_price: Word<F>,
@@ -88,6 +86,7 @@ pub(crate) struct BeginTxGadget<F> {
     // <https://github.com/ethereum/go-ethereum/blob/604e215d1bb070dff98fb76aa965064c74e3633f/core/state/statedb.go#LL1119C9-L1119C9>
     is_coinbase_warm: Cell<F>,
     tx_l1_fee: TxL1FeeGadget<F>,
+    tx_l1_msg: TxL1MsgGadget<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
@@ -101,7 +100,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         let tx_id = cb.query_cell();
 
-        let [tx_nonce, tx_gas, tx_caller_address, tx_callee_address, tx_is_create, tx_call_data_length, tx_call_data_gas_cost, tx_data_gas_cost, tx_type] =
+        let [tx_nonce, tx_gas, tx_caller_address, tx_callee_address, tx_is_create, tx_call_data_length, tx_call_data_gas_cost, tx_data_gas_cost] =
             [
                 TxContextFieldTag::Nonce,
                 TxContextFieldTag::Gas,
@@ -111,18 +110,21 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 TxContextFieldTag::CallDataLength,
                 TxContextFieldTag::CallDataGasCost,
                 TxContextFieldTag::TxDataGasCost,
-                TxContextFieldTag::TxType,
             ]
             .map(|field_tag| cb.tx_context(tx_id.expr(), field_tag, None));
 
-        let tx_is_l1msg = IsEqualGadget::construct(cb, tx_type.expr(), (L1Msg as u64).expr());
-        let tx_l1_fee = cb.condition(not::expr(tx_is_l1msg.expr()), |cb| {
+        let tx_l1_msg = TxL1MsgGadget::construct(cb, tx_id.expr(), tx_caller_address.expr());
+        let tx_l1_fee = cb.condition(not::expr(tx_l1_msg.is_l1_msg()), |cb| {
             TxL1FeeGadget::construct(cb, tx_id.expr(), tx_data_gas_cost.expr())
         });
-        cb.condition(tx_is_l1msg.expr(), |cb| {
+        cb.condition(tx_l1_msg.is_l1_msg(), |cb| {
             cb.require_zero("l1fee is 0 for l1msg", tx_data_gas_cost.expr());
         });
-        let tx_l1_fee_rw_delta = select::expr(tx_is_l1msg.expr(), 0.expr(), tx_l1_fee.rw_delta());
+        // the rw delta caused by l1 related handling
+        let l1_rw_delta = select::expr(tx_l1_msg.is_l1_msg(), tx_l1_msg.rw_delta(), tx_l1_fee.rw_delta());
+
+        // the cost caused by l1
+        let l1_fee_cost = select::expr(tx_l1_msg.is_l1_msg(), 0.expr(), tx_l1_fee.tx_l1_fee());
 
         cb.call_context_lookup(
             1.expr(),
@@ -189,11 +191,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         cb.require_equal(
             "tx_fee == l1_fee + l2_fee",
-            select::expr(
-                tx_is_l1msg.expr(),
-                0.expr(),
-                from_bytes::expr(&tx_l1_fee.tx_l1_fee().cells[..]),
-            ) + from_bytes::expr(&mul_gas_fee_by_gas.product().cells[..16]),
+            l1_fee_cost + from_bytes::expr(&mul_gas_fee_by_gas.product().cells[..16]),
             from_bytes::expr(&tx_fee.cells[..16]),
         );
 
@@ -451,7 +449,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write CallContext CodeHash
                 rw_counter: Delta(
                     22.expr()
-                        + tx_l1_fee_rw_delta.expr()
+                        + l1_rw_delta.expr()
                         + transfer_with_gas_fee.rw_delta()
                         + SHANGHAI_RW_DELTA.expr()
                         + PRECOMPILE_COUNT.expr(),
@@ -507,7 +505,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - a TransferWithGasFeeGadget
                 rw_counter: Delta(
                     7.expr()
-                        + tx_l1_fee_rw_delta.expr()
+                        + l1_rw_delta.expr()
                         + transfer_with_gas_fee.rw_delta()
                         + SHANGHAI_RW_DELTA.expr()
                         + PRECOMPILE_COUNT.expr()
@@ -560,7 +558,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     //   - a TransferWithGasFeeGadget
                     rw_counter: Delta(
                         8.expr()
-                            + tx_l1_fee_rw_delta.expr()
+                            + l1_rw_delta.expr()
                             + transfer_with_gas_fee.rw_delta()
                             + SHANGHAI_RW_DELTA.expr()
                             + PRECOMPILE_COUNT.expr(),
@@ -632,7 +630,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     //   - Write CallContext CodeHash
                     rw_counter: Delta(
                         21.expr()
-                            + tx_l1_fee_rw_delta.expr()
+                            + l1_rw_delta.expr()
                             + transfer_with_gas_fee.rw_delta()
                             + SHANGHAI_RW_DELTA.expr()
                             + PRECOMPILE_COUNT.expr(),
@@ -651,8 +649,6 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         Self {
             tx_id,
-            tx_type,
-            tx_is_l1msg,
             tx_nonce,
             tx_gas,
             tx_gas_price,
@@ -690,6 +686,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             coinbase,
             is_coinbase_warm,
             tx_l1_fee,
+            tx_l1_msg,
         }
     }
 
@@ -705,7 +702,28 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let zero = eth_types::Word::zero();
 
         let mut rws = StepRws::new(block, step);
-        rws.offset_add(if tx.tx_type.is_l1_msg() { 7 } else { 10 } + PRECOMPILE_COUNT);
+
+        let caller_code_hash = if tx.tx_type.is_l1_msg() {
+            let caller_code_hash_pair = rws.next().account_codehash_pair();
+            assert_eq!(caller_code_hash_pair.0, caller_code_hash_pair.1, "expected a read for code hash");
+            caller_code_hash_pair.0
+        } else {
+            U256::zero()
+        };
+        self.tx_l1_msg.assign(region, offset, tx.tx_type, caller_code_hash)?;
+
+        rws.offset_add(
+            if tx.tx_type.is_l1_msg() { 
+                if caller_code_hash.is_zero() {
+                    assert_eq!(tx.nonce, 0, "unexpected nonce {} when caller is not existed (must be 0)", tx.nonce);
+                    if cfg!(feature = "scroll") {10} else {9}
+                } else {
+                    8
+                }
+            } else { 
+                10
+            } + PRECOMPILE_COUNT
+        );
 
         #[cfg(feature = "shanghai")]
         let is_coinbase_warm = rws.next().tx_access_list_value_pair().1;
@@ -742,14 +760,6 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
-        self.tx_type
-            .assign(region, offset, Value::known(F::from(tx.tx_type as u64)))?;
-        self.tx_is_l1msg.assign(
-            region,
-            offset,
-            F::from(tx.tx_type as u64),
-            F::from(L1Msg as u64),
-        )?;
         self.tx_nonce
             .assign(region, offset, Value::known(F::from(tx.nonce)))?;
         self.tx_gas

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -31,8 +31,10 @@ use halo2_proofs::{
 };
 
 mod tx_l1_fee;
+mod tx_l1_msg;
 
 pub(crate) use tx_l1_fee::TxL1FeeGadget;
+pub(crate) use tx_l1_msg::TxL1MsgGadget;
 
 /// Construction of execution state that stays in the same call context, which
 /// lookups the opcode and verifies the execution state is responsible for it,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_fee.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_fee.rs
@@ -131,8 +131,8 @@ impl<F: Field> TxL1FeeGadget<F> {
         3.expr()
     }
 
-    pub(crate) fn tx_l1_fee(&self) -> &U64Word<F> {
-        &self.tx_l1_fee_word
+    pub(crate) fn tx_l1_fee(&self) -> Expression<F> {
+        from_bytes::expr(&self.tx_l1_fee_word.cells)
     }
 
     fn raw_construct(cb: &mut EVMConstraintBuilder<F>, tx_data_gas_cost: Expression<F>) -> Self {
@@ -238,7 +238,7 @@ mod tests {
 
             cb.require_equal(
                 "tx_l1_fee must be correct",
-                from_bytes::expr(&gadget.tx_l1_fee().cells[..]),
+                gadget.tx_l1_fee(),
                 expected_tx_l1_fee.expr(),
             );
 

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_msg.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_msg.rs
@@ -1,23 +1,19 @@
 use super::{CachedRegion, Cell};
 use crate::{
-    evm_circuit::{
-        param::N_BYTES_U64,
-        util::{
-            and, select,
-            constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            from_bytes, U64Word,
-            math_gadget::{IsEqualGadget, IsZeroGadget}
-        },
+    evm_circuit::util::{
+        and,
+        constraint_builder::EVMConstraintBuilder,
+        math_gadget::{IsEqualGadget, IsZeroGadget},
+        select,
     },
     table::{AccountFieldTag, TxFieldTag::TxType as TxTypeField},
     util::Expr,
 };
-use bus_mapping::{
-    circuit_input_builder::{TxL1Fee, TX_L1_COMMIT_EXTRA_COST, TX_L1_FEE_PRECISION},
-    l2_predeployed::l1_gas_price_oracle,
+use eth_types::{geth_types::TxType, Field, U256};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
 };
-use eth_types::{geth_types::TxType, Field, ToLittleEndian, ToScalar, U256};
-use halo2_proofs::{circuit::Value, plonk::{Error, Expression}};
 
 /// L1 Msg Transaction gadget for some extra handling
 #[derive(Clone, Debug)]
@@ -37,24 +33,41 @@ impl<F: Field> TxL1MsgGadget<F> {
         tx_id: Expression<F>,
         caller_address: Expression<F>,
     ) -> Self {
-
         let tx_type = cb.tx_context(tx_id.expr(), TxTypeField, None);
-        let tx_is_l1msg = IsEqualGadget::construct(cb, tx_type.expr(), (TxType::L1Msg as u64).expr());
+        let tx_is_l1msg =
+            IsEqualGadget::construct(cb, tx_type.expr(), (TxType::L1Msg as u64).expr());
         let caller_codehash = cb.query_cell_phase2();
-        let is_caller_empty = IsZeroGadget::construct(cb, "is caller address not existed", caller_codehash.expr());
+        let is_caller_empty =
+            IsZeroGadget::construct(cb, "is caller address not existed", caller_codehash.expr());
 
-        cb.condition(tx_is_l1msg.expr(), |cb|{
-            cb.account_read(caller_address.expr(), AccountFieldTag::CodeHash, caller_codehash.expr());
+        cb.condition(tx_is_l1msg.expr(), |cb| {
+            cb.account_read(
+                caller_address.expr(),
+                AccountFieldTag::CodeHash,
+                caller_codehash.expr(),
+            );
         });
 
-        cb.condition(and::expr([
-                tx_is_l1msg.expr(),
-                is_caller_empty.expr(),
-            ]), |cb|{
-            cb.account_write(caller_address.expr(), AccountFieldTag::CodeHash, cb.empty_code_hash_rlc(), 0.expr(), None);
-            #[cfg(feature = "scroll")]
-            cb.account_write(caller_address.expr(), AccountFieldTag::KeccakCodeHash, cb.empty_keccak_hash_rlc(), 0.expr(), None);
-        });
+        cb.condition(
+            and::expr([tx_is_l1msg.expr(), is_caller_empty.expr()]),
+            |cb| {
+                cb.account_write(
+                    caller_address.expr(),
+                    AccountFieldTag::CodeHash,
+                    cb.empty_code_hash_rlc(),
+                    0.expr(),
+                    None,
+                );
+                #[cfg(feature = "scroll")]
+                cb.account_write(
+                    caller_address.expr(),
+                    AccountFieldTag::KeccakCodeHash,
+                    cb.empty_keccak_hash_rlc(),
+                    0.expr(),
+                    None,
+                );
+            },
+        );
 
         Self {
             tx_type,
@@ -62,7 +75,6 @@ impl<F: Field> TxL1MsgGadget<F> {
             caller_codehash,
             is_caller_empty,
         }
-
     }
 
     pub(crate) fn assign(
@@ -72,12 +84,18 @@ impl<F: Field> TxL1MsgGadget<F> {
         tx_type: TxType,
         code_hash: U256,
     ) -> Result<(), Error> {
-
-        self.tx_type.assign(region, offset, Value::known(F::from(tx_type as u64)))?;
-        self.tx_is_l1msg.assign(region, offset, F::from(tx_type as u64), F::from(TxType::L1Msg as u64))?;
+        self.tx_type
+            .assign(region, offset, Value::known(F::from(tx_type as u64)))?;
+        self.tx_is_l1msg.assign(
+            region,
+            offset,
+            F::from(tx_type as u64),
+            F::from(TxType::L1Msg as u64),
+        )?;
         let code_hash = region.code_hash(code_hash);
         self.caller_codehash.assign(region, offset, code_hash)?;
-        self.is_caller_empty.assign_value(region, offset, code_hash)?;
+        self.is_caller_empty
+            .assign_value(region, offset, code_hash)?;
 
         Ok(())
     }
@@ -86,13 +104,16 @@ impl<F: Field> TxL1MsgGadget<F> {
     pub(crate) fn rw_delta(&self) -> Expression<F> {
         select::expr(
             self.is_caller_empty.expr(),
-            if cfg!(feature = "scroll") {3.expr()} else {2.expr()},
-            1.expr()
+            if cfg!(feature = "scroll") {
+                3.expr()
+            } else {
+                2.expr()
+            },
+            1.expr(),
         )
     }
 
     pub(crate) fn is_l1_msg(&self) -> Expression<F> {
         self.tx_is_l1msg.expr()
     }
-
 }

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_msg.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget/tx_l1_msg.rs
@@ -1,0 +1,98 @@
+use super::{CachedRegion, Cell};
+use crate::{
+    evm_circuit::{
+        param::N_BYTES_U64,
+        util::{
+            and, select,
+            constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+            from_bytes, U64Word,
+            math_gadget::{IsEqualGadget, IsZeroGadget}
+        },
+    },
+    table::{AccountFieldTag, TxFieldTag::TxType as TxTypeField},
+    util::Expr,
+};
+use bus_mapping::{
+    circuit_input_builder::{TxL1Fee, TX_L1_COMMIT_EXTRA_COST, TX_L1_FEE_PRECISION},
+    l2_predeployed::l1_gas_price_oracle,
+};
+use eth_types::{geth_types::TxType, Field, ToLittleEndian, ToScalar, U256};
+use halo2_proofs::{circuit::Value, plonk::{Error, Expression}};
+
+/// L1 Msg Transaction gadget for some extra handling
+#[derive(Clone, Debug)]
+pub(crate) struct TxL1MsgGadget<F> {
+    /// tx is l1 msg tx
+    tx_is_l1msg: IsEqualGadget<F>,
+    /// tx type
+    tx_type: Cell<F>,
+    /// caller is empty
+    is_caller_empty: IsZeroGadget<F>,
+    caller_codehash: Cell<F>,
+}
+
+impl<F: Field> TxL1MsgGadget<F> {
+    pub(crate) fn construct(
+        cb: &mut EVMConstraintBuilder<F>,
+        tx_id: Expression<F>,
+        caller_address: Expression<F>,
+    ) -> Self {
+
+        let tx_type = cb.tx_context(tx_id.expr(), TxTypeField, None);
+        let tx_is_l1msg = IsEqualGadget::construct(cb, tx_type.expr(), (TxType::L1Msg as u64).expr());
+        let caller_codehash = cb.query_cell_phase2();
+        let is_caller_empty = IsZeroGadget::construct(cb, "is caller address not existed", caller_codehash.expr());
+
+        cb.condition(tx_is_l1msg.expr(), |cb|{
+            cb.account_read(caller_address.expr(), AccountFieldTag::CodeHash, caller_codehash.expr());
+        });
+
+        cb.condition(and::expr([
+                tx_is_l1msg.expr(),
+                is_caller_empty.expr(),
+            ]), |cb|{
+            cb.account_write(caller_address.expr(), AccountFieldTag::CodeHash, cb.empty_code_hash_rlc(), 0.expr(), None);
+            #[cfg(feature = "scroll")]
+            cb.account_write(caller_address.expr(), AccountFieldTag::KeccakCodeHash, cb.empty_keccak_hash_rlc(), 0.expr(), None);
+        });
+
+        Self {
+            tx_type,
+            tx_is_l1msg,
+            caller_codehash,
+            is_caller_empty,
+        }
+
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        tx_type: TxType,
+        code_hash: U256,
+    ) -> Result<(), Error> {
+
+        self.tx_type.assign(region, offset, Value::known(F::from(tx_type as u64)))?;
+        self.tx_is_l1msg.assign(region, offset, F::from(tx_type as u64), F::from(TxType::L1Msg as u64))?;
+        let code_hash = region.code_hash(code_hash);
+        self.caller_codehash.assign(region, offset, code_hash)?;
+        self.is_caller_empty.assign_value(region, offset, code_hash)?;
+
+        Ok(())
+    }
+
+    // return rw_delta WHEN tx is l1msg
+    pub(crate) fn rw_delta(&self) -> Expression<F> {
+        select::expr(
+            self.is_caller_empty.expr(),
+            if cfg!(feature = "scroll") {3.expr()} else {2.expr()},
+            1.expr()
+        )
+    }
+
+    pub(crate) fn is_l1_msg(&self) -> Expression<F> {
+        self.tx_is_l1msg.expr()
+    }
+
+}


### PR DESCRIPTION
Since there is no cost for caller in L1msg tx, it can pass tx precheck even the account caller is not existed before tx being executed. In this case, the account would be created and nonce added to 1.

This PR update `begin_tx` step with the behavior before for l1msg tx