### PR TITLE
[WIP] fix: enable test case of `call_precompile_with_value`

### DIFF
--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -323,7 +323,15 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                     ),
                     (
                         CallContextField::GasLeft,
-                        (geth_steps[0].gas.0 - gas_cost - precompile_call_gas_cost).into(),
+                        (geth_steps[0].gas.0
+                            + if has_value {
+                                GAS_STIPEND_CALL_WITH_VALUE
+                            } else {
+                                0
+                            }
+                            - gas_cost
+                            - precompile_call_gas_cost)
+                            .into(),
                     ),
                     (CallContextField::MemorySize, next_memory_word_size.into()),
                     (
@@ -463,7 +471,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                 let real_cost = geth_steps[0].gas.0 - geth_steps[1].gas.0;
                 debug_assert_eq!(
                     real_cost
-                        + if has_value && !callee_exists {
+                        + if has_value {
                             GAS_STIPEND_CALL_WITH_VALUE
                         } else {
                             0

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -479,7 +479,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     stack_pointer: Delta(stack_pointer_delta.expr()),
                     gas_left: To(callee_gas_left.expr()),
                     memory_word_size: To(precompile_output_rws.expr()),
-                    reversible_write_counter: To(transfer_rwc_delta),
+                    reversible_write_counter: Delta(transfer_rwc_delta),
                     ..StepStateTransition::default()
                 });
 


### PR DESCRIPTION
### Description

- Fix to add [GAS_STIPEND_CALL_WITH_VALUE](https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L682C22-L682C22) (2300) to gas-left if value is non-zero.
- Fix to set `reversible_write_counter` to `transfer_rwc_delta` (for precompile).

