### PR TITLE
`FpConfig` to be finalized in ECC circuit post each phase

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -65,6 +65,16 @@ pub struct PrecompileEcParams {
     pub ec_pairing: usize,
 }
 
+impl Default for PrecompileEcParams {
+    fn default() -> Self {
+        Self {
+            ec_add: 50,
+            ec_mul: 50,
+            ec_pairing: 2,
+        }
+    }
+}
+
 /// Circuit Setup Parameters
 #[derive(Debug, Clone, Copy)]
 pub struct CircuitsParams {
@@ -123,11 +133,7 @@ impl Default for CircuitsParams {
             max_evm_rows: 0,
             max_keccak_rows: 0,
             max_rlp_rows: 1000,
-            max_ec_ops: PrecompileEcParams {
-                ec_add: 50,
-                ec_mul: 50,
-                ec_pairing: 2,
-            },
+            max_ec_ops: PrecompileEcParams::default(),
         }
     }
 }

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
@@ -1,7 +1,8 @@
 use eth_types::{ToLittleEndian, U256};
 use halo2_proofs::halo2curves::{
-    bn256::{Fq, Fq2, G1Affine, G2Affine},
+    bn256::{multi_miller_loop, Fq, Fq2, G1Affine, G2Affine, Gt},
     group::cofactor::CofactorCurveAffine,
+    pairing::MillerLoopResult,
 };
 
 use crate::{
@@ -84,6 +85,7 @@ pub(crate) fn opt_data(
                 (ecc_circuit_pair, evm_circuit_pair)
             })
             .unzip();
+        // pad the pairs to make them of fixed size: N_PAIRING_PER_OP.
         ecc_pairs.resize(N_PAIRING_PER_OP, EcPairingPair::ecc_padding());
         evm_pairs.resize(N_PAIRING_PER_OP, EcPairingPair::evm_padding());
         (
@@ -111,6 +113,20 @@ pub(crate) fn opt_data(
             }),
         )
     };
+
+    debug_assert_eq!(
+        {
+            let gt = multi_miller_loop(&[
+                (&op.pairs[0].g1_point, &op.pairs[0].g2_point.into()),
+                (&op.pairs[1].g1_point, &op.pairs[1].g2_point.into()),
+                (&op.pairs[2].g1_point, &op.pairs[2].g2_point.into()),
+                (&op.pairs[3].g1_point, &op.pairs[3].g2_point.into()),
+            ]);
+            let gt = gt.final_exponentiation();
+            gt.eq(&Gt::identity()) as u8
+        },
+        pairing_check
+    );
 
     (
         Some(PrecompileEvent::EcPairing(Box::new(op))),

--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -44,10 +44,10 @@ mod test;
 mod util;
 use util::{
     EcAddAssigned, EcMulAssigned, EcOpsAssigned, EcPairingAssigned, G1Assigned, G1Decomposed,
-    G2Assigned, G2Decomposed, ScalarAssigned, ScalarDecomposed,
+    G2Assigned, G2Decomposed, ScalarAssigned,
 };
 
-use self::util::LOG_TOTAL_NUM_ROWS;
+use self::util::{EcAddDecomposed, EcMulDecomposed, EcPairingDecomposed, LOG_TOTAL_NUM_ROWS};
 
 macro_rules! log_context_cursor {
     ($ctx: ident) => {{
@@ -203,20 +203,19 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
 
                 let mut ctx = config.fp_config.new_context(region);
 
-                macro_rules! assign_ec_op {
-                    ($op_type:ident, $ops:expr, $n_ops:expr, $assign_fn:ident) => {
+                macro_rules! decompose_ec_op {
+                    ($op_type:ident, $ops:expr, $n_ops:expr, $decompose_fn:ident) => {
                         $ops.iter()
                             .filter(|op| !op.skip_by_ecc_circuit())
                             .chain(std::iter::repeat(&$op_type::default()))
                             .take($n_ops)
                             .map(|op| {
-                                self.$assign_fn(
+                                self.$decompose_fn(
                                     &mut ctx,
                                     &ecc_chip,
                                     &fr_chip,
                                     &pairing_chip,
                                     &fp12_chip,
-                                    &keccak_powers,
                                     &op,
                                 )
                             })
@@ -224,21 +223,42 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
                     };
                 }
 
+                macro_rules! assign_ec_op {
+                    ($decomposed_ops:expr, $assign_fn:ident) => {
+                        $decomposed_ops
+                            .iter()
+                            .map(|decomposed_op| {
+                                self.$assign_fn(&mut ctx, decomposed_op, &ecc_chip, &keccak_powers)
+                            })
+                            .collect_vec()
+                    };
+                }
+
                 // P + Q == R
-                let ec_adds_assigned =
-                    assign_ec_op!(EcAddOp, self.add_ops, self.max_add_ops, assign_ec_add_op);
+                let ec_adds_decomposed =
+                    decompose_ec_op!(EcAddOp, self.add_ops, self.max_add_ops, decompose_ec_add_op);
 
                 // s.P = R
-                let ec_muls_assigned =
-                    assign_ec_op!(EcMulOp, self.mul_ops, self.max_mul_ops, assign_ec_mul_op);
+                let ec_muls_decomposed =
+                    decompose_ec_op!(EcMulOp, self.mul_ops, self.max_mul_ops, decompose_ec_mul_op);
 
                 // e(G1 . G2) * ... * e(G1 . G2) -> Gt
-                let ec_pairings_assigned = assign_ec_op!(
+                let ec_pairings_decomposed = decompose_ec_op!(
                     EcPairingOp,
                     self.pairing_ops,
                     self.max_pairing_ops,
-                    assign_ec_pairing_op
+                    decompose_ec_pairing_op
                 );
+
+                // finalize after first phase.
+                config.fp_config.finalize(&mut ctx);
+
+                let ec_adds_assigned = assign_ec_op!(ec_adds_decomposed, assign_ec_add);
+                let ec_muls_assigned = assign_ec_op!(ec_muls_decomposed, assign_ec_mul);
+                let ec_pairings_assigned = assign_ec_op!(ec_pairings_decomposed, assign_ec_pairing);
+
+                // finalize after second phase (RLC).
+                config.fp_config.finalize(&mut ctx);
 
                 Ok(EcOpsAssigned {
                     ec_adds_assigned,
@@ -326,12 +346,11 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
                         idx,
                     );
                     // Scalar s
-                    ec_mul_assigned
-                        .scalar_s
-                        .decomposed
-                        .scalar
-                        .native
-                        .copy_advice(&mut region, config.ecc_table.arg3_rlc, idx);
+                    ec_mul_assigned.scalar_s.scalar.native.copy_advice(
+                        &mut region,
+                        config.ecc_table.arg3_rlc,
+                        idx,
+                    );
                     // R_x
                     ec_mul_assigned.point_r.x_rlc.copy_advice(
                         &mut region,
@@ -402,23 +421,164 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         Ok(())
     }
 
+    fn assign_ec_add(
+        &self,
+        ctx: &mut Context<F>,
+        ec_add_decomposed: &EcAddDecomposed<F>,
+        ecc_chip: &EccChip<F, FpConfig<F, Fq>>,
+        keccak_powers: &[QuantumCell<F>],
+    ) -> EcAddAssigned<F> {
+        EcAddAssigned {
+            point_p: G1Assigned {
+                x_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_add_decomposed.point_p.x_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+                y_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_add_decomposed.point_p.y_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+            },
+            point_q: G1Assigned {
+                x_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_add_decomposed.point_q.x_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+                y_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_add_decomposed.point_q.y_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+            },
+            point_r: G1Assigned {
+                x_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_add_decomposed.point_r.x_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+                y_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_add_decomposed.point_r.y_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+            },
+        }
+    }
+
+    fn assign_ec_mul(
+        &self,
+        ctx: &mut Context<F>,
+        ec_mul_decomposed: &EcMulDecomposed<F>,
+        ecc_chip: &EccChip<F, FpConfig<F, Fq>>,
+        keccak_powers: &[QuantumCell<F>],
+    ) -> EcMulAssigned<F> {
+        EcMulAssigned {
+            point_p: G1Assigned {
+                x_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_mul_decomposed.point_p.x_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+                y_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_mul_decomposed.point_p.y_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+            },
+            scalar_s: ec_mul_decomposed.scalar_s.clone(),
+            point_r: G1Assigned {
+                x_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_mul_decomposed.point_r.x_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+                y_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                    ctx,
+                    ec_mul_decomposed.point_r.y_cells.clone(),
+                    keccak_powers.iter().cloned(),
+                ),
+            },
+        }
+    }
+
+    fn assign_ec_pairing(
+        &self,
+        ctx: &mut Context<F>,
+        ec_pairing_decomposed: &EcPairingDecomposed<F>,
+        ecc_chip: &EccChip<F, FpConfig<F, Fq>>,
+        keccak_powers: &[QuantumCell<F>],
+    ) -> EcPairingAssigned<F> {
+        EcPairingAssigned {
+            g1s: ec_pairing_decomposed
+                .g1s
+                .iter()
+                .map(|g1_decomposed| G1Assigned {
+                    x_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                        ctx,
+                        g1_decomposed.x_cells.clone(),
+                        keccak_powers.iter().cloned(),
+                    ),
+                    y_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                        ctx,
+                        g1_decomposed.y_cells.clone(),
+                        keccak_powers.iter().cloned(),
+                    ),
+                })
+                .collect_vec(),
+            g2s: ec_pairing_decomposed
+                .g2s
+                .iter()
+                .map(|g2_decomposed| G2Assigned {
+                    x_c0_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                        ctx,
+                        g2_decomposed.x_c0_cells.clone(),
+                        keccak_powers.iter().cloned(),
+                    ),
+                    x_c1_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                        ctx,
+                        g2_decomposed.x_c1_cells.clone(),
+                        keccak_powers.iter().cloned(),
+                    ),
+                    y_c0_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                        ctx,
+                        g2_decomposed.y_c0_cells.clone(),
+                        keccak_powers.iter().cloned(),
+                    ),
+                    y_c1_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                        ctx,
+                        g2_decomposed.y_c1_cells.clone(),
+                        keccak_powers.iter().cloned(),
+                    ),
+                })
+                .collect_vec(),
+            input_rlc: ecc_chip.field_chip().range().gate().inner_product(
+                ctx,
+                ec_pairing_decomposed.input_cells.clone().into_iter().rev(),
+                keccak_powers.iter().cloned(),
+            ),
+            success: ec_pairing_decomposed.success,
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
-    fn assign_ec_add_op(
+    fn decompose_ec_add_op(
         &self,
         ctx: &mut Context<F>,
         ecc_chip: &EccChip<F, FpConfig<F, Fq>>,
         _fr_chip: &FpConfig<F, Fr>,
         _pairing_chip: &PairingChip<F>,
         _fp12_chip: &Fp12Chip<F, FpConfig<F, Fq>, Fq12, XI_0>,
-        powers_of_rand: &[QuantumCell<F>],
         op: &EcAddOp,
-    ) -> EcAddAssigned<F> {
+    ) -> EcAddDecomposed<F> {
         log::trace!("[ECC] ==> EcAdd Assignmnet START:");
         log_context_cursor!(ctx);
 
-        let point_p = self.assign_g1(ctx, ecc_chip, op.p, powers_of_rand);
-        let point_q = self.assign_g1(ctx, ecc_chip, op.q, powers_of_rand);
-        let point_r = self.assign_g1(ctx, ecc_chip, op.r, powers_of_rand);
+        let point_p = self.assign_g1(ctx, ecc_chip, op.p);
+        let point_q = self.assign_g1(ctx, ecc_chip, op.q);
+        let point_r = self.assign_g1(ctx, ecc_chip, op.r);
 
         log::trace!("[ECC] EcAdd Inputs Assigned:");
         log_context_cursor!(ctx);
@@ -438,24 +598,12 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         let rand_point = ecc_chip.load_random_point::<G1Affine>(ctx);
 
         // check if P == (0, 0), Q == (0, 0), R == (0, 0)
-        let p_x_is_zero = ecc_chip
-            .field_chip
-            .is_zero(ctx, &point_p.decomposed.ec_point.x);
-        let p_y_is_zero = ecc_chip
-            .field_chip
-            .is_zero(ctx, &point_p.decomposed.ec_point.y);
-        let q_x_is_zero = ecc_chip
-            .field_chip
-            .is_zero(ctx, &point_q.decomposed.ec_point.x);
-        let q_y_is_zero = ecc_chip
-            .field_chip
-            .is_zero(ctx, &point_q.decomposed.ec_point.y);
-        let r_x_is_zero = ecc_chip
-            .field_chip
-            .is_zero(ctx, &point_r.decomposed.ec_point.x);
-        let r_y_is_zero = ecc_chip
-            .field_chip
-            .is_zero(ctx, &point_r.decomposed.ec_point.y);
+        let p_x_is_zero = ecc_chip.field_chip.is_zero(ctx, &point_p.ec_point.x);
+        let p_y_is_zero = ecc_chip.field_chip.is_zero(ctx, &point_p.ec_point.y);
+        let q_x_is_zero = ecc_chip.field_chip.is_zero(ctx, &point_q.ec_point.x);
+        let q_y_is_zero = ecc_chip.field_chip.is_zero(ctx, &point_q.ec_point.y);
+        let r_x_is_zero = ecc_chip.field_chip.is_zero(ctx, &point_r.ec_point.x);
+        let r_y_is_zero = ecc_chip.field_chip.is_zero(ctx, &point_r.ec_point.y);
         let point_p_is_zero = ecc_chip.field_chip.range().gate().and(
             ctx,
             QuantumCell::Existing(p_x_is_zero),
@@ -473,22 +621,22 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         );
 
         // sum1 = if P == (0, 0) then r else r + P
-        let sum1 = ecc_chip.add_unequal(ctx, &rand_point, &point_p.decomposed.ec_point, true);
+        let sum1 = ecc_chip.add_unequal(ctx, &rand_point, &point_p.ec_point, true);
         let sum1 = ecc_chip.select(ctx, &rand_point, &sum1, &point_p_is_zero);
 
         // sum2 = if Q == (0, 0) then sum1 else sum1 + Q
-        let sum2 = ecc_chip.add_unequal(ctx, &sum1, &point_q.decomposed.ec_point, true);
+        let sum2 = ecc_chip.add_unequal(ctx, &sum1, &point_q.ec_point, true);
         let sum2 = ecc_chip.select(ctx, &sum1, &sum2, &point_q_is_zero);
 
         // sum3 = if R == (0, 0) then sum2 else sum2 - R
-        let sum3 = ecc_chip.sub_unequal(ctx, &sum2, &point_r.decomposed.ec_point, true);
+        let sum3 = ecc_chip.sub_unequal(ctx, &sum2, &point_r.ec_point, true);
         let sum3 = ecc_chip.select(ctx, &sum2, &sum3, &point_r_is_zero);
 
         ecc_chip.assert_equal(ctx, &rand_point, &sum3);
 
         log::trace!("[ECC] EcAdd Assignmnet END:");
         log_context_cursor!(ctx);
-        EcAddAssigned {
+        EcAddDecomposed {
             point_p,
             point_q,
             point_r,
@@ -496,39 +644,38 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn assign_ec_mul_op(
+    fn decompose_ec_mul_op(
         &self,
         ctx: &mut Context<F>,
         ecc_chip: &EccChip<F, FpConfig<F, Fq>>,
         fr_chip: &FpConfig<F, Fr>,
         _pairing_chip: &PairingChip<F>,
         _fp12_chip: &Fp12Chip<F, FpConfig<F, Fq>, Fq12, XI_0>,
-        powers_of_rand: &[QuantumCell<F>],
         op: &EcMulOp,
-    ) -> EcMulAssigned<F> {
+    ) -> EcMulDecomposed<F> {
         log::trace!("[ECC] ==> EcMul Assignmnet START:");
         log_context_cursor!(ctx);
 
-        let point_p = self.assign_g1(ctx, ecc_chip, op.p, powers_of_rand);
+        let point_p = self.assign_g1(ctx, ecc_chip, op.p);
         let scalar_s = self.assign_fr(ctx, fr_chip, op.s);
-        let point_r = self.assign_g1(ctx, ecc_chip, op.r, powers_of_rand);
+        let point_r = self.assign_g1(ctx, ecc_chip, op.r);
 
         log::trace!("[ECC] EcMul Inputs Assigned:");
         log_context_cursor!(ctx);
 
         let point_r_got = ecc_chip.scalar_mult(
             ctx,
-            &point_p.decomposed.ec_point,
-            &scalar_s.decomposed.scalar.limbs().to_vec(),
+            &point_p.ec_point,
+            &scalar_s.scalar.limbs().to_vec(),
             fr_chip.limb_bits,
             4, // TODO: window bits?
         );
-        ecc_chip.assert_equal(ctx, &point_r.decomposed.ec_point, &point_r_got);
+        ecc_chip.assert_equal(ctx, &point_r.ec_point, &point_r_got);
 
         log::trace!("[ECC] EcMul Assignmnet END:");
         log_context_cursor!(ctx);
 
-        EcMulAssigned {
+        EcMulDecomposed {
             point_p,
             scalar_s,
             point_r,
@@ -536,16 +683,15 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn assign_ec_pairing_op(
+    fn decompose_ec_pairing_op(
         &self,
         ctx: &mut Context<F>,
         ecc_chip: &EccChip<F, FpConfig<F, Fq>>,
         _fr_chip: &FpConfig<F, Fr>,
         pairing_chip: &PairingChip<F>,
         fp12_chip: &Fp12Chip<F, FpConfig<F, Fq>, Fq12, XI_0>,
-        powers_of_rand: &[QuantumCell<F>],
         op: &EcPairingOp,
-    ) -> EcPairingAssigned<F> {
+    ) -> EcPairingDecomposed<F> {
         log::trace!("[ECC] ==> EcPairing Assignment START:");
         log_context_cursor!(ctx);
 
@@ -554,23 +700,10 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
             .iter()
             .map(|pair| {
                 let (x_cells, y_cells) = self.decompose_g1(pair.g1_point);
-                let decomposed = G1Decomposed {
+                G1Decomposed {
                     ec_point: pairing_chip.load_private_g1(ctx, Value::known(pair.g1_point)),
-                    x_cells: x_cells.clone(),
-                    y_cells: y_cells.clone(),
-                };
-                G1Assigned {
-                    decomposed,
-                    x_rlc: ecc_chip.field_chip().range().gate().inner_product(
-                        ctx,
-                        x_cells,
-                        powers_of_rand.iter().cloned(),
-                    ),
-                    y_rlc: ecc_chip.field_chip().range().gate().inner_product(
-                        ctx,
-                        y_cells,
-                        powers_of_rand.iter().cloned(),
-                    ),
+                    x_cells,
+                    y_cells,
                 }
             })
             .collect_vec();
@@ -584,35 +717,12 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
             .map(|pair| {
                 let [x_c0_cells, x_c1_cells, y_c0_cells, y_c1_cells] =
                     self.decompose_g2(pair.g2_point);
-                let decomposed = G2Decomposed {
+                G2Decomposed {
                     ec_point: pairing_chip.load_private_g2(ctx, Value::known(pair.g2_point)),
-                    x_c0_cells: x_c0_cells.clone(),
-                    x_c1_cells: x_c1_cells.clone(),
-                    y_c0_cells: y_c0_cells.clone(),
-                    y_c1_cells: y_c1_cells.clone(),
-                };
-                G2Assigned {
-                    decomposed,
-                    x_c0_rlc: ecc_chip.field_chip().range().gate().inner_product(
-                        ctx,
-                        x_c0_cells,
-                        powers_of_rand.iter().cloned(),
-                    ),
-                    x_c1_rlc: ecc_chip.field_chip().range().gate().inner_product(
-                        ctx,
-                        x_c1_cells,
-                        powers_of_rand.iter().cloned(),
-                    ),
-                    y_c0_rlc: ecc_chip.field_chip().range().gate().inner_product(
-                        ctx,
-                        y_c0_cells,
-                        powers_of_rand.iter().cloned(),
-                    ),
-                    y_c1_rlc: ecc_chip.field_chip().range().gate().inner_product(
-                        ctx,
-                        y_c1_cells,
-                        powers_of_rand.iter().cloned(),
-                    ),
+                    x_c0_cells,
+                    x_c1_cells,
+                    y_c0_cells,
+                    y_c1_cells,
                 }
             })
             .collect_vec();
@@ -626,21 +736,16 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
             .zip_eq(g2s.iter())
             .flat_map(|(g1, g2)| {
                 std::iter::empty()
-                    .chain(g1.decomposed.x_cells.iter().rev())
-                    .chain(g1.decomposed.y_cells.iter().rev())
-                    .chain(g2.decomposed.x_c1_cells.iter().rev())
-                    .chain(g2.decomposed.x_c0_cells.iter().rev())
-                    .chain(g2.decomposed.y_c1_cells.iter().rev())
-                    .chain(g2.decomposed.y_c0_cells.iter().rev())
+                    .chain(g1.x_cells.iter().rev())
+                    .chain(g1.y_cells.iter().rev())
+                    .chain(g2.x_c1_cells.iter().rev())
+                    .chain(g2.x_c0_cells.iter().rev())
+                    .chain(g2.y_c1_cells.iter().rev())
+                    .chain(g2.y_c0_cells.iter().rev())
                     .cloned()
                     .collect::<Vec<QuantumCell<F>>>()
             })
             .collect::<Vec<QuantumCell<F>>>();
-        let input_rlc = ecc_chip.field_chip().range().gate().inner_product(
-            ctx,
-            input_cells.into_iter().rev(),
-            powers_of_rand.iter().cloned(),
-        );
 
         log::trace!("[ECC] EcPairing Inputs RLC Assigned:");
         log_context_cursor!(ctx);
@@ -648,7 +753,7 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         let pairs = g1s
             .iter()
             .zip(g2s.iter())
-            .map(|(g1, g2)| (&g1.decomposed.ec_point, &g2.decomposed.ec_point))
+            .map(|(g1, g2)| (&g1.ec_point, &g2.ec_point))
             .collect_vec();
 
         let success = {
@@ -674,10 +779,10 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         log::trace!("[ECC] EcPairingAssignment END:");
         log_context_cursor!(ctx);
 
-        EcPairingAssigned {
+        EcPairingDecomposed {
             g1s,
             g2s,
-            input_rlc,
+            input_cells,
             success,
         }
     }
@@ -687,27 +792,13 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         ctx: &mut Context<F>,
         fp_chip: &EccChip<F, FpConfig<F, Fq>>,
         g1: G1Affine,
-        powers_of_rand: &[QuantumCell<F>],
-    ) -> G1Assigned<F> {
+    ) -> G1Decomposed<F> {
         let ec_point = fp_chip.load_private(ctx, (Value::known(g1.x), Value::known(g1.y)));
         let (x_cells, y_cells) = self.decompose_g1(g1);
-        let decomposed = G1Decomposed {
+        G1Decomposed {
             ec_point,
-            x_cells: x_cells.clone(),
-            y_cells: x_cells.clone(),
-        };
-        G1Assigned {
-            decomposed,
-            x_rlc: fp_chip.field_chip().range.gate.inner_product(
-                ctx,
-                x_cells,
-                powers_of_rand.iter().cloned(),
-            ),
-            y_rlc: fp_chip.field_chip().range.gate.inner_product(
-                ctx,
-                y_cells,
-                powers_of_rand.iter().cloned(),
-            ),
+            x_cells,
+            y_cells,
         }
     }
 
@@ -756,8 +847,7 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         s: Fr,
     ) -> ScalarAssigned<F> {
         let scalar = fr_chip.load_private(ctx, FpConfig::<F, Fr>::fe_to_witness(&Value::known(s)));
-        let decomposed = ScalarDecomposed { scalar };
-        ScalarAssigned { decomposed }
+        ScalarAssigned { scalar }
     }
 }
 

--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -267,11 +267,10 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
                 let ec_muls_assigned = assign_ec_op!(ec_muls_decomposed, assign_ec_mul);
                 let ec_pairings_assigned = assign_ec_op!(ec_pairings_decomposed, assign_ec_pairing);
 
-                #[cfg(not(feature = "onephase"))]
-                {
-                    // finalize after second phase (RLC).
-                    config.fp_config.finalize(&mut ctx);
-                }
+                // Finalize the Fp config always at the end of assignment.
+                let lookup_cells = config.fp_config.finalize(&mut ctx);
+                log::info!("total number of lookup cells: {}", lookup_cells);
+                ctx.print_stats(&["EccCircuit: FpConfig context"]);
 
                 Ok(EcOpsAssigned {
                     ec_adds_assigned,

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -48,7 +48,7 @@ fn run<F: Field, const MUST_FAIL: bool>(
 trait GenRand {
     fn gen_rand<R: RngCore + CryptoRng>(r: &mut R) -> Self;
 
-    fn gen_rang_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self;
+    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self;
 }
 
 impl GenRand for EcAddOp {
@@ -59,7 +59,7 @@ impl GenRand for EcAddOp {
         Self { p, q, r }
     }
 
-    fn gen_rang_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
+    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
         let valid = Self::gen_rand(r);
         Self {
             p: valid.p,
@@ -77,7 +77,7 @@ impl GenRand for EcMulOp {
         Self { p, s, r }
     }
 
-    fn gen_rang_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
+    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
         let valid = Self::gen_rand(r);
         Self {
             p: valid.p,
@@ -115,7 +115,7 @@ impl GenRand for EcPairingOp {
         }
     }
 
-    fn gen_rang_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
+    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
         let mut valid = Self::gen_rand(r);
         match r.gen::<bool>() {
             // change output.
@@ -146,7 +146,7 @@ fn gen<T: GenRand, R: RngCore + CryptoRng>(mut r: &mut R, max_len: usize) -> Vec
 fn gen_neg<T: GenRand, R: RngCore + CryptoRng>(mut r: &mut R, max_len: usize) -> Vec<T> {
     std::iter::repeat(0)
         .take(max_len)
-        .map(move |_| T::gen_rang_neg(&mut r))
+        .map(move |_| T::gen_rand_neg(&mut r))
         .collect()
 }
 #[test]

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -46,49 +46,37 @@ fn run<F: Field, const MUST_FAIL: bool>(
 }
 
 trait GenRand {
-    fn gen_rand<R: RngCore + CryptoRng>(r: &mut R) -> Self;
-
-    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self;
+    fn gen_rand<R: RngCore + CryptoRng>(r: &mut R, is_neg: bool) -> Self;
 }
 
 impl GenRand for EcAddOp {
-    fn gen_rand<R: RngCore + CryptoRng>(mut r: &mut R) -> Self {
+    fn gen_rand<R: RngCore + CryptoRng>(mut r: &mut R, is_neg: bool) -> Self {
         let p = G1Affine::random(&mut r);
         let q = G1Affine::random(&mut r);
-        let r = p.add(&q).into();
+        let r = if is_neg {
+            G1Affine::random(&mut r)
+        } else {
+            p.add(&q).into()
+        };
         Self { p, q, r }
-    }
-
-    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
-        let valid = Self::gen_rand(r);
-        Self {
-            p: valid.p,
-            q: valid.q,
-            r: valid.r.add(&G1Affine::generator()).into(),
-        }
     }
 }
 
 impl GenRand for EcMulOp {
-    fn gen_rand<R: RngCore + CryptoRng>(mut r: &mut R) -> Self {
+    fn gen_rand<R: RngCore + CryptoRng>(mut r: &mut R, is_neg: bool) -> Self {
         let p = G1Affine::random(&mut r);
         let s = <Fr as halo2_proofs::arithmetic::Field>::random(&mut r);
-        let r = p.mul(&s).into();
+        let r = if is_neg {
+            G1Affine::random(&mut r)
+        } else {
+            p.mul(&s).into()
+        };
         Self { p, s, r }
-    }
-
-    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
-        let valid = Self::gen_rand(r);
-        Self {
-            p: valid.p,
-            s: valid.s,
-            r: valid.r.add(&G1Affine::generator()).into(),
-        }
     }
 }
 
 impl GenRand for EcPairingOp {
-    fn gen_rand<R: RngCore + CryptoRng>(mut r: &mut R) -> Self {
+    fn gen_rand<R: RngCore + CryptoRng>(mut r: &mut R, is_neg: bool) -> Self {
         let alpha = Fr::random(&mut r);
         let beta = Fr::random(&mut r);
         let point_p = G1Affine::from(G1Affine::generator() * alpha);
@@ -104,51 +92,41 @@ impl GenRand for EcPairingOp {
         let point_b = G2Affine::from(G2Affine::generator() * beta);
         let point_c = G1Affine::from(G1Affine::generator() * alpha * beta);
         let point_d = G2Affine::generator();
-        Self {
-            pairs: [
-                EcPairingPair::new(point_p_negated, point_q),
-                EcPairingPair::new(point_s, point_t),
-                EcPairingPair::new(point_a_negated, point_b),
-                EcPairingPair::new(point_c, point_d),
-            ],
-            output: eth_types::U256::one(),
-        }
-    }
 
-    fn gen_rand_neg<R: RngCore + CryptoRng>(r: &mut R) -> Self {
-        let mut valid = Self::gen_rand(r);
-        match r.gen::<bool>() {
-            // change output.
-            true => Self {
-                pairs: valid.pairs,
-                output: eth_types::U256::one() - valid.output,
-            },
-            // change a point in one of the pairs.
-            false => {
-                valid.pairs[0].g1_point =
-                    valid.pairs[0].g1_point.add(&G1Affine::generator()).into();
-                Self {
-                    pairs: valid.pairs,
-                    output: valid.output,
+        let mut pairs = [
+            EcPairingPair::new(point_p_negated, point_q),
+            EcPairingPair::new(point_s, point_t),
+            EcPairingPair::new(point_a_negated, point_b),
+            EcPairingPair::new(point_c, point_d),
+        ];
+        let output = eth_types::U256::one();
+
+        if is_neg {
+            match r.gen::<bool>() {
+                // change output.
+                true => Self {
+                    pairs,
+                    output: eth_types::U256::one() - output,
+                },
+                // change a point in one of the pairs.
+                false => {
+                    pairs[0].g1_point = pairs[0].g1_point.add(&G1Affine::generator()).into();
+                    Self { pairs, output }
                 }
             }
+        } else {
+            Self { pairs, output }
         }
     }
 }
 
-fn gen<T: GenRand, R: RngCore + CryptoRng>(mut r: &mut R, max_len: usize) -> Vec<T> {
+fn gen<T: GenRand, R: RngCore + CryptoRng>(mut r: &mut R, max_len: usize, is_neg: bool) -> Vec<T> {
     std::iter::repeat(0)
         .take(max_len)
-        .map(move |_| T::gen_rand(&mut r))
+        .map(move |_| T::gen_rand(&mut r, is_neg))
         .collect()
 }
 
-fn gen_neg<T: GenRand, R: RngCore + CryptoRng>(mut r: &mut R, max_len: usize) -> Vec<T> {
-    std::iter::repeat(0)
-        .take(max_len)
-        .map(move |_| T::gen_rand_neg(&mut r))
-        .collect()
-}
 #[test]
 fn test_ecc_circuit_positive() {
     use crate::ecc_circuit::util::LOG_TOTAL_NUM_ROWS;
@@ -159,9 +137,9 @@ fn test_ecc_circuit_positive() {
     run::<Fr, false>(
         LOG_TOTAL_NUM_ROWS,
         PrecompileEcParams::default(),
-        gen(&mut rng, 9),
-        gen(&mut rng, 9),
-        gen(&mut rng, 1),
+        gen(&mut rng, 9, false),
+        gen(&mut rng, 9, false),
+        gen(&mut rng, 1, false),
     )
 }
 
@@ -175,9 +153,9 @@ fn test_ecc_circuit_negative() {
     run::<Fr, true>(
         LOG_TOTAL_NUM_ROWS,
         PrecompileEcParams::default(),
-        gen_neg(&mut rng, 9),
-        gen_neg(&mut rng, 9),
-        gen_neg(&mut rng, 1),
+        gen(&mut rng, 9, true),
+        gen(&mut rng, 9, true),
+        gen(&mut rng, 1, true),
     )
 }
 
@@ -194,9 +172,9 @@ fn variadic_size_check() {
         max_add_ops: default_params.ec_add,
         max_mul_ops: default_params.ec_mul,
         max_pairing_ops: default_params.ec_pairing,
-        add_ops: gen(&mut rng, 25),
-        mul_ops: gen(&mut rng, 20),
-        pairing_ops: gen(&mut rng, 2),
+        add_ops: gen(&mut rng, 25, false),
+        mul_ops: gen(&mut rng, 20, false),
+        pairing_ops: gen(&mut rng, 2, false),
         _marker: PhantomData,
     };
     let prover1 = MockProver::<Fr>::run(LOG_TOTAL_NUM_ROWS, &circuit, vec![]).unwrap();
@@ -205,9 +183,9 @@ fn variadic_size_check() {
         max_add_ops: default_params.ec_add,
         max_mul_ops: default_params.ec_mul,
         max_pairing_ops: default_params.ec_pairing,
-        add_ops: gen(&mut rng, 20),
-        mul_ops: gen(&mut rng, 15),
-        pairing_ops: gen(&mut rng, 1),
+        add_ops: gen(&mut rng, 20, false),
+        mul_ops: gen(&mut rng, 15, false),
+        pairing_ops: gen(&mut rng, 1, false),
         _marker: PhantomData,
     };
     let prover2 = MockProver::<Fr>::run(LOG_TOTAL_NUM_ROWS, &circuit, vec![]).unwrap();

--- a/zkevm-circuits/src/ecc_circuit/util.rs
+++ b/zkevm-circuits/src/ecc_circuit/util.rs
@@ -19,17 +19,13 @@ pub struct G1Decomposed<F: Field> {
 }
 
 pub struct G1Assigned<F: Field> {
-    pub decomposed: G1Decomposed<F>,
     pub x_rlc: AssignedValue<F>,
     pub y_rlc: AssignedValue<F>,
 }
 
-pub struct ScalarDecomposed<F: Field> {
-    pub scalar: CRTInteger<F>,
-}
-
+#[derive(Clone)]
 pub struct ScalarAssigned<F: Field> {
-    pub decomposed: ScalarDecomposed<F>,
+    pub scalar: CRTInteger<F>,
 }
 
 pub struct G2Decomposed<F: Field> {
@@ -41,11 +37,16 @@ pub struct G2Decomposed<F: Field> {
 }
 
 pub struct G2Assigned<F: Field> {
-    pub decomposed: G2Decomposed<F>,
     pub x_c0_rlc: AssignedValue<F>,
     pub x_c1_rlc: AssignedValue<F>,
     pub y_c0_rlc: AssignedValue<F>,
     pub y_c1_rlc: AssignedValue<F>,
+}
+
+pub struct EcAddDecomposed<F: Field> {
+    pub point_p: G1Decomposed<F>,
+    pub point_q: G1Decomposed<F>,
+    pub point_r: G1Decomposed<F>,
 }
 
 pub struct EcAddAssigned<F: Field> {
@@ -54,10 +55,23 @@ pub struct EcAddAssigned<F: Field> {
     pub point_r: G1Assigned<F>,
 }
 
+pub struct EcMulDecomposed<F: Field> {
+    pub point_p: G1Decomposed<F>,
+    pub scalar_s: ScalarAssigned<F>,
+    pub point_r: G1Decomposed<F>,
+}
+
 pub struct EcMulAssigned<F: Field> {
     pub point_p: G1Assigned<F>,
     pub scalar_s: ScalarAssigned<F>,
     pub point_r: G1Assigned<F>,
+}
+
+pub struct EcPairingDecomposed<F: Field> {
+    pub g1s: Vec<G1Decomposed<F>>,
+    pub g2s: Vec<G2Decomposed<F>>,
+    pub input_cells: Vec<QuantumCell<F>>,
+    pub success: AssignedValue<F>,
 }
 
 pub struct EcPairingAssigned<F: Field> {

--- a/zkevm-circuits/src/ecc_circuit/util.rs
+++ b/zkevm-circuits/src/ecc_circuit/util.rs
@@ -12,77 +12,89 @@ pub(super) const EC_MUL_CELLS: usize = 405_500; // actual: 405_476
 pub(super) const EC_PAIRING_CELLS: usize = 6_627_500; // actual: 6_627_442
 pub(super) const COLUMN_NUM_LIMIT: usize = 150; // Max number of columns allowed
 
-pub struct G1Decomposed<F: Field> {
+/// Decomposed state of a G1 curve point.
+pub(super) struct G1Decomposed<F: Field> {
+    /// The assigned EcPoint.
     pub ec_point: EcPoint<F, CRTInteger<F>>,
+    /// Cells for the x-coordinate of the G1 curve point in LE format.
     pub x_cells: Vec<QuantumCell<F>>,
+    /// Cells for the y-coordinate of the G1 curve point in LE format.
     pub y_cells: Vec<QuantumCell<F>>,
 }
 
-pub struct G1Assigned<F: Field> {
+/// State of the G1 curve point after RLC operations.
+pub(super) struct G1Assigned<F: Field> {
+    /// RLC of x-coordinate that will be copied to the ECC Table.
     pub x_rlc: AssignedValue<F>,
+    /// RLC of y-coordinate that will be copied to the ECC Table.
     pub y_rlc: AssignedValue<F>,
 }
 
+/// State of a scalar field element. Since the scalar fits within the field, we don't need to take
+/// RLC over its bytes/cells. Hence we can decompose and assign the scalar in the first phase.
 #[derive(Clone)]
-pub struct ScalarAssigned<F: Field> {
+pub(super) struct ScalarAssigned<F: Field> {
     pub scalar: CRTInteger<F>,
 }
 
-pub struct G2Decomposed<F: Field> {
+/// Decomposed state of a G2 curve point.
+pub(super) struct G2Decomposed<F: Field> {
+    /// The assigned EcPoint.
     pub ec_point: EcPoint<F, FieldExtPoint<CRTInteger<F>>>,
+    /// Cells for the coeff 0 of x-coordinate of the G2 curve point in LE format.
     pub x_c0_cells: Vec<QuantumCell<F>>,
+    /// Cells for the coeff 1 of x-coordinate of the G2 curve point in LE format.
     pub x_c1_cells: Vec<QuantumCell<F>>,
+    /// Cells for the coeff 0 of y-coordinate of the G2 curve point in LE format.
     pub y_c0_cells: Vec<QuantumCell<F>>,
+    /// Cells for the coeff 1 of y-coordinate of the G2 curve point in LE format.
     pub y_c1_cells: Vec<QuantumCell<F>>,
 }
 
-pub struct G2Assigned<F: Field> {
-    pub x_c0_rlc: AssignedValue<F>,
-    pub x_c1_rlc: AssignedValue<F>,
-    pub y_c0_rlc: AssignedValue<F>,
-    pub y_c1_rlc: AssignedValue<F>,
-}
-
-pub struct EcAddDecomposed<F: Field> {
+/// State of EcAdd operation post first phase.
+pub(super) struct EcAddDecomposed<F: Field> {
     pub point_p: G1Decomposed<F>,
     pub point_q: G1Decomposed<F>,
     pub point_r: G1Decomposed<F>,
 }
 
-pub struct EcAddAssigned<F: Field> {
+/// State of EcAdd operation post second phase.
+pub(super) struct EcAddAssigned<F: Field> {
     pub point_p: G1Assigned<F>,
     pub point_q: G1Assigned<F>,
     pub point_r: G1Assigned<F>,
 }
 
-pub struct EcMulDecomposed<F: Field> {
+/// State of EcMul operation post first phase.
+pub(super) struct EcMulDecomposed<F: Field> {
     pub point_p: G1Decomposed<F>,
     pub scalar_s: ScalarAssigned<F>,
     pub point_r: G1Decomposed<F>,
 }
 
-pub struct EcMulAssigned<F: Field> {
+/// State of EcMul operation post second phase.
+pub(super) struct EcMulAssigned<F: Field> {
     pub point_p: G1Assigned<F>,
     pub scalar_s: ScalarAssigned<F>,
     pub point_r: G1Assigned<F>,
 }
 
-pub struct EcPairingDecomposed<F: Field> {
-    pub g1s: Vec<G1Decomposed<F>>,
-    pub g2s: Vec<G2Decomposed<F>>,
+/// State of EcPairing operation post first phase.
+pub(super) struct EcPairingDecomposed<F: Field> {
     pub input_cells: Vec<QuantumCell<F>>,
     pub success: AssignedValue<F>,
 }
 
-pub struct EcPairingAssigned<F: Field> {
-    pub g1s: Vec<G1Assigned<F>>,
-    pub g2s: Vec<G2Assigned<F>>,
+/// State of EcPairing operation post second phase.
+pub(super) struct EcPairingAssigned<F: Field> {
+    /// RLC of (G1, G2) pairs.
     pub input_rlc: AssignedValue<F>,
     pub success: AssignedValue<F>,
 }
 
+/// Wrapper struct that holds all the ecXX states post second phase.
 #[derive(Default)]
-pub struct EcOpsAssigned<F: Field> {
+pub(super) struct EcOpsAssigned<F: Field> {
     pub ec_adds_assigned: Vec<EcAddAssigned<F>>,
     pub ec_muls_assigned: Vec<EcMulAssigned<F>>,
     pub ec_pairings_assigned: Vec<EcPairingAssigned<F>>,


### PR DESCRIPTION
### Description

Refactor ECC circuit such that phase1 and phase2 parts are handled separately with the `FpConfig` being finalized post each phase to ensure that range check lookups are configured.

- Decomposition and Assignment is split, where `Decomposition` handles phase1 and any RLC is handled in `Assignment` part
- `fpconfig.finalize` is called post each phase
- minor refactoring around the above points