### PR TITLE
fix: replace branch with tag for `halo2-lib`, `snark-verifier` and `mpt-circuit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,6 +2161,21 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 [[package]]
 name = "halo2-base"
 version = "0.2.2"
+source = "git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
+dependencies = [
+ "ff",
+ "halo2_proofs",
+ "itertools",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand_chacha",
+ "rustc-hash",
+]
+
+[[package]]
+name = "halo2-base"
+version = "0.2.2"
 source = "git+https://github.com/scroll-tech/halo2-lib?branch=develop#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
 dependencies = [
  "ff",
@@ -2176,11 +2191,30 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.2.2"
+source = "git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
+dependencies = [
+ "ff",
+ "group",
+ "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0)",
+ "itertools",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "halo2-ecc"
+version = "0.2.2"
 source = "git+https://github.com/scroll-tech/halo2-lib?branch=develop#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
 dependencies = [
  "ff",
  "group",
- "halo2-base",
+ "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
  "itertools",
  "num-bigint",
  "num-integer",
@@ -2211,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "halo2-mpt-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=v0.5#1c11b6c9b1245073a76c3ce7100b6798060f7cb8"
+source = "git+https://github.com/scroll-tech/mpt-circuit.git?tag=v0.5.0#1c11b6c9b1245073a76c3ce7100b6798060f7cb8"
 dependencies = [
  "ethers-core",
  "halo2_proofs",
@@ -4506,12 +4540,12 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#12c306ec57849921e690221b10b8a08189868d4a"
+source = "git+https://github.com/scroll-tech/snark-verifier?tag=v0.1.0#12c306ec57849921e690221b10b8a08189868d4a"
 dependencies = [
  "bytes",
  "ethereum-types 0.14.1",
- "halo2-base",
- "halo2-ecc",
+ "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
+ "halo2-ecc 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
  "hex",
  "itertools",
  "lazy_static",
@@ -4530,12 +4564,12 @@ dependencies = [
 [[package]]
 name = "snark-verifier-sdk"
 version = "0.0.1"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#12c306ec57849921e690221b10b8a08189868d4a"
+source = "git+https://github.com/scroll-tech/snark-verifier?tag=v0.1.0#12c306ec57849921e690221b10b8a08189868d4a"
 dependencies = [
  "bincode",
  "env_logger 0.10.0",
  "ethereum-types 0.14.1",
- "halo2-base",
+ "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
  "hex",
  "itertools",
  "lazy_static",
@@ -5493,8 +5527,8 @@ dependencies = [
  "ethers-core",
  "ethers-signers",
  "gadgets",
- "halo2-base",
- "halo2-ecc",
+ "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0)",
+ "halo2-ecc 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0)",
  "halo2_proofs",
  "hex",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,47 +2174,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "halo2-base"
-version = "0.2.2"
-source = "git+https://github.com/scroll-tech/halo2-lib?branch=develop#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
-dependencies = [
- "ff",
- "halo2_proofs",
- "itertools",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rand_chacha",
- "rustc-hash",
-]
-
-[[package]]
 name = "halo2-ecc"
 version = "0.2.2"
 source = "git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
 dependencies = [
  "ff",
  "group",
- "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0)",
- "itertools",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_core",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "halo2-ecc"
-version = "0.2.2"
-source = "git+https://github.com/scroll-tech/halo2-lib?branch=develop#2c225864227e74b207d9f4b9e08c4d5f1afc69a1"
-dependencies = [
- "ff",
- "group",
- "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
+ "halo2-base",
  "itertools",
  "num-bigint",
  "num-integer",
@@ -4540,12 +4506,12 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/snark-verifier?tag=v0.1.0#12c306ec57849921e690221b10b8a08189868d4a"
+source = "git+https://github.com/scroll-tech/snark-verifier?tag=v0.1.1#11a09d4a37c31c659b29e2dac0ceb544a776ad7b"
 dependencies = [
  "bytes",
  "ethereum-types 0.14.1",
- "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
- "halo2-ecc 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
+ "halo2-base",
+ "halo2-ecc",
  "hex",
  "itertools",
  "lazy_static",
@@ -4564,12 +4530,12 @@ dependencies = [
 [[package]]
 name = "snark-verifier-sdk"
 version = "0.0.1"
-source = "git+https://github.com/scroll-tech/snark-verifier?tag=v0.1.0#12c306ec57849921e690221b10b8a08189868d4a"
+source = "git+https://github.com/scroll-tech/snark-verifier?tag=v0.1.1#11a09d4a37c31c659b29e2dac0ceb544a776ad7b"
 dependencies = [
  "bincode",
  "env_logger 0.10.0",
  "ethereum-types 0.14.1",
- "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?branch=develop)",
+ "halo2-base",
  "hex",
  "itertools",
  "lazy_static",
@@ -5527,8 +5493,8 @@ dependencies = [
  "ethers-core",
  "ethers-signers",
  "gadgets",
- "halo2-base 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0)",
- "halo2-ecc 0.2.2 (git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.0)",
+ "halo2-base",
+ "halo2-ecc",
  "halo2_proofs",
  "hex",
  "itertools",

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -21,8 +21,8 @@ serde_json = "1.0"
 rand = "0.8"
 
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.1" }
+snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.1", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
 
 
 [features]

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -21,8 +21,8 @@ serde_json = "1.0"
 rand = "0.8"
 
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0" }
+snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
 
 
 [features]

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -43,8 +43,8 @@ libsecp256k1 = "0.7"
 num-bigint = { version = "0.4" }
 subtle = "2.4"
 rand_chacha = "0.3"
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.1" }
+snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.1", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
 hex = "0.4.3"
 rayon = "1.5"
 once_cell = "1.17.0"

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -32,11 +32,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.78"
 
 hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0723"}
-#mpt-circuits = { package = "halo2-mpt-circuits", path = "../../mpt-circuit" }
 misc-precompiled-circuit = { package = "rmd160-circuits", git = "https://github.com/scroll-tech/misc-precompiled-circuit.git", branch = "integration" }
 
-halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", default-features=false, features=["halo2-pse","display"] }
-halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", default-features=false, features=["halo2-pse","display"] }
+halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", tag = "v0.1.0", default-features=false, features=["halo2-pse","display"] }
+halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", tag = "v0.1.0", default-features=false, features=["halo2-pse","display"] }
 
 maingate = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_02_02" }
 
@@ -44,8 +43,8 @@ libsecp256k1 = "0.7"
 num-bigint = { version = "0.4" }
 subtle = "2.4"
 rand_chacha = "0.3"
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0" }
+snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.0", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
 hex = "0.4.3"
 rayon = "1.5"
 once_cell = "1.17.0"

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
-mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "v0.5" }
+mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", tag = "v0.5.0" }
 zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "v0.6" }
 hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0723"}
 bus-mapping = { path = "../bus-mapping" }


### PR DESCRIPTION
### Description

- Replace branch with tag for these dependencies, and the commit hash should be no change (except snark-verifier).
- Fix to use snark-verifier `v0.1.1` which set its dependency `halo2-lib` from develop branch to tag `v0.1.0`.
- There is a audit fix between snark-verifier `v0.1.0` and `v0.1.1`: https://github.com/scroll-tech/snark-verifier/compare/v0.1.0...v0.1.1


