### PR TITLE
Fix: constraint on num_all_txs_acc' is wrong

### DIFF
--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -881,7 +881,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                     );
 
                     // num_all_txs_acc' - num_all_txs_acc = is_l1_msg' ? queue_index' -
-                    // total_l1_popped + 1 : 1
+                    // total_l1_popped' + 1 : 1
                     cb.require_equal(
                         "num_all_txs_acc' - num_all_txs_acc",
                         meta.query_advice(num_all_txs_acc, Rotation::next())
@@ -889,7 +889,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                         select::expr(
                             meta.query_advice(is_l1_msg, Rotation::next()),
                             meta.query_advice(tx_nonce, Rotation::next())
-                                - meta.query_advice(total_l1_popped_before, Rotation::cur())
+                                - meta.query_advice(total_l1_popped_before, Rotation::next())
                                 + 1.expr(),
                             1.expr(),
                         ),


### PR DESCRIPTION
### Description

This is a continuation of https://github.com/scroll-tech/zkevm-circuits/pull/789. 
```
num_all_txs_acc' = num_all_txs_acc + (is_l1_msg ? queue_index' - total_l1_popped_before' + 1 : 1).
```

### Issue Link

chunk_8540

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update