### PR TITLE
Remove CopyDataType::Precompile

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -27,7 +27,6 @@ use halo2_proofs::{
     },
     plonk::Expression,
 };
-use strum::IntoEnumIterator;
 
 /// An execution step of the EVM.
 #[derive(Clone, Debug)]
@@ -207,16 +206,12 @@ pub enum CopyDataType {
     /// scenario where we wish to accumulate the value (RLC) over all rows.
     /// This is used for Copy Lookup from SHA3 opcode verification.
     RlcAcc,
-    /// When the source of the copy is a call to a precompiled contract.
-    Precompile(PrecompileCalls),
 }
 impl CopyDataType {
-    /// Get variants that represent a precompile call.
-    pub fn precompile_types() -> Vec<Self> {
-        PrecompileCalls::iter().map(Self::Precompile).collect()
-    }
+    /// How many bits are necessary to represent a copy data type.
+    pub const N_BITS: usize = 3usize;
 }
-const NUM_COPY_DATA_TYPES: usize = 15usize;
+const NUM_COPY_DATA_TYPES: usize = 6usize;
 pub struct CopyDataTypeIter {
     idx: usize,
     back_idx: usize,
@@ -231,15 +226,6 @@ impl CopyDataTypeIter {
             3usize => Some(CopyDataType::TxCalldata),
             4usize => Some(CopyDataType::TxLog),
             5usize => Some(CopyDataType::RlcAcc),
-            6usize => Some(CopyDataType::Precompile(PrecompileCalls::Ecrecover)),
-            7usize => Some(CopyDataType::Precompile(PrecompileCalls::Sha256)),
-            8usize => Some(CopyDataType::Precompile(PrecompileCalls::Ripemd160)),
-            9usize => Some(CopyDataType::Precompile(PrecompileCalls::Identity)),
-            10usize => Some(CopyDataType::Precompile(PrecompileCalls::Modexp)),
-            11usize => Some(CopyDataType::Precompile(PrecompileCalls::Bn128Add)),
-            12usize => Some(CopyDataType::Precompile(PrecompileCalls::Bn128Mul)),
-            13usize => Some(CopyDataType::Precompile(PrecompileCalls::Bn128Pairing)),
-            14usize => Some(CopyDataType::Precompile(PrecompileCalls::Blake2F)),
             _ => None,
         }
     }
@@ -306,7 +292,6 @@ impl From<CopyDataType> for usize {
             CopyDataType::TxCalldata => 3,
             CopyDataType::TxLog => 4,
             CopyDataType::RlcAcc => 5,
-            CopyDataType::Precompile(prec_call) => 5 + usize::from(prec_call),
         }
     }
 }
@@ -320,7 +305,6 @@ impl From<&CopyDataType> for u64 {
             CopyDataType::TxCalldata => 3,
             CopyDataType::TxLog => 4,
             CopyDataType::RlcAcc => 5,
-            CopyDataType::Precompile(prec_call) => 5 + u64::from(*prec_call),
         }
     }
 }

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -448,6 +448,16 @@ impl CopyEvent {
         self.dst_type == CopyDataType::Memory || self.dst_type == CopyDataType::TxLog
     }
 
+    /// Whether the RLC of data must be computed.
+    pub fn has_rlc(&self) -> bool {
+        match (self.src_type, self.dst_type) {
+            (CopyDataType::RlcAcc, _) => true,
+            (_, CopyDataType::RlcAcc) => true,
+            (_, CopyDataType::Bytecode) => true,
+            _ => false,
+        }
+    }
+
     /// The RW counter of the first RW lookup performed by this copy event.
     pub fn rw_counter_start(&self) -> u64 {
         usize::from(self.rw_counter_start) as u64

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -434,12 +434,10 @@ impl CopyEvent {
 
     /// Whether the RLC of data must be computed.
     pub fn has_rlc(&self) -> bool {
-        match (self.src_type, self.dst_type) {
-            (CopyDataType::RlcAcc, _) => true,
-            (_, CopyDataType::RlcAcc) => true,
-            (_, CopyDataType::Bytecode) => true,
-            _ => false,
-        }
+        matches!(
+            (self.src_type, self.dst_type),
+            (CopyDataType::RlcAcc, _) | (_, CopyDataType::RlcAcc) | (_, CopyDataType::Bytecode)
+        )
     }
 
     /// The RW counter of the first RW lookup performed by this copy event.

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -374,7 +374,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             src_addr: callee_call.call_data_offset,
                             src_addr_end: callee_call.call_data_offset + n_input_bytes as u64,
                             dst_id: NumberOrHash::Number(callee_call.call_id),
-                            dst_type: CopyDataType::Precompile(precompile_call),
+                            dst_type: CopyDataType::RlcAcc,
                             dst_addr: 0,
                             log_id: None,
                             rw_counter_start,
@@ -400,7 +400,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         &mut exec_step,
                         CopyEvent {
                             src_id: NumberOrHash::Number(callee_call.call_id),
-                            src_type: CopyDataType::Precompile(precompile_call),
+                            src_type: CopyDataType::RlcAcc,
                             src_addr: 0,
                             src_addr_end: result.len() as u64,
                             dst_id: NumberOrHash::Number(callee_call.call_id),

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -92,9 +92,6 @@ pub struct CopyCircuitConfig<F> {
     /// In case of a bytecode tag, this denotes whether or not the copied byte
     /// is an opcode or push data byte.
     pub is_code: Column<Advice>,
-    /// Indicates whether or not the copy event copies bytes to a precompiled call or copies bytes
-    /// from a precompiled call back to caller.
-    pub is_precompiled: Column<Advice>,
     /// Booleans to indicate what copy data type exists at the current row.
     pub is_tx_calldata: Column<Advice>,
     /// Booleans to indicate what copy data type exists at the current row.
@@ -166,8 +163,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
         let value_acc = meta.advice_column_in(SecondPhase);
 
         let is_code = meta.advice_column();
-        let (is_precompiled, is_tx_calldata, is_bytecode, is_memory, is_tx_log) = (
-            meta.advice_column(),
+        let (is_tx_calldata, is_bytecode, is_memory, is_tx_log) = (
             meta.advice_column(),
             meta.advice_column(),
             meta.advice_column(),
@@ -214,7 +210,6 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             meta,
             q_enable,
             &tag,
-            is_precompiled,
             is_tx_calldata,
             is_bytecode,
             is_memory,
@@ -293,18 +288,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 challenges.keccak_input(),
             );
 
-            constrain_event_rlc_acc(
-                cb,
-                meta,
-                is_last_col,
-                value_acc,
-                rlc_acc,
-                is_precompiled,
-                is_memory,
-                is_tx_calldata,
-                is_bytecode,
-                tag,
-            );
+            constrain_event_rlc_acc(cb, meta, is_last_col, value_acc, rlc_acc, is_bytecode, tag);
 
             // Apply the same constraints for the RLCs of words before and after the write.
             let word_rlc_both = [(value_word_rlc, value), (value_word_rlc_prev, value_prev)];
@@ -464,7 +448,6 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             value_acc,
             is_pad,
             is_code,
-            is_precompiled,
             is_tx_calldata,
             is_bytecode,
             is_memory,
@@ -488,7 +471,7 @@ impl<F: Field> CopyCircuitConfig<F> {
         &self,
         region: &mut Region<F>,
         offset: &mut usize,
-        tag_chip: &BinaryNumberChip<F, CopyDataType, 4>,
+        tag_chip: &BinaryNumberChip<F, CopyDataType, { CopyDataType::N_BITS }>,
         is_src_end_chip: &IsEqualChip<F>,
         lt_word_end_chip: &IsEqualChip<F>,
         challenges: Challenges<Value<F>>,
@@ -583,15 +566,6 @@ impl<F: Field> CopyCircuitConfig<F> {
                 || Value::known(F::from(non_pad_non_mask)),
             )?;
 
-            // if the memory copy operation is related to precompile calls.
-            let is_precompiled = CopyDataType::precompile_types().contains(tag);
-            assert!(!is_precompiled, "CopyDataType::Precompile is deprecated");
-            region.assign_advice(
-                || format!("is_precompiled at row: {}", *offset),
-                self.is_precompiled,
-                *offset,
-                || Value::known(F::from(is_precompiled)),
-            )?;
             region.assign_advice(
                 || format!("is_tx_calldata at row: {}", *offset),
                 self.is_tx_calldata,
@@ -725,7 +699,7 @@ impl<F: Field> CopyCircuitConfig<F> {
         region: &mut Region<F>,
         offset: &mut usize,
         enabled: bool,
-        tag_chip: &BinaryNumberChip<F, CopyDataType, 4>,
+        tag_chip: &BinaryNumberChip<F, CopyDataType, { CopyDataType::N_BITS }>,
         is_src_end_chip: &IsEqualChip<F>,
         lt_word_end_chip: &IsEqualChip<F>,
     ) -> Result<(), Error> {
@@ -899,7 +873,6 @@ impl<F: Field> CopyCircuitConfig<F> {
         )?;
 
         for column in [
-            self.is_precompiled,
             self.is_tx_calldata,
             self.is_bytecode,
             self.is_memory,

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -585,6 +585,7 @@ impl<F: Field> CopyCircuitConfig<F> {
 
             // if the memory copy operation is related to precompile calls.
             let is_precompiled = CopyDataType::precompile_types().contains(tag);
+            assert!(!is_precompiled, "CopyDataType::Precompile is deprecated");
             region.assign_advice(
                 || format!("is_precompiled at row: {}", *offset),
                 self.is_precompiled,

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -223,6 +223,8 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             // Detect the first row of an event. When true, both reader and writer are initialized.
             let is_first = meta.query_advice(is_first, CURRENT);
             // Detect the last step of an event. This works on both reader and writer rows.
+            // This is a boolean since is_last cannot be true on both rows because of constraint
+            // "is_last == 0 when q_step == 1" and the alternating values of q_step.
             let is_last_step =
                 meta.query_advice(is_last, CURRENT) + meta.query_advice(is_last, NEXT_ROW);
             // Whether this row is part of an event but not the last step. When true, the next step

--- a/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
+++ b/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
@@ -363,24 +363,17 @@ pub fn constrain_event_rlc_acc<F: Field>(
         );
     });
 
+    cb.require_zero("", meta.query_advice(is_precompiled, CURRENT));
+    cb.require_zero("", meta.query_advice(is_precompiled, NEXT_ROW));
+
     // Check the rlc_acc given in the event if any of:
-    // - Precompile => *
-    // - * => Precompile
-    // - Memory => Bytecode
-    // - TxCalldata => Bytecode
+    // - RlcAcc => *
     // - * => RlcAcc
+    // - * => Bytecode
     let rlc_acc_cond = sum::expr([
-        meta.query_advice(is_precompiled, CURRENT),
-        meta.query_advice(is_precompiled, NEXT_ROW),
-        and::expr([
-            meta.query_advice(is_memory, CURRENT),
-            meta.query_advice(is_bytecode, NEXT_ROW),
-        ]),
-        and::expr([
-            meta.query_advice(is_tx_calldata, CURRENT),
-            meta.query_advice(is_bytecode, NEXT_ROW),
-        ]),
+        tag.value_equals(CopyDataType::RlcAcc, CURRENT)(meta),
         tag.value_equals(CopyDataType::RlcAcc, NEXT_ROW)(meta),
+        meta.query_advice(is_bytecode, NEXT_ROW),
     ]);
 
     cb.condition(rlc_acc_cond * meta.query_advice(is_last, NEXT_ROW), |cb| {

--- a/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
+++ b/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
@@ -1,5 +1,5 @@
 use super::{CURRENT, NEXT_ROW, NEXT_STEP};
-use bus_mapping::{circuit_input_builder::CopyDataType, precompile::PrecompileCalls};
+use bus_mapping::circuit_input_builder::CopyDataType;
 use eth_types::Field;
 use gadgets::{
     binary_number::BinaryNumberConfig,
@@ -14,8 +14,7 @@ use crate::evm_circuit::util::constraint_builder::{BaseConstraintBuilder, Constr
 pub fn constrain_tag<F: Field>(
     meta: &mut ConstraintSystem<F>,
     q_enable: Column<Fixed>,
-    tag: &BinaryNumberConfig<CopyDataType, 4>,
-    is_precompiled: Column<Advice>,
+    tag: &BinaryNumberConfig<CopyDataType, { CopyDataType::N_BITS }>,
     is_tx_calldata: Column<Advice>,
     is_bytecode: Column<Advice>,
     is_memory: Column<Advice>,
@@ -23,34 +22,12 @@ pub fn constrain_tag<F: Field>(
 ) {
     meta.create_gate("decode tag", |meta| {
         let enabled = meta.query_fixed(q_enable, CURRENT);
-        let is_precompile = meta.query_advice(is_precompiled, CURRENT);
         let is_tx_calldata = meta.query_advice(is_tx_calldata, CURRENT);
         let is_bytecode = meta.query_advice(is_bytecode, CURRENT);
         let is_memory = meta.query_advice(is_memory, CURRENT);
         let is_tx_log = meta.query_advice(is_tx_log, CURRENT);
-        let precompiles = sum::expr([
-            tag.value_equals(
-                CopyDataType::Precompile(PrecompileCalls::Ecrecover),
-                CURRENT,
-            )(meta),
-            tag.value_equals(CopyDataType::Precompile(PrecompileCalls::Sha256), CURRENT)(meta),
-            tag.value_equals(
-                CopyDataType::Precompile(PrecompileCalls::Ripemd160),
-                CURRENT,
-            )(meta),
-            tag.value_equals(CopyDataType::Precompile(PrecompileCalls::Identity), CURRENT)(meta),
-            tag.value_equals(CopyDataType::Precompile(PrecompileCalls::Modexp), CURRENT)(meta),
-            tag.value_equals(CopyDataType::Precompile(PrecompileCalls::Bn128Add), CURRENT)(meta),
-            tag.value_equals(CopyDataType::Precompile(PrecompileCalls::Bn128Mul), CURRENT)(meta),
-            tag.value_equals(
-                CopyDataType::Precompile(PrecompileCalls::Bn128Pairing),
-                CURRENT,
-            )(meta),
-            tag.value_equals(CopyDataType::Precompile(PrecompileCalls::Blake2F), CURRENT)(meta),
-        ]);
         vec![
             // Match boolean indicators to their respective tag values.
-            enabled.expr() * (is_precompile - precompiles),
             enabled.expr()
                 * (is_tx_calldata - tag.value_equals(CopyDataType::TxCalldata, CURRENT)(meta)),
             enabled.expr()
@@ -85,7 +62,7 @@ pub fn constrain_must_terminate<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,
     q_enable: Column<Fixed>,
-    tag: &BinaryNumberConfig<CopyDataType, 4>,
+    tag: &BinaryNumberConfig<CopyDataType, { CopyDataType::N_BITS }>,
 ) {
     // If an event has started (tag != Padding on reader and writer rows), require q_enable=1 at the
     // next step. This prevents querying rows where constraints are disabled.
@@ -109,7 +86,7 @@ pub fn constrain_forward_parameters<F: Field>(
     meta: &mut VirtualCells<'_, F>,
     is_continue: Expression<F>,
     id: Column<Advice>,
-    tag: BinaryNumberConfig<CopyDataType, 4>,
+    tag: BinaryNumberConfig<CopyDataType, { CopyDataType::N_BITS }>,
     src_addr_end: Column<Advice>,
 ) {
     cb.condition(is_continue.expr(), |cb| {
@@ -347,11 +324,8 @@ pub fn constrain_event_rlc_acc<F: Field>(
     value_acc: Column<Advice>,
     rlc_acc: Column<Advice>,
     // The flags to determine whether rlc_acc is requested from the event.
-    is_precompiled: Column<Advice>,
-    is_memory: Column<Advice>,
-    is_tx_calldata: Column<Advice>,
     is_bytecode: Column<Advice>,
-    tag: BinaryNumberConfig<CopyDataType, 4>,
+    tag: BinaryNumberConfig<CopyDataType, { CopyDataType::N_BITS }>,
 ) {
     // Forward rlc_acc from the event to all rows.
     let not_last = not::expr(meta.query_advice(is_last, CURRENT));
@@ -363,13 +337,11 @@ pub fn constrain_event_rlc_acc<F: Field>(
         );
     });
 
-    cb.require_zero("", meta.query_advice(is_precompiled, CURRENT));
-    cb.require_zero("", meta.query_advice(is_precompiled, NEXT_ROW));
-
     // Check the rlc_acc given in the event if any of:
     // - RlcAcc => *
     // - * => RlcAcc
     // - * => Bytecode
+    // See also `CopyEvent::has_rlc()`
     let rlc_acc_cond = sum::expr([
         tag.value_equals(CopyDataType::RlcAcc, CURRENT)(meta),
         tag.value_equals(CopyDataType::RlcAcc, NEXT_ROW)(meta),

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -406,7 +406,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                             cb.curr.state.call_id.expr(),
                             CopyDataType::Memory.expr(),
                             callee_call_id.expr(),
-                            5.expr() + call_gadget.callee_address_expr(), // refer u64::from(CopyDataType)
+                            CopyDataType::RlcAcc.expr(),
                             call_gadget.cd_address.offset(),
                             call_gadget.cd_address.offset() + precompile_input_len.expr(),
                             0.expr(),
@@ -429,7 +429,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                         let precompile_output_bytes_rlc = cb.query_cell_phase2();
                         cb.copy_table_lookup(
                             callee_call_id.expr(),
-                            5.expr() + call_gadget.callee_address_expr(), // refer u64::from(CopyDataType)
+                            CopyDataType::RlcAcc.expr(),
                             callee_call_id.expr(),
                             CopyDataType::Memory.expr(),
                             0.expr(),

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1517,7 +1517,7 @@ pub struct CopyTable {
     /// Binary chip to constrain the copy table conditionally depending on the
     /// current row's tag, whether it is Bytecode, Memory, TxCalldata or
     /// TxLog. This also now includes various precompile calls, hence will take up more cells.
-    pub tag: BinaryNumberConfig<CopyDataType, 4>,
+    pub tag: BinaryNumberConfig<CopyDataType, { CopyDataType::N_BITS }>,
 }
 
 type CopyTableRow<F> = [(Value<F>, &'static str); 8];
@@ -1561,6 +1561,11 @@ impl CopyTable {
         challenges: Challenges<Value<F>>,
     ) -> Vec<(CopyDataType, CopyTableRow<F>, CopyCircuitRow<F>)> {
         assert!(copy_event.src_addr_end >= copy_event.src_addr);
+        assert!(
+            copy_event.src_type != CopyDataType::Padding
+                && copy_event.dst_type != CopyDataType::Padding,
+            "Padding is an internal type"
+        );
 
         let mut assignments = Vec::new();
         // rlc_acc
@@ -1702,15 +1707,6 @@ impl CopyTable {
                     .unwrap()
             } else {
                 F::from(thread.addr)
-            };
-
-            match copy_event.src_type {
-                CopyDataType::Precompile(_) => panic!("XXX src CopyDataType::Precompile"),
-                _ => {}
-            };
-            match copy_event.dst_type {
-                CopyDataType::Precompile(_) => panic!("XXX dst CopyDataType::Precompile"),
-                _ => {}
             };
 
             assignments.push((


### PR DESCRIPTION
The Copy circuit does not need to know anything special about precompiles.

- Migrate precompile code to `CopyDataType::RlcAcc`.
- Remove `CopyDataType::Precompile` and special cases.
- Reduce the tag decomposition back to 3 bits.
- Clarify the logic around `rlc_acc`.

This solves TOB-SCROLL2-7 (clearer tag logic) and TOB-SCROLL2-11 (explained `is_last_step`).