### PR TITLE
Fix: L1Msg tx is allowed to skip by sequencer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "eth-types",
  "ethers-core",
  "halo2_proofs",
+ "hex",
  "itertools",
  "log",
  "rand",

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -13,6 +13,7 @@ zkevm-circuits = { path = "../zkevm-circuits" }
 ark-std = "0.3.0"
 env_logger = "0.10.0"
 ethers-core = "0.17.0"
+hex = "0.4.3"
 log = "0.4"
 itertools = "0.10.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/aggregator/src/chunk.rs
+++ b/aggregator/src/chunk.rs
@@ -36,10 +36,7 @@ impl ChunkHash {
         // <https://github.com/scroll-tech/zkevm-circuits/blob/25dd32aa316ec842ffe79bb8efe9f05f86edc33e/bus-mapping/src/circuit_input_builder.rs#L690>
 
         let mut total_l1_popped = block.start_l1_queue_index;
-        log::debug!(
-            "ChunkHash::from_witness_block: start_l1_queue_index = {}",
-            total_l1_popped
-        );
+        log::debug!("chunk-hash: start_l1_queue_index = {}", total_l1_popped);
         let data_bytes = iter::empty()
             // .chain(block_headers.iter().flat_map(|(&block_num, block)| {
             .chain(block.context.ctxs.iter().flat_map(|(b_num, b_ctx)| {
@@ -60,7 +57,7 @@ impl ChunkHash {
 
                 let num_txs = (num_l2_txs + num_l1_msgs) as u16;
                 log::debug!(
-                    "ChunkHash::from_witness_block: [block {}] total_l1_popped = {}, num_l1_msgs = {}, num_l2_txs = {}, num_txs = {}",
+                    "chunk-hash: [block {}] total_l1_popped = {}, num_l1_msgs = {}, num_l2_txs = {}, num_txs = {}",
                     b_num,
                     total_l1_popped,
                     num_l1_msgs,
@@ -80,7 +77,11 @@ impl ChunkHash {
             .chain(block.txs.iter().flat_map(|tx| tx.hash.to_fixed_bytes()))
             .collect::<Vec<u8>>();
 
-        let data_hash = H256(keccak256(&data_bytes));
+        let data_hash = H256(keccak256(data_bytes));
+        log::debug!(
+            "chunk-hash: data hash = {}",
+            hex::encode(data_hash.to_fixed_bytes())
+        );
 
         let post_state_root = block
             .context

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -744,6 +744,10 @@ fn keccak_inputs_pi_circuit(
     transactions: &[Transaction],
 ) -> Vec<Vec<u8>> {
     let mut total_l1_popped = start_l1_queue_index;
+    log::debug!(
+        "start_l1_queue_index in keccak_inputs: {}",
+        start_l1_queue_index
+    );
     let data_bytes = iter::empty()
         .chain(block_headers.iter().flat_map(|(&block_num, block)| {
             let num_l2_txs = transactions
@@ -759,7 +763,15 @@ fn keccak_inputs_pi_circuit(
                 .map_or(0, |max_queue_index| max_queue_index - total_l1_popped + 1);
             total_l1_popped += num_l1_msgs;
 
-            let num_txs = num_l2_txs + num_l1_msgs;
+            let num_txs = (num_l2_txs + num_l1_msgs) as u16;
+            log::debug!(
+                "[block {}] total_l1_popped: {}, num_l1_msgs: {}, num_l2_txs: {}, num_txs: {}",
+                block_num,
+                total_l1_popped,
+                num_l1_msgs,
+                num_l2_txs,
+                num_txs,
+            );
 
             iter::empty()
                 // Block Values

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -785,6 +785,10 @@ fn keccak_inputs_pi_circuit(
         .chain(transactions.iter().flat_map(|tx| tx.hash.to_fixed_bytes()))
         .collect::<Vec<u8>>();
     let data_hash = H256(keccak256(&data_bytes));
+    log::debug!(
+        "chunk data hash: {}",
+        hex::encode(data_hash.to_fixed_bytes())
+    );
     let after_state_root = block_headers
         .last_key_value()
         .map(|(_, blk)| blk.eth_block.state_root)

--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -163,6 +163,8 @@ pub struct Block {
     pub circuits_params: CircuitsParams,
     /// chain id
     pub chain_id: u64,
+    /// start_l1_queue_index
+    pub start_l1_queue_index: u64,
     /// IO to/from the precompiled contract calls.
     pub precompile_events: PrecompileEvents,
 }
@@ -209,6 +211,36 @@ impl Block {
             },
             exp_events: Vec::new(),
             chain_id,
+            circuits_params,
+            ..Default::default()
+        };
+        let info = BlockHead::new(chain_id, history_hashes, eth_block)?;
+        block.headers.insert(info.number.as_u64(), info);
+        Ok(block)
+    }
+
+    /// Create a new block.
+    pub fn new_with_l1_queue_index(
+        chain_id: u64,
+        start_l1_queue_index: u64,
+        history_hashes: Vec<Word>,
+        eth_block: &eth_types::Block<eth_types::Transaction>,
+        circuits_params: CircuitsParams,
+    ) -> Result<Self, Error> {
+        let mut block = Self {
+            block_steps: BlockSteps {
+                end_block_not_last: ExecStep {
+                    exec_state: ExecState::EndBlock,
+                    ..ExecStep::default()
+                },
+                end_block_last: ExecStep {
+                    exec_state: ExecState::EndBlock,
+                    ..ExecStep::default()
+                },
+            },
+            exp_events: Vec::new(),
+            chain_id,
+            start_l1_queue_index,
             circuits_params,
             ..Default::default()
         };

--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -88,6 +88,8 @@ pub struct BlockHead {
     pub difficulty: Word,
     /// base fee
     pub base_fee: Word,
+    /// start l1 queue index
+    pub start_l1_queue_index: u64,
     /// Original block from geth
     pub eth_block: eth_types::Block<eth_types::Transaction>,
 }
@@ -108,6 +110,7 @@ impl BlockHead {
         Ok(Self {
             chain_id,
             history_hashes,
+            start_l1_queue_index: 0,
             coinbase: eth_block
                 .author
                 .ok_or(Error::EthTypeError(eth_types::Error::IncompleteBlock))?,
@@ -135,6 +138,7 @@ impl BlockHead {
     /// Create a new block.
     pub fn new_with_l1_queue_index(
         chain_id: u64,
+        start_l1_queue_index: u64,
         history_hashes: Vec<Word>,
         eth_block: &eth_types::Block<eth_types::Transaction>,
     ) -> Result<Self, Error> {
@@ -148,6 +152,7 @@ impl BlockHead {
         Ok(Self {
             chain_id,
             history_hashes,
+            start_l1_queue_index,
             coinbase: eth_block
                 .author
                 .ok_or(Error::EthTypeError(eth_types::Error::IncompleteBlock))?,

--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -289,7 +289,12 @@ impl Block {
             circuits_params,
             ..Default::default()
         };
-        let info = BlockHead::new(chain_id, history_hashes, eth_block)?;
+        let info = BlockHead::new_with_l1_queue_index(
+            chain_id,
+            start_l1_queue_index,
+            history_hashes,
+            eth_block,
+        )?;
         block.headers.insert(info.number.as_u64(), info);
         Ok(block)
     }

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -103,6 +103,7 @@ impl PublicData {
         let mut num_txs_in_blocks = BTreeMap::new();
         // short for total number of l1 msgs popped before
         let mut total_l1_popped = self.start_l1_queue_index;
+        log::debug!("start_l1_queue_index: {}", total_l1_popped);
         for &block_num in self.block_ctxs.ctxs.keys() {
             let num_l2_txs = self
                 .transactions
@@ -693,6 +694,7 @@ impl<F: Field> PiCircuitConfig<F> {
             let is_rpi_padding = i >= block_values.ctxs.len();
             let block_num = block.number.as_u64();
             let num_txs = num_txs_in_blocks.get(&block_num).cloned().unwrap_or(0) as u16;
+            log::debug!("num_txs in block {}: {}", block_num, num_txs);
 
             // Assign fields in pi columns and connect them to block table
             let fields = vec![

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -196,7 +196,7 @@ impl PublicData {
 
     fn get_pi(&self) -> H256 {
         let data_hash = H256(keccak256(self.data_bytes()));
-        log::debug!("data hash: {}", hex::encode(&data_hash.to_fixed_bytes()));
+        log::debug!("data hash: {}", hex::encode(data_hash.to_fixed_bytes()));
 
         let pi_bytes = self.pi_bytes(data_hash);
         let pi_hash = keccak256(pi_bytes);

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -195,6 +195,8 @@ impl PublicData {
 
     fn get_pi(&self) -> H256 {
         let data_hash = H256(keccak256(self.data_bytes()));
+        log::debug!("data hash: {}", hex::encode(&data_hash.to_fixed_bytes()));
+
         let pi_bytes = self.pi_bytes(data_hash);
         let pi_hash = keccak256(pi_bytes);
 

--- a/zkevm-circuits/src/witness.rs
+++ b/zkevm-circuits/src/witness.rs
@@ -3,7 +3,10 @@
 //! used to generate witnesses for circuits.
 
 mod block;
-pub use block::{block_apply_mpt_state, block_convert, Block, BlockContext, BlockContexts};
+pub use block::{
+    block_apply_mpt_state, block_convert, block_convert_with_l1_queue_index, Block, BlockContext,
+    BlockContexts,
+};
 
 mod bytecode;
 pub use bytecode::Bytecode;

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -65,6 +65,8 @@ pub struct Block<F> {
     pub mpt_updates: MptUpdates,
     /// Chain ID
     pub chain_id: u64,
+    /// StartL1QueueIndex
+    pub start_l1_queue_index: u64,
     /// IO to/from precompile calls.
     pub precompile_events: PrecompileEvents,
 }
@@ -458,8 +460,20 @@ pub fn block_convert<F: Field>(
         keccak_inputs: circuit_input_builder::keccak_inputs(block, code_db)?,
         mpt_updates,
         chain_id,
+        start_l1_queue_index: 0,
         precompile_events: block.precompile_events.clone(),
     })
+}
+
+pub fn block_convert_with_l1_queue_index<F: Field>(
+    block: &circuit_input_builder::Block,
+    code_db: &bus_mapping::state_db::CodeDB,
+    start_l1_queue_index: u64,
+) -> Result<Block<F>, Error> {
+    let mut block = block_convert(block, code_db)?;
+    block.start_l1_queue_index = start_l1_queue_index;
+
+    Ok(block)
 }
 
 /// Attach witness block with mpt states

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -465,6 +465,7 @@ pub fn block_convert<F: Field>(
     })
 }
 
+/// Convert a block struct in bus-mapping to a witness block used in circuits
 pub fn block_convert_with_l1_queue_index<F: Field>(
     block: &circuit_input_builder::Block,
     code_db: &bus_mapping::state_db::CodeDB,


### PR DESCRIPTION
### Description

This PR makes two changes

- [x] num_txs in the calculation of chunk_data_hash is updated to the new definition.
- [x] do not change block table's assignment.
- [ ] calculation of `num_l1_msgs` and `num_l2_txs` are done in tx circuit and copy their sum back to pi circuit.

### Issue Link

The rollup contract allows the sequencer to skip "malicious" L1 enforced tx (i.e. `L1Msg` tx) that could cause circuit overflow. Therefore the semantic of `num_txs` in a chunk is different from the one we have right now. 

- Previously, it means that `num_txs = len(chunk.txs)`. 
- However, according to the [latest go impl of relayer](https://github.com/scroll-tech/scroll/blob/7097bdb4e1a0615b2206984a285ffb0f30524fe9/common/types/block.go#L64-L66), `num_txs = num_l1_msgs + num_l2_txs` and [`num_l1_msgs` ](https://github.com/scroll-tech/scroll/blob/8b58bd1eab3dbadd716369ad5b0cb9323b792337/common/types/block.go#L22-L37) count in these skipped L1 msgs. This means that the num of txs that are handled by the EVM circuit does not necessarily equal to the new `num_txs` definition.

Previously we rely on the assumption that `num_txs = len(chunk.txs)` to make sure that
1. all txs in each chunk's block are included in the tx table.
2. **each tx's block number is correct**. You can't assign a wrong `(BlockNumber, tx_id, tx.block_num+1)` row in tx table.

The rules that we use (you can find more details at #733) is 
1. we use block table to get each block's `cum_num_txs, prev_cum_num_txs` and `prev_cum_num_txs = cum_num_txs - num_txs`.
2. each tx must satisfy that `tx.block.prev_cum_num_txs < tx_id <= tx.block.cum_num_txs`.
3. tx_id in tx table is **continuous**, i.e. `tx_id' = tx_id + 1` (it's strictly increasing by 1). 

Note that the evm circuit also relies on the rules 2 & 3 to make sure that txs in chunk cannot be skipped.
1. `EndTx -> BeginTx`: next.state.tx_id = curr.state.tx_id + 1;
2. `EndTx -> EndInnerBlock`: curr.state.tx_id == curr.block.cum_num_txs`. 

However this rule no longer holds if we use the new definition of `num_txs` in block table to get each block's `cum_num_txs, prev_cum_num_txs`. We give an example of how block table and tx table will look like below.

- block table 
   | block num | num_txs | prev_cnt| cnt|
   |-|-|-|-|
   | 1 | 5 |  0 | 5 |
   | 2 | 3 | 5 | 8|

- tx table 
   |tx id | block_num |  is_l1_msg| queue_index | total_l1_popped | prev_cnt | cnt|
   |-|-|-|-|-|-|-|
   | 1 | 1 |  true |3 | 2 | 0 | 5 |
   | 2 | 1 | false  |  | 4| 0|5|
   | 3 | 1 | false | | 4| 0 | 5|
   | 4 | 1 | false | | 4| 0 | 5|
   | 5 | 2 | true | 6 | 4 | 5 | 8|

It's easy to see that the 5th row will fail the 2nd rule. We can use a simple method to fix this issue: 
> allow the `tx_id`s are not continuous, they are allowed to contain gap. That is, `tx_id' > tx_id`. 

The tx table using this method will look like:

 |tx id | block_num |  is_l1_msg| queue_index | total_l1_popped | prev_cnt | cnt|
   |-|-|-|-|-|-|-|
   | 1 | 1 |  true |3 | 2 | 0 | 5 |
   | 3 | 1 | false  |  | 4| 0|5|
   | 4 | 1 | false | | 4| 0 | 5|
   | 5 | 1 | false | | 4| 0 | 5|
   | 8 | 2 | true | 6 | 4 | 5 | 8|

It's easy to see that we can now pass the rule 2's check. But this method breaks the 3rd rule that evm circuit relies on. This means that we also need make changes to evm circuit (oops not good) which is not desirable.
### Design choice

We want to keep the changes as small as possible. For example, we don't want to make changes to evm circuit. To achieve that, we decide to keep the original semantic of `num_txs, cum_num_txs` in block table (do not use `num_l1_msgs + num_l2_txs` as `num_txs`). 

That is, the new definition is only applied in the calculation of chunk_data_hash. And we count the `num_l1_msgs` and `num_l2_txs` in tx table. And then enforce that the sum equals to the `num_txs` in pi column using copy constraints.

Continuing our previous example, block table assigned by this method will look like:

- block table 
   | block num | num_txs | prev_cnt| cnt|
   |-|-|-|-|
   | 1 | 4 |  0 | 4 |
   | 2 | 1 | 4 | 5 |

- tx table 
   |tx id | block_num |  is_l1_msg| queue_index | total_l1_popped | prev_cnt | cnt|
   |-|-|-|-|-|-|-|
   | 1 | 1 |  true |3 | 2 | 0 | 4 |
   | 2 | 1 | false  |  | 4| 0|4|
   | 3 | 1 | false | | 4| 0 | 4|
   | 4 | 1 | false | | 4| 0 | 4|
   | 5 | 2 | true | 6 | 4 | 4 | 5|

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



