### PR TITLE
Fix: allow skipping of L1Msg tx part 2 i.e. calculate num_all_txs in tx circuit

### DIFF
--- a/circuit-benchmarks/src/tx_circuit.rs
+++ b/circuit-benchmarks/src/tx_circuit.rs
@@ -84,7 +84,7 @@ mod tests {
         let max_txs: usize = 2_usize.pow(degree) / ROWS_PER_TX;
 
         let txs = vec![mock::CORRECT_MOCK_TXS[0].clone().into()];
-        let circuit = TxCircuit::<Fr>::new(max_txs, MAX_CALLDATA, *mock::MOCK_CHAIN_ID, txs);
+        let circuit = TxCircuit::<Fr>::new(max_txs, MAX_CALLDATA, *mock::MOCK_CHAIN_ID, 0, txs);
         (degree as usize, circuit)
     }
 

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1361,7 +1361,8 @@ impl<F: Field> PiCircuitConfig<F> {
                 .into_iter()
                 .map(|_| BlockContext::padding(public_data.chain_id)),
         ) {
-            // note that
+            // Note that the num_txs field in block table is different from num_txs
+            // of the chunk data hash. They are not necessarily equal.
             let num_txs = public_data
                 .transactions
                 .iter()

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -28,7 +28,7 @@ use crate::{
     evm_circuit::{util::constraint_builder::BaseConstraintBuilder, EvmCircuitExports},
     pi_circuit::param::{
         BASE_FEE_OFFSET, BLOCK_HEADER_BYTES_NUM, BLOCK_LEN, BLOCK_NUM_OFFSET, BYTE_POW_BASE,
-        CHAIN_ID_OFFSET, GAS_LIMIT_OFFSET, KECCAK_DIGEST_SIZE, NUM_TXS_OFFSET, RPI_CELL_IDX,
+        CHAIN_ID_OFFSET, GAS_LIMIT_OFFSET, KECCAK_DIGEST_SIZE, RPI_CELL_IDX,
         RPI_LENGTH_ACC_CELL_IDX, RPI_RLC_ACC_CELL_IDX, TIMESTAMP_OFFSET,
     },
     state_circuit::StateCircuitExports,
@@ -46,11 +46,12 @@ use once_cell::sync::Lazy;
 
 use crate::{
     evm_circuit::param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_U64, N_BYTES_WORD},
-    pi_circuit::param::{COINBASE_OFFSET, DIFFICULTY_OFFSET},
+    pi_circuit::param::{COINBASE_OFFSET, DIFFICULTY_OFFSET, NUM_ALL_TXS_OFFSET},
     table::{
         BlockContextFieldTag,
         BlockContextFieldTag::{
-            BaseFee, ChainId, Coinbase, CumNumTxs, Difficulty, GasLimit, NumTxs, Number, Timestamp,
+            BaseFee, ChainId, Coinbase, CumNumTxs, Difficulty, GasLimit, NumAllTxs, NumTxs, Number,
+            Timestamp,
         },
     },
     util::rlc_be_bytes,
@@ -99,11 +100,12 @@ impl Default for PublicData {
 }
 
 impl PublicData {
-    fn get_num_txs(&self) -> BTreeMap<u64, u64> {
-        let mut num_txs_in_blocks = BTreeMap::new();
+    // Return num of all txs in each block (taking skipped l1 msgs into account)
+    fn get_num_all_txs(&self) -> BTreeMap<u64, u64> {
+        let mut num_all_txs_in_blocks = BTreeMap::new();
         // short for total number of l1 msgs popped before
         let mut total_l1_popped = self.start_l1_queue_index;
-        log::debug!("start_l1_queue_index: {}", total_l1_popped);
+        log::debug!("[public_data] start_l1_queue_index: {}", total_l1_popped);
         for &block_num in self.block_ctxs.ctxs.keys() {
             let num_l2_txs = self
                 .transactions
@@ -118,33 +120,33 @@ impl PublicData {
                 .map(|tx| tx.nonce)
                 .max()
                 .map_or(0, |max_queue_index| max_queue_index - total_l1_popped + 1);
-            total_l1_popped += num_l1_msgs;
 
             let num_txs = num_l2_txs + num_l1_msgs;
-            num_txs_in_blocks.insert(block_num, num_txs);
+            num_all_txs_in_blocks.insert(block_num, num_txs);
 
-            log::trace!(
-                "[block {}] total_l1_popped: {}, num_l1_msgs: {}, num_l2_txs: {}, num_txs: {}",
+            log::debug!(
+                "[public_data][block {}] total_l1_popped_before: {}, num_l1_msgs: {}, num_l2_txs: {}, num_txs: {}",
                 block_num,
                 total_l1_popped,
                 num_l1_msgs,
                 num_l2_txs,
                 num_txs
             );
+            total_l1_popped += num_l1_msgs;
         }
 
-        num_txs_in_blocks
+        num_all_txs_in_blocks
     }
 
     /// Compute the bytes for dataHash from the verifier's perspective.
     fn data_bytes(&self) -> Vec<u8> {
-        let num_txs_in_blocks = self.get_num_txs();
+        let num_all_txs_in_blocks = self.get_num_all_txs();
         let result = iter::empty()
             .chain(self.block_ctxs.ctxs.iter().flat_map(|(block_num, block)| {
-                let num_txs = num_txs_in_blocks
+                let num_all_txs = num_all_txs_in_blocks
                     .get(block_num)
                     .cloned()
-                    .unwrap_or_else(|| panic!("get num_txs in block {block_num}"))
+                    .unwrap_or_else(|| panic!("get num_all_txs in block {block_num}"))
                     as u16;
                 iter::empty()
                     // Block Values
@@ -152,7 +154,7 @@ impl PublicData {
                     .chain(block.timestamp.as_u64().to_be_bytes())
                     .chain(block.base_fee.to_be_bytes())
                     .chain(block.gas_limit.to_be_bytes())
-                    .chain(num_txs.to_be_bytes())
+                    .chain(num_all_txs.to_be_bytes())
             }))
             // Tx Hashes
             .chain(
@@ -196,7 +198,10 @@ impl PublicData {
 
     fn get_pi(&self) -> H256 {
         let data_hash = H256(keccak256(self.data_bytes()));
-        log::debug!("data hash: {}", hex::encode(data_hash.to_fixed_bytes()));
+        log::debug!(
+            "[pi] chunk data hash: {}",
+            hex::encode(data_hash.to_fixed_bytes())
+        );
 
         let pi_bytes = self.pi_bytes(data_hash);
         let pi_hash = keccak256(pi_bytes);
@@ -660,7 +665,7 @@ impl<F: Field> PiCircuitConfig<F> {
             .iter()
             .map(|tx| tx.hash)
             .collect::<Vec<H256>>();
-        let num_txs_in_blocks = public_data.get_num_txs();
+        let num_all_txs_in_blocks = public_data.get_num_all_txs();
 
         let mut offset = 0;
         let mut block_copy_cells = vec![];
@@ -693,8 +698,12 @@ impl<F: Field> PiCircuitConfig<F> {
         {
             let is_rpi_padding = i >= block_values.ctxs.len();
             let block_num = block.number.as_u64();
-            let num_txs = num_txs_in_blocks.get(&block_num).cloned().unwrap_or(0) as u16;
-            log::debug!("num_txs in block {}: {}", block_num, num_txs);
+            let num_all_txs = num_all_txs_in_blocks.get(&block_num).cloned().unwrap_or(0) as u16;
+            log::debug!(
+                "[pi assign] num_all_txs in block {}: {}",
+                block_num,
+                num_all_txs
+            );
 
             // Assign fields in pi columns and connect them to block table
             let fields = vec![
@@ -708,7 +717,7 @@ impl<F: Field> PiCircuitConfig<F> {
                 ), // timestamp
                 (block.base_fee.to_be_bytes().to_vec(), BASE_FEE_OFFSET), // base_fee
                 (block.gas_limit.to_be_bytes().to_vec(), GAS_LIMIT_OFFSET), // gas_limit
-                (num_txs.to_be_bytes().to_vec(), NUM_TXS_OFFSET),         // num_txs
+                (num_all_txs.to_be_bytes().to_vec(), NUM_ALL_TXS_OFFSET), // num_all_txs
             ];
             for (bytes, block_offset) in fields {
                 let cells = self.assign_field_in_pi(
@@ -722,15 +731,10 @@ impl<F: Field> PiCircuitConfig<F> {
                     false,
                     challenges,
                 )?;
-                // do not copy num_txs to block table as the meaning of num_txs
-                // in block table is len(block.txs), and this is different from num_l1_msgs +
-                // num_l2_txs
-                if block_offset != NUM_TXS_OFFSET {
-                    block_copy_cells.push((
-                        cells[RPI_CELL_IDX].clone(),
-                        block_table_offset + block_offset,
-                    ));
-                }
+                block_copy_cells.push((
+                    cells[RPI_CELL_IDX].clone(),
+                    block_table_offset + block_offset,
+                ));
             }
 
             block_table_offset += BLOCK_LEN;
@@ -1355,27 +1359,30 @@ impl<F: Field> PiCircuitConfig<F> {
         let mut cum_num_txs = 0usize;
         let mut block_value_cells = vec![];
         let block_ctxs = &public_data.block_ctxs;
-        // let num_txs_in_blocks = public_data.get_num_txs();
+        let num_all_txs_in_blocks = public_data.get_num_all_txs();
         for block_ctx in block_ctxs.ctxs.values().cloned().chain(
             (block_ctxs.ctxs.len()..max_inner_blocks)
                 .into_iter()
                 .map(|_| BlockContext::padding(public_data.chain_id)),
         ) {
-            // Note that the num_txs field in block table is different from num_txs
-            // of the chunk data hash. They are not necessarily equal.
             let num_txs = public_data
                 .transactions
                 .iter()
                 .filter(|tx| tx.block_number == block_ctx.number.as_u64())
                 .count();
+            // unwrap_or(0) for padding block
+            let num_all_txs = num_all_txs_in_blocks
+                .get(&block_ctx.number.as_u64())
+                .cloned()
+                .unwrap_or(0);
             let tag = [
                 Coinbase, Timestamp, Number, Difficulty, GasLimit, BaseFee, ChainId, NumTxs,
-                CumNumTxs,
+                CumNumTxs, NumAllTxs,
             ];
             let mut cum_num_txs_field = F::from(cum_num_txs as u64);
             cum_num_txs += num_txs;
             for (row, tag) in block_ctx
-                .table_assignments(num_txs, cum_num_txs, challenges)
+                .table_assignments(num_txs, cum_num_txs, num_all_txs, challenges)
                 .into_iter()
                 .zip(tag.iter())
             {

--- a/zkevm-circuits/src/pi_circuit/param.rs
+++ b/zkevm-circuits/src/pi_circuit/param.rs
@@ -1,5 +1,5 @@
 /// Fixed by the spec
-pub(super) const BLOCK_LEN: usize = 9;
+pub(super) const BLOCK_LEN: usize = 10;
 pub(super) const BYTE_POW_BASE: u64 = 256;
 pub(super) const BLOCK_HEADER_BYTES_NUM: usize = 58;
 pub(super) const KECCAK_DIGEST_SIZE: usize = 32;
@@ -19,5 +19,5 @@ pub(super) const DIFFICULTY_OFFSET: usize = 3;
 pub(super) const GAS_LIMIT_OFFSET: usize = 4;
 pub(super) const BASE_FEE_OFFSET: usize = 5;
 pub(super) const CHAIN_ID_OFFSET: usize = 6;
-pub(super) const NUM_TXS_OFFSET: usize = 7;
-pub(super) const CUM_NUM_TXS_OFFSET: usize = 8;
+// pub(super) const CUM_NUM_TXS_OFFSET: usize = 8;
+pub(super) const NUM_ALL_TXS_OFFSET: usize = 9;

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1189,11 +1189,15 @@ pub enum BlockContextFieldTag {
     /// add it here for convenience.
     ChainId,
     /// In a multi-block setup, this variant represents the total number of txs
-    /// included in this block.
+    /// included (executed) in this block.
     NumTxs,
     /// In a multi-block setup, this variant represents the cumulative number of
     /// txs included up to this block, including the txs in this block.
     CumNumTxs,
+    /// In a multi-block setup, this variant represents the total number of txs
+    /// included in this block which also taking skipped l1 msgs into account.
+    /// This could possibly be larger than NumTxs.
+    NumAllTxs,
 }
 impl_expr!(BlockContextFieldTag);
 
@@ -1254,7 +1258,7 @@ impl BlockTable {
                         .filter(|tx| tx.block_number == block_ctx.number.as_u64())
                         .count();
                     cum_num_txs += num_txs;
-                    for row in block_ctx.table_assignments(num_txs, cum_num_txs, challenges) {
+                    for row in block_ctx.table_assignments(num_txs, cum_num_txs, 0, challenges) {
                         region.assign_fixed(
                             || format!("block table row {offset}"),
                             self.tag,

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -789,7 +789,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                 let block_num_diff = meta.query_advice(block_num, Rotation::next())
                     - meta.query_advice(block_num, Rotation::cur());
 
-                vec![(lookup_condition * block_num_diff, u16_table.clone().into())]
+                vec![(lookup_condition * block_num_diff, u16_table.into())]
             },
         );
 

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -218,9 +218,6 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         let block_num = meta.advice_column();
 
         let total_l1_popped_before = meta.advice_column();
-        // num_l1_msgs takes skipped L1Msg tx into account.
-        let num_l1_msgs_acc = meta.advice_column();
-        let num_l2_txs_acc = meta.advice_column();
         // num_all_txs = num_l1_msgs + num_l2_txs
         let num_all_txs_acc = meta.advice_column();
 
@@ -1105,8 +1102,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
             tx_nonce,
             block_num,
             block_num_unchanged,
-            num_l1_msgs: num_l1_msgs_acc,
-            num_l2_txs: num_l2_txs_acc,
+            num_all_txs_acc,
             total_l1_popped_before,
             is_l1_msg,
             is_chain_id,
@@ -1923,7 +1919,6 @@ impl<F: Field> TxCircuit<F> {
                     None,
                     None,
                     None,
-                    None,
                 )?;
 
                 // Assign all tx fields except for call data
@@ -2183,8 +2178,7 @@ impl<F: Field> TxCircuit<F> {
                             None,
                             Some(cur_block_num),
                             Some(next_block_num),
-                            Some(num_l1_msgs),
-                            Some(num_l2_txs),
+                            Some(num_all_txs_acc),
                             Some(total_l1_popped_before),
                         )?;
                         let sv_address: F = sign_data.get_addr().to_scalar().unwrap();
@@ -2240,7 +2234,6 @@ impl<F: Field> TxCircuit<F> {
                             None,
                             Some(is_final),
                             Some(calldata_gas_cost),
-                            None,
                             None,
                             None,
                             None,

--- a/zkevm-circuits/src/tx_circuit/dev.rs
+++ b/zkevm-circuits/src/tx_circuit/dev.rs
@@ -97,14 +97,20 @@ pub struct TxCircuitTester<F: Field> {
 
 impl<F: Field> TxCircuitTester<F> {
     /// Return a new TxCircuit
-    pub fn new(max_txs: usize, max_calldata: usize, chain_id: u64, txs: Vec<Transaction>) -> Self {
+    pub fn new(
+        max_txs: usize,
+        max_calldata: usize,
+        chain_id: u64,
+        start_l1_queue_index: u64,
+        txs: Vec<Transaction>,
+    ) -> Self {
         TxCircuitTester::<F> {
             sig_circuit: SigCircuit {
                 max_verif: max_txs,
                 signatures: get_sign_data(&txs, max_txs, chain_id as usize).unwrap(),
                 _marker: PhantomData,
             },
-            tx_circuit: TxCircuit::new(max_txs, max_calldata, chain_id, txs),
+            tx_circuit: TxCircuit::new(max_txs, max_calldata, chain_id, start_l1_queue_index, txs),
         }
     }
 }
@@ -117,7 +123,8 @@ impl<F: Field> SubCircuit<F> for TxCircuitTester<F> {
         let max_txs = block.circuits_params.max_txs;
         let chain_id = block.chain_id;
         let max_calldata = block.circuits_params.max_calldata;
-        Self::new(max_txs, max_calldata, chain_id, txs)
+        let start_l1_queue_index = block.start_l1_queue_index;
+        Self::new(max_txs, max_calldata, chain_id, start_l1_queue_index, txs)
     }
 
     fn synthesize_sub(

--- a/zkevm-circuits/src/tx_circuit/test.rs
+++ b/zkevm-circuits/src/tx_circuit/test.rs
@@ -131,7 +131,6 @@ fn run<F: Field>(
         Err(e) => panic!("{e:#?}"),
     };
 
-    prover.assert_satisfied_par();
     prover.verify_at_rows_par(0..active_row_num, 0..active_row_num)
 }
 

--- a/zkevm-circuits/src/tx_circuit/test.rs
+++ b/zkevm-circuits/src/tx_circuit/test.rs
@@ -113,6 +113,7 @@ fn run<F: Field>(
     chain_id: u64,
     max_txs: usize,
     max_calldata: usize,
+    start_l1_queue_index: u64,
 ) -> Result<(), Vec<VerifyFailure>> {
     let active_row_num = TxCircuit::<F>::min_num_rows(max_txs, max_calldata);
 
@@ -123,13 +124,14 @@ fn run<F: Field>(
             signatures: get_sign_data(&txs, max_txs, chain_id as usize).unwrap(),
             _marker: PhantomData,
         },
-        tx_circuit: TxCircuit::new(max_txs, max_calldata, chain_id, txs),
+        tx_circuit: TxCircuit::new(max_txs, max_calldata, chain_id, start_l1_queue_index, txs),
     };
     let prover = match MockProver::run(k, &circuit, vec![]) {
         Ok(prover) => prover,
         Err(e) => panic!("{e:#?}"),
     };
 
+    prover.assert_satisfied_par();
     prover.verify_at_rows_par(0..active_row_num, 0..active_row_num)
 }
 
@@ -156,7 +158,8 @@ fn tx_circuit_2tx_2max_tx() {
             .collect(),
             *mock::MOCK_CHAIN_ID,
             MAX_TXS,
-            MAX_CALLDATA
+            MAX_CALLDATA,
+            0,
         ),
         Ok(())
     );
@@ -169,7 +172,7 @@ fn tx_circuit_0tx_1max_tx() {
     const MAX_CALLDATA: usize = 32;
 
     assert_eq!(
-        run::<Fr>(vec![], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        run::<Fr>(vec![], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA, 0),
         Ok(())
     );
 }
@@ -183,7 +186,7 @@ fn tx_circuit_1tx_1max_tx() {
     let tx: Transaction = mock::CORRECT_MOCK_TXS[0].clone().into();
 
     assert_eq!(
-        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA, 0),
         Ok(())
     );
 }
@@ -197,7 +200,7 @@ fn tx_circuit_1tx_2max_tx() {
     let tx = build_pre_eip155_tx();
 
     assert_eq!(
-        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA, 0),
         Ok(())
     );
 }
@@ -211,7 +214,7 @@ fn tx_circuit_l1_msg_tx() {
     let tx = build_l1_msg_tx();
 
     assert_eq!(
-        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        run::<Fr>(vec![tx], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA, 0),
         Ok(())
     );
 }
@@ -226,7 +229,14 @@ fn tx_circuit_bad_address() {
     // This address doesn't correspond to the account that signed this tx.
     tx.from = AddrOrWallet::from(address!("0x1230000000000000000000000000000000000456"));
 
-    assert!(run::<Fr>(vec![tx.into()], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA).is_err(),);
+    assert!(run::<Fr>(
+        vec![tx.into()],
+        *mock::MOCK_CHAIN_ID,
+        MAX_TXS,
+        MAX_CALLDATA,
+        0
+    )
+    .is_err(),);
 }
 
 #[test]
@@ -239,7 +249,13 @@ fn tx_circuit_to_is_zero() {
     tx.transaction_index = U64::from(1);
 
     assert_eq!(
-        run::<Fr>(vec![tx.into()], *mock::MOCK_CHAIN_ID, MAX_TXS, MAX_CALLDATA),
+        run::<Fr>(
+            vec![tx.into()],
+            *mock::MOCK_CHAIN_ID,
+            MAX_TXS,
+            MAX_CALLDATA,
+            0
+        ),
         Ok(())
     );
 }

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -228,6 +228,7 @@ impl BlockContext {
         &self,
         num_txs: usize,
         cum_num_txs: usize,
+        num_all_txs: u64,
         challenges: &Challenges<Value<F>>,
     ) -> Vec<[Value<F>; 3]> {
         let current_block_number = self.number.to_scalar().unwrap();
@@ -279,6 +280,11 @@ impl BlockContext {
                     Value::known(F::from(BlockContextFieldTag::CumNumTxs as u64)),
                     Value::known(current_block_number),
                     Value::known(F::from(cum_num_txs as u64)),
+                ],
+                [
+                    Value::known(F::from(BlockContextFieldTag::NumAllTxs as u64)),
+                    Value::known(current_block_number),
+                    Value::known(F::from(num_all_txs as u64)),
                 ],
             ],
             self.block_hash_assignments(randomness),

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -284,7 +284,7 @@ impl BlockContext {
                 [
                     Value::known(F::from(BlockContextFieldTag::NumAllTxs as u64)),
                     Value::known(current_block_number),
-                    Value::known(F::from(num_all_txs as u64)),
+                    Value::known(F::from(num_all_txs)),
                 ],
             ],
             self.block_hash_assignments(randomness),


### PR DESCRIPTION
### Description

This PR aims to add constraints on tx.block_number in tx table. We group txs with same block number and then get the 
`num_all_txs` in each group (i.e. block). Then we do lookup arg into block table in tx circuit. Since the `num_txs` in pi's chunk data hash preimage means `num_all_txs` now, we now copy it to the `NumAllTxs` row in block table. That is, the `NumTxs` and `CumNumTxs` in block number is not constrained by pi circuit then. 

The **lookup arg into block table** in tx circuit are done at `tag == BlockNum` rows and it looks as
- the input expr is `(NumAllTxs, tx_table.value, num_all_txs_acc)`.  

This is the 2nd part of the https://github.com/scroll-tech/zkevm-circuits/pull/760. 

### Issue Link

https://github.com/scroll-tech/zkevm-circuits/pull/759

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update