### PR TITLE
refactor: remove keccak constants from aggregator

### DIFF
--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -50,8 +50,8 @@ pub(crate) const BITS: usize = 88;
 // TODO: update me(?)
 pub const MAX_AGG_SNARKS: usize = 10;
 
-// The number of keccak rounds is the sum of
-// - batch public input hash: 2 rounds
-// - chunk's public input hash: 2 * MAX_AGG_SNARKS
-// - batch data hash: (32 * MAX_AGG_SNARKS)/INPUT_LEN_PER_ROUND
-pub(crate) const MAX_KECCAK_ROUNDS: usize = 2 + 2 * MAX_AGG_SNARKS + (32 * MAX_AGG_SNARKS) / INPUT_LEN_PER_ROUND;
+/// The number of keccak rounds is the sum of
+/// - batch public input hash: 2 rounds
+/// - chunk's public input hash: 2 * MAX_AGG_SNARKS
+/// - batch data hash: (32 * MAX_AGG_SNARKS)/INPUT_LEN_PER_ROUND
+pub(crate) const MAX_KECCAK_ROUNDS: usize = 2 * (MAX_AGG_SNARKS + 1) + (32 * MAX_AGG_SNARKS) / INPUT_LEN_PER_ROUND;

--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -11,15 +11,6 @@ pub(crate) const DIGEST_LEN: usize = 32;
 /// Input length per round
 pub(crate) const INPUT_LEN_PER_ROUND: usize = 136;
 
-// Each round requires (NUM_ROUNDS+1) * DEFAULT_KECCAK_ROWS = 300 rows.
-// This library is hard coded for this parameter.
-// Modifying the following parameters may result into bugs.
-// Adopted from keccak circuit
-pub(crate) const DEFAULT_KECCAK_ROWS: usize = 12;
-// Adopted from keccak circuit
-pub(crate) const NUM_ROUNDS: usize = 24;
-pub(crate) const ROWS_PER_ROUND: usize = (NUM_ROUNDS + 1) * DEFAULT_KECCAK_ROWS;
-
 // TODO(ZZ): update to the right degree
 #[allow(dead_code)]
 pub(crate) const LOG_DEGREE: u32 = 19;
@@ -59,8 +50,8 @@ pub(crate) const BITS: usize = 88;
 // TODO: update me(?)
 pub const MAX_AGG_SNARKS: usize = 10;
 
-/// The number of keccak rounds is the sum of
-/// - batch public input hash: 2 rounds
-/// - chunk's public input hash: 2 * MAX_AGG_SNARKS
-/// - batch data hash: (32 * MAX_AGG_SNARKS)/136 = 3
-pub(crate) const MAX_KECCAK_ROUNDS: usize = 2 * MAX_AGG_SNARKS + 5;
+// The number of keccak rounds is the sum of
+// - batch public input hash: 2 rounds
+// - chunk's public input hash: 2 * MAX_AGG_SNARKS
+// - batch data hash: (32 * MAX_AGG_SNARKS)/INPUT_LEN_PER_ROUND
+pub(crate) const MAX_KECCAK_ROUNDS: usize = 2 + 2 * MAX_AGG_SNARKS + (32 * MAX_AGG_SNARKS) / INPUT_LEN_PER_ROUND;

--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -54,4 +54,6 @@ pub const MAX_AGG_SNARKS: usize = 10;
 /// - batch public input hash: 2 rounds
 /// - chunk's public input hash: 2 * MAX_AGG_SNARKS
 /// - batch data hash: (32 * MAX_AGG_SNARKS)/INPUT_LEN_PER_ROUND
-pub(crate) const MAX_KECCAK_ROUNDS: usize = 2 * (MAX_AGG_SNARKS + 1) + (32 * MAX_AGG_SNARKS) / INPUT_LEN_PER_ROUND;
+const DATA_HASH_ROUNDS: usize = (32 * MAX_AGG_SNARKS) / INPUT_LEN_PER_ROUND;
+const DATA_HASH_ROUNDS_PAD: usize = if INPUT_LEN_PER_ROUND * DATA_HASH_ROUNDS < 32 * MAX_AGG_SNARKS { 1 } else { 0 };
+pub(crate) const MAX_KECCAK_ROUNDS: usize = 2 * (MAX_AGG_SNARKS + 1) + DATA_HASH_ROUNDS + DATA_HASH_ROUNDS_PAD;

--- a/aggregator/src/tests/aggregation.rs
+++ b/aggregator/src/tests/aggregation.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::mock_chunk::MockChunkCircuit;
 
-#[ignore = "it takes too much time"]
+// #[ignore = "it takes too much time"]
 #[test]
 fn test_aggregation_circuit() {
     env_logger::init();

--- a/aggregator/src/tests/aggregation.rs
+++ b/aggregator/src/tests/aggregation.rs
@@ -13,6 +13,7 @@ use crate::{
 
 use super::mock_chunk::MockChunkCircuit;
 
+#[ignore = "it takes too much time"]
 #[test]
 fn test_aggregation_circuit() {
     env_logger::init();

--- a/aggregator/src/tests/rlc/dynamic_hashes.rs
+++ b/aggregator/src/tests/rlc/dynamic_hashes.rs
@@ -17,9 +17,16 @@ use zkevm_circuits::{
 
 use crate::{
     aggregation::RlcConfig,
-    constants::{LOG_DEGREE, ROWS_PER_ROUND},
-    util::keccak_round_capacity,
+    constants::LOG_DEGREE
+
+    // ROWS_PER_ROUND},
+    // util::keccak_round_capacity,
 };
+use zkevm_circuits::keccak_circuit::{
+    KeccakCircuit,
+    keccak_packed_multi::{get_num_rows_per_round, get_num_rows_per_update}
+};
+
 
 #[derive(Default, Debug, Clone)]
 struct DynamicHashCircuit {
@@ -95,7 +102,7 @@ impl Circuit<Fr> for DynamicHashCircuit {
         let witness = multi_keccak(
             &[hash_preimage.clone()],
             challenge,
-            keccak_round_capacity(1 << LOG_DEGREE),
+            KeccakCircuit::<Fr>::capacity_for_rows(1 << LOG_DEGREE),
         )
         .unwrap();
 
@@ -113,7 +120,7 @@ impl Circuit<Fr> for DynamicHashCircuit {
                         config
                             .keccak_circuit_config
                             .set_row(&mut region, offset, keccak_row)?;
-                    if offset % ROWS_PER_ROUND == 0 && data_rlc_cells.len() < 4 {
+                    if offset % get_num_rows_per_update() == 0 && data_rlc_cells.len() < 4 {
                         // second element is data rlc
                         data_rlc_cells.push(row[1].clone());
                     }

--- a/aggregator/src/tests/rlc/dynamic_hashes.rs
+++ b/aggregator/src/tests/rlc/dynamic_hashes.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use zkevm_circuits::keccak_circuit::{
     KeccakCircuit,
-    keccak_packed_multi::{get_num_rows_per_round, get_num_rows_per_update}
+    keccak_packed_multi::get_num_rows_per_update
 };
 
 
@@ -115,12 +115,13 @@ impl Circuit<Fr> for DynamicHashCircuit {
                 // keccak part
                 // ==============================
                 let mut data_rlc_cells = vec![];
+                let keccak_f_rows = get_num_rows_per_update();
                 for (offset, keccak_row) in witness.iter().enumerate() {
                     let row =
                         config
                             .keccak_circuit_config
                             .set_row(&mut region, offset, keccak_row)?;
-                    if offset % get_num_rows_per_update() == 0 && data_rlc_cells.len() < 4 {
+                    if offset % keccak_f_rows == 0 && data_rlc_cells.len() < 4 {
                         // second element is data rlc
                         data_rlc_cells.push(row[1].clone());
                     }

--- a/aggregator/src/tests/rlc/dynamic_hashes.rs
+++ b/aggregator/src/tests/rlc/dynamic_hashes.rs
@@ -14,19 +14,14 @@ use zkevm_circuits::{
     table::{KeccakTable, LookupTable},
     util::{Challenges, SubCircuitConfig},
 };
-
 use crate::{
     aggregation::RlcConfig,
     constants::LOG_DEGREE
-
-    // ROWS_PER_ROUND},
-    // util::keccak_round_capacity,
 };
 use zkevm_circuits::keccak_circuit::{
     KeccakCircuit,
     keccak_packed_multi::get_num_rows_per_update
 };
-
 
 #[derive(Default, Debug, Clone)]
 struct DynamicHashCircuit {

--- a/aggregator/src/util.rs
+++ b/aggregator/src/util.rs
@@ -16,8 +16,6 @@ use crate::{
     constants::{DIGEST_LEN, INPUT_LEN_PER_ROUND, MAX_AGG_SNARKS}
 };
 
-use std::env::var;
-
 /// Return
 /// - the indices of the rows that contain the input preimages
 /// - the indices of the rows that contain the output digest

--- a/aggregator/tests.sh
+++ b/aggregator/tests.sh
@@ -1,8 +1,10 @@
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_chunk_prover -- --nocapture 2>&1 | tee mock_chunk.log
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit -- --nocapture 2>&1 | tee mock_aggregation.log
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_compression -- --nocapture 2>&1 | tee compression.log
+RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_chunk_prover -- --nocapture 2>&1 | tee mock_chunk.log
+RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_compression -- --nocapture 2>&1 | tee compression.log
 
 # the following 3 tests takes super long time
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit -- --ignored --nocapture 2>&1 | tee aggregation.log
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_two_layer_proof_compression -- --ignored --nocapture 2>&1 | tee compression_2_layer.log
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_e2e -- --ignored --nocapture 2>&1 | tee aggregation_e2e.log
+RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit -- --nocapture 2>&1 | tee aggregation.log
+RUST_BACKTRACE=full RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit_full -- --nocapture 2>&1 | tee aggregation_full.log
+RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_two_layer_proof_compression -- --nocapture 2>&1 | tee compression_2_layer.log
+
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_aggregation -- --nocapture 2>&1 | tee mock_aggregation.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_e2e -- --nocapture 2>&1 | tee aggregation_e2e.log

--- a/aggregator/tests.sh
+++ b/aggregator/tests.sh
@@ -1,5 +1,5 @@
 # RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_chunk_prover -- --nocapture 2>&1 | tee mock_chunk.log
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_aggregation -- --nocapture 2>&1 | tee mock_aggregation.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit -- --nocapture 2>&1 | tee mock_aggregation.log
 # RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_compression -- --nocapture 2>&1 | tee compression.log
 
 # the following 3 tests takes super long time

--- a/aggregator/tests.sh
+++ b/aggregator/tests.sh
@@ -1,10 +1,8 @@
 RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_chunk_prover -- --nocapture 2>&1 | tee mock_chunk.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_aggregation -- --nocapture 2>&1 | tee mock_aggregation.log
 RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_compression -- --nocapture 2>&1 | tee compression.log
 
 # the following 3 tests takes super long time
-RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit -- --nocapture 2>&1 | tee aggregation.log
-RUST_BACKTRACE=full RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit_full -- --nocapture 2>&1 | tee aggregation_full.log
-RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_two_layer_proof_compression -- --nocapture 2>&1 | tee compression_2_layer.log
-
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_aggregation -- --nocapture 2>&1 | tee mock_aggregation.log
-# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_e2e -- --nocapture 2>&1 | tee aggregation_e2e.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit -- --ignored --nocapture 2>&1 | tee aggregation.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_two_layer_proof_compression -- --ignored --nocapture 2>&1 | tee compression_2_layer.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_e2e -- --ignored --nocapture 2>&1 | tee aggregation_e2e.log

--- a/aggregator/tests.sh
+++ b/aggregator/tests.sh
@@ -1,6 +1,6 @@
-RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_chunk_prover -- --nocapture 2>&1 | tee mock_chunk.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_chunk_prover -- --nocapture 2>&1 | tee mock_chunk.log
 # RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_aggregation -- --nocapture 2>&1 | tee mock_aggregation.log
-RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_compression -- --nocapture 2>&1 | tee compression.log
+# RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_mock_compression -- --nocapture 2>&1 | tee compression.log
 
 # the following 3 tests takes super long time
 # RUST_LOG=trace MODE=greeter cargo test --release --features=print-trace test_aggregation_circuit -- --ignored --nocapture 2>&1 | tee aggregation.log

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -34,7 +34,7 @@ use crate::{
         split, split_uniform, transform, transform_to, Part,
     },
     table::{KeccakTable, LookupTable},
-    util::{Challenges, SubCircuit, SubCircuitConfig},
+    util::{Challenges, SubCircuit, SubCircuitConfig, unusable_rows},
     witness,
 };
 use eth_types::Field;
@@ -1066,8 +1066,17 @@ impl<F: Field> KeccakCircuit<F> {
     /// The number of keccak_f's that can be done in this circuit
     pub fn capacity(&self) -> Option<usize> {
         if self.num_rows > 0 {
-            // Subtract two for unusable rows
-            Some(self.num_rows / ((NUM_ROUNDS + 1) * get_num_rows_per_round()) - 2)
+            Some((self.num_rows - keccak_unusable_rows()) / ((NUM_ROUNDS + 1) * get_num_rows_per_round()))
+        } else {
+            None
+        }
+    }
+
+     /// Class function. The number of keccak_f's that can be done in a circuit
+     /// with a certain number of rows
+     pub fn capacity_for_rows(num_rows: usize) -> Option<usize> {
+        if num_rows > 0 {
+            Some((num_rows - keccak_unusable_rows()) / ((NUM_ROUNDS + 1) * get_num_rows_per_round()))
         } else {
             None
         }

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -34,7 +34,7 @@ use crate::{
         split, split_uniform, transform, transform_to, Part,
     },
     table::{KeccakTable, LookupTable},
-    util::{Challenges, SubCircuit, SubCircuitConfig, unusable_rows},
+    util::{Challenges, SubCircuit, SubCircuitConfig},
     witness,
 };
 use eth_types::Field;

--- a/zkevm-circuits/src/keccak_circuit/keccak_packed_multi.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_packed_multi.rs
@@ -12,11 +12,19 @@ use std::{env::var, vec};
 
 const MAX_DEGREE: usize = 9;
 
-pub(crate) fn get_num_rows_per_round() -> usize {
+/// Obtain the rows required for 1 iteration of f-box's inner round
+/// function (consisting of 5 phases) within Keccak circuit
+pub fn get_num_rows_per_round() -> usize {
     var("KECCAK_ROWS")
         .unwrap_or_else(|_| format!("{DEFAULT_KECCAK_ROWS}"))
         .parse()
         .expect("Cannot parse KECCAK_ROWS env var as usize")
+}
+/// Obtain the rows required for 1 iteration of the f-box
+/// function (consisting of nr = 12 + 2*l inner rounds)
+/// within Keccak circuit
+pub fn get_num_rows_per_update() -> usize {
+    get_num_rows_per_round() *(NUM_ROUNDS + 1)
 }
 
 pub(crate) fn keccak_unusable_rows() -> usize {


### PR DESCRIPTION
### Description

This PR removes keccak constants from the aggregator and makes it agnostic to the internal parameters of the keccak circuit. 

### Issue Link

Closes #744 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
