### PR TITLE
Fix RLP::Len's tag_length bug

### DIFF
--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -2354,6 +2354,11 @@ impl<F: Field> TxCircuit<F> {
                         })
                     };
                     log::debug!("calldata len: {}", tx.call_data.len());
+                    let rlp_sign_tag_length = if tx.tx_type.is_l1_msg() {
+                        0
+                    } else {
+                        get_rlp_len_tag_length(&rlp_unsigned_tx_be_bytes)
+                    };
                     for (tag, rlp_tag, is_none, be_bytes_rlc, be_bytes_length, value) in [
                         // need to be in same order as that tx table load function uses
                         (
@@ -2501,7 +2506,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             zero_rlc,
-                            Some(get_rlp_len_tag_length(&rlp_unsigned_tx_be_bytes)),
+                            Some(rlp_sign_tag_length),
                             Value::known(F::from(rlp_unsigned_tx_be_bytes.len() as u64)),
                         ),
                         (

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -74,6 +74,7 @@ use halo2_proofs::plonk::Fixed;
 #[cfg(not(feature = "onephase"))]
 use halo2_proofs::plonk::SecondPhase;
 use itertools::Itertools;
+use crate::witness::rlp_fsm::get_rlp_len_tag_length;
 
 /// Number of rows of one tx occupies in the fixed part of tx table
 pub const TX_LEN: usize = 23;
@@ -2500,7 +2501,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             zero_rlc,
-                            Some(rlp_unsigned_tx_be_bytes.len().tag_length()),
+                            Some(get_rlp_len_tag_length(&rlp_unsigned_tx_be_bytes)),
                             Value::known(F::from(rlp_unsigned_tx_be_bytes.len() as u64)),
                         ),
                         (
@@ -2521,7 +2522,7 @@ impl<F: Field> TxCircuit<F> {
                             Some(Len),
                             Some(false),
                             zero_rlc,
-                            Some(rlp_signed_tx_be_bytes.len().tag_length()),
+                            Some(get_rlp_len_tag_length(&rlp_signed_tx_be_bytes)),
                             Value::known(F::from(rlp_signed_tx_be_bytes.len() as u64)),
                         ),
                         (

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -68,13 +68,13 @@ use std::{
     marker::PhantomData,
 };
 
+use crate::witness::rlp_fsm::get_rlp_len_tag_length;
 #[cfg(feature = "onephase")]
 use halo2_proofs::plonk::FirstPhase as SecondPhase;
 use halo2_proofs::plonk::Fixed;
 #[cfg(not(feature = "onephase"))]
 use halo2_proofs::plonk::SecondPhase;
 use itertools::Itertools;
-use crate::witness::rlp_fsm::get_rlp_len_tag_length;
 
 /// Number of rows of one tx occupies in the fixed part of tx table
 pub const TX_LEN: usize = 23;

--- a/zkevm-circuits/src/witness/rlp_fsm.rs
+++ b/zkevm-circuits/src/witness/rlp_fsm.rs
@@ -54,6 +54,19 @@ impl ValueTagLength for Vec<u8> {
     }
 }
 
+// return the tag length of the top-level BeginList tag
+pub(crate) fn get_rlp_len_tag_length(rlp_bytes: &[u8]) -> u32 {
+    assert!(rlp_bytes[0] >= 0xc0);
+
+    if rlp_bytes[0] < 0xf8 {
+        // list
+        1
+    } else {
+        // long_list
+        (rlp_bytes[0] - 0xf7).into()
+    }
+}
+
 /// RLP tags
 #[derive(Default, Clone, Copy, Debug, EnumIter, PartialEq, Eq)]
 pub enum Tag {

--- a/zkevm-circuits/src/witness/rlp_fsm.rs
+++ b/zkevm-circuits/src/witness/rlp_fsm.rs
@@ -56,14 +56,20 @@ impl ValueTagLength for Vec<u8> {
 
 // return the tag length of the top-level BeginList tag
 pub(crate) fn get_rlp_len_tag_length(rlp_bytes: &[u8]) -> u32 {
-    assert!(rlp_bytes[0] >= 0xc0);
+    let begin_list_byte = if rlp_bytes[0] < 0xc0 {
+        // it's eip2718 (first byte is transaction type)
+        rlp_bytes[1]
+    } else {
+        rlp_bytes[0]
+    };
 
-    if rlp_bytes[0] < 0xf8 {
+    assert!(begin_list_byte >= 0xc0);
+    if begin_list_byte < 0xf8 {
         // list
         1
     } else {
         // long_list
-        (rlp_bytes[0] - 0xf7).into()
+        (begin_list_byte - 0xf7).into()
     }
 }
 


### PR DESCRIPTION
### Description


### Issue Link

If an example RLP bytes starts with `0xf8ff`, then the tag_length of `RLP::Len` is considered as 1 (`0xf8 - 0xf7`) in RLP circuit. However, in the witness gen of tx circuit, it misunderstands that it took 2 bytes to represent as the total length = `0x0101` .

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update