### PR TITLE
Feat: handle oog for precompiles

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     circuit_input_builder::CallContext,
-    error::ExecError,
+    error::{ExecError, OogError},
     exec_trace::OperationRef,
     operation::RWCounter,
     precompile::{PrecompileAuxData, PrecompileCalls},
@@ -106,6 +106,11 @@ impl ExecStep {
     /// Returns `true` if this is an execution step of Precompile.
     pub fn is_precompiled(&self) -> bool {
         matches!(self.exec_state, ExecState::Precompile(_))
+    }
+
+    /// Returns `true` if `error` is oog in precompile calls
+    pub fn is_precompile_oog_err(&self) -> bool {
+        matches!(self.error, Some(ExecError::OutOfGas(OogError::Precompile)))
     }
 }
 

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1679,7 +1679,6 @@ impl<'a> CircuitInputStateRef<'a> {
                             );
                             return Ok(Some(ExecError::PrecompileFailed));
                         }
-                        // FIXME: remove this branch once modexp invalid cases are handled.
                         PrecompileCalls::Modexp => {
                             // Log the precompile address and gas left. Since this failure is mainly
                             // caused by out of gas.
@@ -1688,7 +1687,7 @@ impl<'a> CircuitInputStateRef<'a> {
                                 code_address,
                                 step.gas.0,
                             );
-                            return Ok(Some(ExecError::PrecompileFailed));
+                            return Ok(None);
                         }
                         pre_call => {
                             log::trace!("precompile call failed for {:?}", pre_call);

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1656,6 +1656,10 @@ impl<'a> CircuitInputStateRef<'a> {
                 OpcodeId::CALL | OpcodeId::CALLCODE | OpcodeId::DELEGATECALL | OpcodeId::STATICCALL
             ) {
                 let code_address = step.stack.nth_last(1)?.to_address();
+                // NOTE: we do not know the amount of gas that precompile got here
+                //   because the callGasTemp might probably be smaller than the gas
+                //   on top of the stack (step.stack.last())
+                // Therefore we postpone the oog handling to the implementor of callop.
                 if is_precompiled(&code_address) {
                     let precompile_call: PrecompileCalls = code_address[19].into();
                     match precompile_call {

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1295,7 +1295,11 @@ impl<'a> CircuitInputStateRef<'a> {
 
         // successful revert also makes call.is_success == false
         // but this "successful revert" should not be handled here
-        if !is_return_revert_succ && !call.is_success && !exec_step.is_precompiled() {
+        if !is_return_revert_succ
+            && !call.is_success
+            && !exec_step.is_precompiled()
+            && !exec_step.is_precompile_oog_err()
+        {
             // add call failure ops for exception cases
             self.call_context_read(
                 exec_step,

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -96,6 +96,8 @@ pub enum OogError {
     SloadSstore,
     /// Out of Gas for CALL, CALLCODE, DELEGATECALL and STATICCALL
     Call,
+    /// Out of Gas for Precompile
+    Precompile,
     /// Out of Gas for CREATE and CREATE2
     Create,
     /// Out of Gas for SELFDESTRUCT

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -73,6 +73,7 @@ mod error_oog_account_access;
 mod error_oog_call;
 mod error_oog_log;
 mod error_oog_memory_copy;
+mod error_oog_precompile;
 mod error_oog_sload_sstore;
 mod error_precompile_failed;
 mod error_return_data_outofbound;

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -457,7 +457,8 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                 } else {
                     None
                 };
-                if has_oog_err {
+                // modexp's oog error is handled in ModExpGadget
+                if has_oog_err && precompile_call != PrecompileCalls::Modexp {
                     log::debug!(
                         "precompile call ({:?}) runs out of gas: callee_gas_left_with_stipend = {}",
                         precompile_call,

--- a/bus-mapping/src/evm/opcodes/error_oog_precompile.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_precompile.rs
@@ -23,7 +23,7 @@ impl ErrorOOGPrecompile {
             &mut exec_step,
             call.call_id,
             CallContextField::CalleeAddress,
-            call.address.to_word(),
+            call.code_address().unwrap().to_word(),
         );
         state.call_context_read(
             &mut exec_step,

--- a/bus-mapping/src/evm/opcodes/error_oog_precompile.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_precompile.rs
@@ -1,0 +1,37 @@
+use crate::{
+    circuit_input_builder::{Call, CircuitInputStateRef, ExecStep},
+    error::{ExecError, OogError},
+    operation::CallContextField,
+    Error,
+};
+use eth_types::{GethExecStep, ToWord};
+
+#[derive(Copy, Clone, Debug)]
+pub struct ErrorOOGPrecompile;
+
+impl ErrorOOGPrecompile {
+    pub fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_step: &GethExecStep,
+        call: Call,
+    ) -> Result<ExecStep, Error> {
+        let mut exec_step = state.new_step(geth_step)?;
+        exec_step.error = Some(ExecError::OutOfGas(OogError::Precompile));
+
+        // callee_address
+        state.call_context_read(
+            &mut exec_step,
+            call.call_id,
+            CallContextField::CalleeAddress,
+            call.address.to_word(),
+        );
+        state.call_context_read(
+            &mut exec_step,
+            call.call_id,
+            CallContextField::CallDataLength,
+            call.call_data_length.into(),
+        );
+
+        Ok(exec_step)
+    }
+}

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -42,24 +42,7 @@ pub(crate) fn execute_precompiled(
         }
         Err(err) => match err {
             PrecompileError::OutOfGas => (vec![], gas, true),
-            PrecompileError::Blake2WrongLength => {
-                todo!()
-            }
-            PrecompileError::Blake2WrongFinalIndicatorFlag => {
-                todo!()
-            }
-            PrecompileError::ModexpExpOverflow => {
-                todo!()
-            }
-            PrecompileError::ModexpBaseOverflow => {
-                todo!()
-            }
-            PrecompileError::ModexpModOverflow => {
-                todo!()
-            }
-            PrecompileError::Bn128FieldPointNotAMember
-            | PrecompileError::Bn128AffineGFailedToCreate
-            | PrecompileError::Bn128PairLength => (vec![], gas, false),
+            _ => (vec![], gas, false),
         },
     }
 }

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -1,7 +1,7 @@
 //! precompile helpers
 
 use eth_types::{evm_types::GasCost, Address, ToBigEndian, Word};
-use revm_precompile::{Precompile, Precompiles};
+use revm_precompile::{Precompile, PrecompileError, Precompiles};
 use strum::EnumIter;
 
 use crate::circuit_input_builder::{EcMulOp, EcPairingOp};
@@ -13,7 +13,11 @@ pub fn is_precompiled(address: &Address) -> bool {
         .is_some()
 }
 
-pub(crate) fn execute_precompiled(address: &Address, input: &[u8], gas: u64) -> (Vec<u8>, u64) {
+pub(crate) fn execute_precompiled(
+    address: &Address,
+    input: &[u8],
+    gas: u64,
+) -> (Vec<u8>, u64, bool) {
     let Some(Precompile::Standard(precompile_fn)) = Precompiles::berlin()
         .get(address.as_fixed_bytes())  else {
         panic!("calling non-exist precompiled contract address")
@@ -28,15 +32,35 @@ pub(crate) fn execute_precompiled(address: &Address, input: &[u8], gas: u64) -> 
                     if input_valid {
                         // detect some edge cases like modulus = 0
                         assert_eq!(modulus_len.as_usize(), return_value.len());
-                        (return_value, gas_cost)
+                        (return_value, gas_cost, false) // no oog error
                     } else {
-                        (vec![], gas)
+                        (vec![], gas, false)
                     }
                 }
-                _ => (return_value, gas_cost),
+                _ => (return_value, gas_cost, false),
             }
         }
-        Err(_) => (vec![], gas),
+        Err(err) => match err {
+            PrecompileError::OutOfGas => (vec![], gas, true),
+            PrecompileError::Blake2WrongLength => {
+                todo!()
+            }
+            PrecompileError::Blake2WrongFinalIndicatorFlag => {
+                todo!()
+            }
+            PrecompileError::ModexpExpOverflow => {
+                todo!()
+            }
+            PrecompileError::ModexpBaseOverflow => {
+                todo!()
+            }
+            PrecompileError::ModexpModOverflow => {
+                todo!()
+            }
+            PrecompileError::Bn128FieldPointNotAMember
+            | PrecompileError::Bn128AffineGFailedToCreate
+            | PrecompileError::Bn128PairLength => (vec![], gas, false),
+        },
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -196,6 +196,7 @@ use jump::JumpGadget;
 use jumpdest::JumpdestGadget;
 use jumpi::JumpiGadget;
 
+use crate::evm_circuit::execution::error_oog_precompile::ErrorOOGPrecompileGadget;
 use memory::MemoryGadget;
 use msize::MsizeGadget;
 use mul_div_mod::MulDivModGadget;
@@ -329,6 +330,7 @@ pub(crate) struct ExecutionConfig<F> {
     block_ctx_u256_gadget: Box<BlockCtxU256Gadget<F>>,
     // error gadgets
     error_oog_call: Box<ErrorOOGCallGadget<F>>,
+    error_oog_precompile: Box<ErrorOOGPrecompileGadget<F>>,
     error_oog_constant: Box<ErrorOOGConstantGadget<F>>,
     error_oog_exp: Box<ErrorOOGExpGadget<F>>,
     error_oog_memory_copy: Box<ErrorOOGMemoryCopyGadget<F>>,
@@ -612,6 +614,7 @@ impl<F: Field> ExecutionConfig<F> {
             error_oog_log: configure_gadget!(),
             error_oog_sload_sstore: configure_gadget!(),
             error_oog_call: configure_gadget!(),
+            error_oog_precompile: configure_gadget!(),
             error_oog_memory_copy: configure_gadget!(),
             error_oog_account_access: configure_gadget!(),
             error_oog_sha3: configure_gadget!(),
@@ -1457,6 +1460,9 @@ impl<F: Field> ExecutionConfig<F> {
             }
             ExecutionState::ErrorOutOfGasCall => {
                 assign_exec_step!(self.error_oog_call)
+            }
+            ExecutionState::ErrorOutOfGasPrecompile => {
+                assign_exec_step!(self.error_oog_precompile)
             }
             ExecutionState::ErrorOutOfGasDynamicMemoryExpansion => {
                 assign_exec_step!(self.error_oog_dynamic_memory_gadget)

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -94,6 +94,7 @@ mod error_oog_dynamic_memory;
 mod error_oog_exp;
 mod error_oog_log;
 mod error_oog_memory_copy;
+mod error_oog_precompile;
 mod error_oog_sha3;
 mod error_oog_sload_sstore;
 mod error_oog_static_memory;

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
@@ -243,6 +243,40 @@ mod test {
                         - 1).to_word(),
                     ..Default::default()
                 },
+                PrecompileCallArgs {
+                    name: "modexp length in u256",
+                    setup_code: bytecode! {
+                        // Base size
+                        PUSH1(0x20)
+                        PUSH1(0x00)
+                        MSTORE
+                        // Esize
+                        PUSH1(0x20)
+                        PUSH1(0x20)
+                        MSTORE
+                        // Msize
+                        PUSH1(0x20)
+                        PUSH1(0x40)
+                        MSTORE
+                        // B, E and M
+                        PUSH32(word!("0x0000000000000000000000000000000000000000000000000000000000000008"))
+                        PUSH1(0x60)
+                        MSTORE
+                        PUSH32(word!("0x1000000000000000000000000000000000000000000000000000000000000009"))
+                        PUSH1(0x80)
+                        MSTORE
+                        PUSH32(word!("0xfcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"))
+                        PUSH1(0xA0)
+                        MSTORE
+                    },
+                    call_data_offset: 0x0.into(),
+                    call_data_length: 0xc0.into(),
+                    ret_offset: 0xe0.into(),
+                    ret_size: 0x01.into(),
+                    address: PrecompileCalls::Modexp.address().to_word(),
+                    gas: 20.to_word(),
+                    ..Default::default()
+                },
             ]
         };
     }

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
@@ -1,0 +1,223 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_GAS},
+        step::{ExecutionState, ExecutionState::PrecompileBn256Add},
+        util::{
+            common_gadget::RestoreContextGadget,
+            constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+            from_bytes,
+            math_gadget::{BinaryNumberGadget, LtGadget},
+            CachedRegion, Cell,
+        },
+    },
+    table::CallContextFieldTag,
+    witness::{Block, Call, ExecStep, Tag::Value, Transaction},
+};
+use bus_mapping::precompile::PrecompileCalls;
+use eth_types::{evm_types::GasCost, Field};
+use gadgets::util::{expr_from_bytes, sum, Expr};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
+
+struct NPairsGadget<F> {
+    input_mod_192: Cell<F>,
+    input_div_192: Cell<F>,
+    input_mod_lt_192: LtGadget<F, 1>,
+}
+
+impl<F: Field> NPairsGadget<F> {
+    fn construct(cb: &mut EVMConstraintBuilder<F>, input_len: Expression<F>) -> Self {
+        // r == len(input) % 192
+        let input_mod_192 = cb.query_byte();
+        // r < 192
+        let input_mod_192_lt = LtGadget::construct(cb, input_mod_192.expr(), 192.expr());
+        cb.require_equal("len(input) % 192 < 192", input_mod_192_lt.expr(), 1.expr());
+        // q == len(input) // 192
+        let input_div_192 = cb.query_cell();
+        // q * 192 + r == call_data_length
+        cb.require_equal(
+            "q * 192 + r == len(input)",
+            input_div_192.expr() * 192.expr() + input_mod_192.expr(),
+            input_len,
+        );
+
+        Self {
+            input_mod_192,
+            input_div_192,
+            input_mod_lt_192,
+        }
+    }
+
+    fn assign(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        input_len: u64,
+    ) -> Result<(), Error> {
+        self.input_mod_192
+            .assign(region, offset, Value::known(F::from(input_len % 192)))?;
+        self.input_div_192
+            .assign(region, offset, Value::known(F::from(input_len / 192)))?;
+        self.input_mod_lt_192
+            .assign(region, offset, F::from(input_len % 192), F::from(192))?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ErrorOOGPrecompileGadget<F> {
+    addr_bits: BinaryNumberGadget<F, 4>,
+    call_data_length: Cell<F>,
+    n_pairs: NPairsGadget<F>,
+    required_gas: Cell<F>,
+    insufficient_gas: LtGadget<F, N_BYTES_GAS>,
+    restore_context: RestoreContextGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
+    const NAME: &'static str = "ErrorOutOfGasPrecompile";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::ErrorOutOfGasPrecompile;
+
+    fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
+        let required_gas = cb.query_cell();
+
+        // read callee_address
+        let precompile_addr = cb.call_context(None, CallContextFieldTag::CalleeAddress);
+        let addr_bits = BinaryNumberGadget::construct(cb, precompile_addr.expr());
+
+        // read call data length
+        let call_data_length = cb.call_context(None, CallContextFieldTag::CallDataLength);
+        let n_pairs = NPairsGadget::construct(cb, call_data_length.expr());
+
+        // calculate required gas for precompile
+        let precompiles_required_gas = vec![
+            (
+                addr_bits.value_equals(PrecompileCalls::Ecrecover),
+                GasCost::PRECOMPILE_ECRECOVER_BASE,
+            ),
+            // addr_bits.value_equals(PrecompileCalls::Sha256),
+            // addr_bits.value_equals(PrecompileCalls::Ripemd160),
+            // addr_bits.value_equals(PrecompileCalls::Blake2F),
+
+            // TODO: handle identity and modexp
+            // (addr_bits.value_equals(PrecompileCalls::Identity), 0.expr()),
+            // (addr_bits.value_equals(PrecompileCalls::Modexp),),
+            (
+                addr_bits.value_equals(PrecompileCalls::Bn128Add),
+                GasCost::PRECOMPILE_BN256ADD.as_u64().expr(),
+            ),
+            (
+                addr_bits.value_equals(PrecompileCalls::Bn128Mul),
+                GasCost::PRECOMPILE_BN256MUL.as_u64().expr(),
+            ),
+            (
+                addr_bits.value_equals(PrecompileCalls::Bn128Pairing),
+                GasCost::PRECOMPILE_BN256PAIRING.expr()
+                    + n_pairs.expr() * GasCost::PRECOMPILE_BN256PAIRING_PER_PAIR.expr(),
+            ),
+        ];
+
+        cb.require_equal(
+            "precompile_addr must be in precompile calls' set",
+            sum::expr(
+                precompiles_required_gas
+                    .iter()
+                    .map(|(cond, _)| cond)
+                    .cloned(),
+            ),
+            1.expr(),
+        );
+
+        cb.require_equal(
+            "require_gas == sum(is_precompile[addr] * required_gas[addr])",
+            required_gas.expr(),
+            precompiles_required_gas
+                .iter()
+                .fold(0.expr(), |acc, (condition, required_gas)| {
+                    acc + condition.expr() * required_gas.expr()
+                }),
+        );
+
+        // gas_left < required_gas
+        let insufficient_gas =
+            LtGadget::construct(cb, cb.curr.state.gas_left.expr(), required_gas.expr());
+        cb.require_equal(
+            "gas_left < required_gas",
+            lt_required_gas_gadget.expr(),
+            1.expr(),
+        );
+
+        let restore_context = RestoreContextGadget::construct2(
+            cb,
+            false.expr(),
+            cb.curr.state.gas_left.expr(),
+            0.expr(),
+            0.expr(), // ReturnDataOffset
+            0.expr(), // ReturnDataLength
+            0.expr(),
+            0.expr(),
+        );
+
+        Self {
+            required_gas,
+            insufficient_gas,
+            n_pairs,
+            addr_bits,
+            call_data_length,
+            restore_context,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        _transaction: &Transaction,
+        call: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        // addr_bits
+        let precompile_addr = call.callee_address;
+        self.addr_bits
+            .assign(region, offset, precompile_addr.to_fixed_bytes()[19])?;
+
+        // call_data_length
+        self.call_data_length.assign(
+            region,
+            offset,
+            Value::known(F::from(call.call_data_length)),
+        )?;
+
+        // n_pairs
+        let n_pairs = call.call_data_length / 192;
+        self.n_pairs.assign(region, offset, call.call_data_length)?;
+
+        // required_gas
+        let precompile_call: PrecompileCalls = call.callee_address.to_fixed_bytes()[19].into();
+        let required_gas = if precompile_call == PrecompileCalls::Bn128Pairing {
+            precompile_call.base_gas_cost() + n_pairs * PRECOMPILE_BN256PAIRING_PER_PAIR
+        } else {
+            precompile_call.base_gas_cost()
+        };
+        self.required_gas
+            .assign(region, offset, Value::known(F::from(required_gas.as_u64())))?;
+
+        // insufficient_gas
+        self.insufficient_gas.assign(
+            region,
+            offset,
+            F::from(step.gas_left),
+            F::from(required_gas.as_u64()),
+        )?;
+
+        // restore context
+        self.restore_context
+            .assign(region, offset, block, call, step, 2)
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
@@ -58,17 +58,16 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
                 addr_bits.value_equals(PrecompileCalls::Ecrecover),
                 GasCost::PRECOMPILE_ECRECOVER_BASE.expr(),
             ),
+            // These are handled in PrecompileFailedGadget
             // addr_bits.value_equals(PrecompileCalls::Sha256),
             // addr_bits.value_equals(PrecompileCalls::Ripemd160),
             // addr_bits.value_equals(PrecompileCalls::Blake2F),
-
-            // TODO: handle modexp
             (
                 addr_bits.value_equals(PrecompileCalls::Identity),
                 GasCost::PRECOMPILE_IDENTITY_BASE.expr()
                     + n_words.quotient() * GasCost::PRECOMPILE_IDENTITY_PER_WORD.expr(),
             ),
-            // (addr_bits.value_equals(PrecompileCalls::Modexp),),
+            // modexp is handled in ModExpGadget
             (
                 addr_bits.value_equals(PrecompileCalls::Bn128Add),
                 GasCost::PRECOMPILE_BN256ADD.as_u64().expr(),
@@ -85,7 +84,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
         ];
 
         cb.require_equal(
-            "precompile_addr must be in precompile calls' set",
+            "precompile_addr must belong to precompile calls' set",
             sum::expr(
                 precompiles_required_gas
                     .iter()

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
@@ -1,12 +1,12 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_GAS,
+        param::{N_BYTES_EC_PAIR, N_BYTES_GAS, N_BYTES_MEMORY_WORD_SIZE, N_BYTES_WORD},
         step::ExecutionState,
         util::{
             common_gadget::RestoreContextGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            math_gadget::{BinaryNumberGadget, LtGadget},
+            math_gadget::{BinaryNumberGadget, ConstantDivisionGadget, LtGadget},
             CachedRegion, Cell,
         },
     },
@@ -16,64 +16,15 @@ use crate::{
 use bus_mapping::precompile::PrecompileCalls;
 use eth_types::{evm_types::GasCost, Field, ToScalar};
 use gadgets::util::{sum, Expr};
-use halo2_proofs::{
-    circuit::Value,
-    plonk::{Error, Expression},
-};
-
-#[derive(Clone, Debug)]
-struct NPairsGadget<F> {
-    input_mod_192: Cell<F>,
-    input_div_192: Cell<F>,
-    input_mod_lt_192: LtGadget<F, 1>,
-}
-
-impl<F: Field> NPairsGadget<F> {
-    fn construct(cb: &mut EVMConstraintBuilder<F>, input_len: Expression<F>) -> Self {
-        // r == len(input) % 192
-        let input_mod_192 = cb.query_byte();
-        // r < 192
-        let input_mod_lt_192 = LtGadget::construct(cb, input_mod_192.expr(), 192.expr());
-        cb.require_equal("len(input) % 192 < 192", input_mod_lt_192.expr(), 1.expr());
-        // q == len(input) // 192
-        let input_div_192 = cb.query_cell();
-        // q * 192 + r == call_data_length
-        cb.require_equal(
-            "q * 192 + r == len(input)",
-            input_div_192.expr() * 192.expr() + input_mod_192.expr(),
-            input_len,
-        );
-
-        Self {
-            input_mod_192,
-            input_div_192,
-            input_mod_lt_192,
-        }
-    }
-
-    fn assign(
-        &self,
-        region: &mut CachedRegion<'_, '_, F>,
-        offset: usize,
-        input_len: u64,
-    ) -> Result<(), Error> {
-        self.input_mod_192
-            .assign(region, offset, Value::known(F::from(input_len % 192)))?;
-        self.input_div_192
-            .assign(region, offset, Value::known(F::from(input_len / 192)))?;
-        self.input_mod_lt_192
-            .assign(region, offset, F::from(input_len % 192), F::from(192))?;
-
-        Ok(())
-    }
-}
+use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorOOGPrecompileGadget<F> {
     precompile_addr: Cell<F>,
     addr_bits: BinaryNumberGadget<F, 4>,
     call_data_length: Cell<F>,
-    n_pairs: NPairsGadget<F>,
+    n_pairs: ConstantDivisionGadget<F, 1>, // 1 is enough as call_data_length < 192*256
+    n_words: ConstantDivisionGadget<F, N_BYTES_MEMORY_WORD_SIZE>,
     required_gas: Cell<F>,
     insufficient_gas: LtGadget<F, N_BYTES_GAS>,
     restore_context: RestoreContextGadget<F>,
@@ -93,7 +44,13 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
 
         // read call data length
         let call_data_length = cb.call_context(None, CallContextFieldTag::CallDataLength);
-        let n_pairs = NPairsGadget::construct(cb, call_data_length.expr());
+        let n_pairs =
+            ConstantDivisionGadget::construct(cb, call_data_length.expr(), N_BYTES_EC_PAIR as u64);
+        let n_words = ConstantDivisionGadget::construct(
+            cb,
+            call_data_length.expr() + (N_BYTES_WORD - 1).expr(),
+            N_BYTES_WORD as u64,
+        );
 
         // calculate required gas for precompile
         let precompiles_required_gas = vec![
@@ -105,8 +62,12 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
             // addr_bits.value_equals(PrecompileCalls::Ripemd160),
             // addr_bits.value_equals(PrecompileCalls::Blake2F),
 
-            // TODO: handle identity and modexp
-            // (addr_bits.value_equals(PrecompileCalls::Identity), 0.expr()),
+            // TODO: handle modexp
+            (
+                addr_bits.value_equals(PrecompileCalls::Identity),
+                GasCost::PRECOMPILE_IDENTITY_BASE.expr()
+                    + n_words.quotient() * GasCost::PRECOMPILE_IDENTITY_PER_WORD.expr(),
+            ),
             // (addr_bits.value_equals(PrecompileCalls::Modexp),),
             (
                 addr_bits.value_equals(PrecompileCalls::Bn128Add),
@@ -119,8 +80,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
             (
                 addr_bits.value_equals(PrecompileCalls::Bn128Pairing),
                 GasCost::PRECOMPILE_BN256PAIRING.expr()
-                    + n_pairs.input_div_192.expr()
-                        * GasCost::PRECOMPILE_BN256PAIRING_PER_PAIR.expr(),
+                    + n_pairs.quotient() * GasCost::PRECOMPILE_BN256PAIRING_PER_PAIR.expr(),
             ),
         ];
 
@@ -166,6 +126,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
             required_gas,
             insufficient_gas,
             n_pairs,
+            n_words,
             addr_bits,
             call_data_length,
             restore_context,
@@ -200,16 +161,34 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
 
         // n_pairs
         let n_pairs = call.call_data_length / 192;
-        self.n_pairs.assign(region, offset, call.call_data_length)?;
+        self.n_pairs
+            .assign(region, offset, call.call_data_length as u128)?;
+
+        // n_words
+        self.n_words.assign(
+            region,
+            offset,
+            (call.call_data_length + (N_BYTES_WORD as u64) - 1) as u128,
+        )?;
 
         // required_gas
         let precompile_call: PrecompileCalls = precompile_addr.to_fixed_bytes()[19].into();
-        let required_gas = if precompile_call == PrecompileCalls::Bn128Pairing {
-            precompile_call.base_gas_cost().as_u64()
-                + n_pairs * GasCost::PRECOMPILE_BN256PAIRING_PER_PAIR.as_u64()
-        } else {
-            precompile_call.base_gas_cost().as_u64()
+        let required_gas = match precompile_call {
+            PrecompileCalls::Bn128Pairing => {
+                precompile_call.base_gas_cost().as_u64()
+                    + n_pairs * GasCost::PRECOMPILE_BN256PAIRING_PER_PAIR.as_u64()
+            }
+            PrecompileCalls::Identity => {
+                let n_words = (call.call_data_length + 31) / 32;
+                precompile_call.base_gas_cost().as_u64()
+                    + n_words * GasCost::PRECOMPILE_IDENTITY_PER_WORD.as_u64()
+            }
+            PrecompileCalls::Bn128Add | PrecompileCalls::Bn128Mul | PrecompileCalls::Ecrecover => {
+                precompile_call.base_gas_cost().as_u64()
+            }
+            _ => unreachable!(),
         };
+
         self.required_gas
             .assign(region, offset, Value::known(F::from(required_gas)))?;
 
@@ -224,5 +203,67 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
         // restore context
         self.restore_context
             .assign(region, offset, block, call, step, 2)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_util::CircuitTestBuilder;
+    use bus_mapping::{evm::PrecompileCallArgs, precompile::PrecompileCalls};
+    use eth_types::{
+        bytecode,
+        evm_types::{GasCost, OpcodeId},
+        word, ToWord,
+    };
+    use itertools::Itertools;
+    use mock::TestContext;
+
+    lazy_static::lazy_static! {
+        static ref TEST_VECTOR: Vec<PrecompileCallArgs> = {
+            vec![
+                PrecompileCallArgs {
+                    name: "multi-bytes success (more than 32 bytes)",
+                    setup_code: bytecode! {
+                        // place params in memory
+                        PUSH30(word!("0x0123456789abcdef0f1e2d3c4b5a6978"))
+                        PUSH1(0x00) // place from 0x00 in memory
+                        MSTORE
+                        PUSH30(word!("0xaabbccdd001122331039abcdefefef84"))
+                        PUSH1(0x20) // place from 0x20 in memory
+                        MSTORE
+                    },
+                    // copy 63 bytes from memory addr 0
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x3f.into(),
+                    // return only 35 bytes and write from memory addr 72
+                    ret_offset: 0x48.into(),
+                    ret_size: 0x23.into(),
+                    address: PrecompileCalls::Identity.address().to_word(),
+                    gas: (PrecompileCalls::Identity.base_gas_cost().as_u64()
+                        + 2 * GasCost::PRECOMPILE_IDENTITY_PER_WORD.as_u64()
+                        - 1).to_word(),
+                    ..Default::default()
+                },
+            ]
+        };
+    }
+
+    #[test]
+    fn precompile_oog_test() {
+        let call_kinds = vec![
+            OpcodeId::CALL,
+            OpcodeId::STATICCALL,
+            OpcodeId::DELEGATECALL,
+            OpcodeId::CALLCODE,
+        ];
+
+        for (test_vector, &call_kind) in TEST_VECTOR.iter().cartesian_product(&call_kinds) {
+            let bytecode = test_vector.with_call_op(call_kind);
+
+            CircuitTestBuilder::new_from_test_ctx(
+                TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
+            )
+            .run();
+        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -530,7 +530,7 @@ mod test {
         evm::{OpcodeId, PrecompileCallArgs},
         precompile::PrecompileCalls,
     };
-    use eth_types::{bytecode, word, ToWord, Word};
+    use eth_types::{bytecode, evm_types::GasCost, word, ToWord, Word};
     use halo2_proofs::halo2curves::bn256::{G1Affine, G2Affine};
     use itertools::Itertools;
     use mock::TestContext;
@@ -992,6 +992,72 @@ mod test {
                 }
             ]
         };
+
+        static ref OOG_TEST_VECTOR: Vec<PrecompileCallArgs> = {
+            vec![
+                PrecompileCallArgs {
+                    name: "ecPairing (pairing true): 2 pairs",
+                    setup_code: bytecode! {
+                        // G1_x1
+                        PUSH32(word!("0x2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da"))
+                        PUSH1(0x00)
+                        MSTORE
+                        // G1_y1
+                        PUSH32(word!("0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6"))
+                        PUSH1(0x20)
+                        MSTORE
+                        // G2_x11
+                        PUSH32(word!("0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc"))
+                        PUSH1(0x40)
+                        MSTORE
+                        // G2_x12
+                        PUSH32(word!("0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9"))
+                        PUSH1(0x60)
+                        MSTORE
+                        // G2_y11
+                        PUSH32(word!("0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90"))
+                        PUSH1(0x80)
+                        MSTORE
+                        // G2_y12
+                        PUSH32(word!("0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e"))
+                        PUSH1(0xA0)
+                        MSTORE
+                        // G1_x2
+                        PUSH32(word!("0x0000000000000000000000000000000000000000000000000000000000000001"))
+                        PUSH1(0xC0)
+                        MSTORE
+                        // G1_y2
+                        PUSH32(word!("0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45"))
+                        PUSH1(0xE0)
+                        MSTORE
+                        // G2_x21
+                        PUSH32(word!("0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4"))
+                        PUSH2(0x100)
+                        MSTORE
+                        // G2_x22
+                        PUSH32(word!("0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7"))
+                        PUSH2(0x120)
+                        MSTORE
+                        // G2_y21
+                        PUSH32(word!("0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2"))
+                        PUSH2(0x140)
+                        MSTORE
+                        // G2_y22
+                        PUSH32(word!("0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc"))
+                        PUSH2(0x160)
+                        MSTORE
+                    },
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x180.into(),
+                    ret_offset: 0x180.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    gas: (PrecompileCalls::Bn128Pairing.base_gas_cost().as_u64()
+                        + 2* GasCost::PRECOMPILE_BN256PAIRING_PER_PAIR.as_u64() - 1).to_word(),
+                    ..Default::default()
+                },
+            ]
+        };
     }
 
     #[test]
@@ -1004,6 +1070,29 @@ mod test {
         ];
 
         TEST_VECTOR
+            .iter()
+            .cartesian_product(&call_kinds)
+            .par_bridge()
+            .for_each(|(test_vector, &call_kind)| {
+                let bytecode = test_vector.with_call_op(call_kind);
+
+                CircuitTestBuilder::new_from_test_ctx(
+                    TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
+                )
+                .run();
+            })
+    }
+
+    #[test]
+    fn precompile_ec_pairing_oog_test() {
+        let call_kinds = vec![
+            OpcodeId::CALL,
+            OpcodeId::STATICCALL,
+            OpcodeId::DELEGATECALL,
+            OpcodeId::CALLCODE,
+        ];
+
+        OOG_TEST_VECTOR
             .iter()
             .cartesian_product(&call_kinds)
             .par_bridge()

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
@@ -707,6 +707,7 @@ pub struct ModExpGadget<F> {
 
     input_bytes_acc: Cell<F>,
     output_bytes_acc: Cell<F>,
+    is_gas_insufficient: LtGadget<F, N_BYTES_U64>,
     gas_cost_gadget: ModExpGasCost<F>,
     garbage_bytes_holder: [Cell<F>; INPUT_LIMIT - 96],
 }
@@ -747,11 +748,16 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             None,
         );
 
-        let call_success = util::and::expr([
-            input.is_valid(),
-            //TODO: replace this constants when gas gadget is ready
-            1.expr(),
-        ]);
+        let gas_cost_gadget =
+            ModExpGasCost::construct(cb, &input.base_len, &input.exp, &input.modulus_len);
+        let is_gas_insufficient = LtGadget::construct(
+            cb,
+            cb.curr.state.gas_left.expr(),
+            gas_cost_gadget.dynamic_gas.max(),
+        );
+
+        let call_success =
+            util::and::expr([input.is_valid(), not::expr(is_gas_insufficient.expr())]);
 
         cb.require_equal(
             "call success if valid input and enough gas",
@@ -791,13 +797,13 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             output.bytes_rlc(),
         );
 
-        let gas_cost_gadget =
-            ModExpGasCost::construct(cb, &input.base_len, &input.exp, &input.modulus_len);
         let gas_cost = select::expr(
             is_success.expr(),
             gas_cost_gadget.dynamic_gas.max(),
             cb.curr.state.gas_left.expr(),
         );
+
+        let rd_length = select::expr(is_success.expr(), input.modulus_len(), 0.expr());
 
         let restore_context_gadget = RestoreContextGadget::construct2(
             cb,
@@ -805,7 +811,7 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             gas_cost.expr(),
             0.expr(),
             0.expr(),
-            input.modulus_len(),
+            rd_length,
             0.expr(),
             0.expr(),
         );
@@ -824,6 +830,7 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             output,
             input_bytes_acc,
             output_bytes_acc,
+            is_gas_insufficient,
             gas_cost_gadget,
             garbage_bytes_holder,
         }
@@ -888,12 +895,18 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
                 .assign(region, offset, n_padded_zeroes_pow * input_rlc)?;
             self.output_bytes_acc.assign(region, offset, output_rlc)?;
 
-            let _gas_cost = self.gas_cost_gadget.assign(
+            let required_gas_cost = self.gas_cost_gadget.assign(
                 region,
                 offset,
                 &data.input_lens[0],
                 &data.input_lens[2],
                 &data.inputs[1],
+            )?;
+            self.is_gas_insufficient.assign(
+                region,
+                offset,
+                F::from(step.gas_left),
+                F::from(required_gas_cost),
             )?;
         } else {
             log::error!("unexpected aux_data {:?} for modexp", step.aux_data);

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -101,6 +101,8 @@ pub(crate) const MAX_N_BYTES_INTEGER: usize = 31;
 // Number of bytes an EVM word has.
 pub(crate) const N_BYTES_WORD: usize = 32;
 
+pub(crate) const N_BYTES_EC_PAIR: usize = 192;
+
 // Number of bytes an u64 has.
 pub(crate) const N_BYTES_U64: usize = 8;
 

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -121,6 +121,7 @@ pub enum ExecutionState {
     ErrorOutOfGasEXP,
     ErrorOutOfGasSHA3,
     ErrorOutOfGasCall,
+    ErrorOutOfGasPrecompile,
     ErrorOutOfGasSloadSstore,
     ErrorOutOfGasCREATE,
     ErrorOutOfGasSELFDESTRUCT,

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -20,6 +20,7 @@ pub enum FixedTableTag {
     Range32,
     Range64,
     Range128,
+    Range192,
     Range256,
     Range512,
     Range1024,
@@ -59,6 +60,9 @@ impl FixedTableTag {
             }
             Self::Range128 => {
                 Box::new((0..128).map(move |value| [tag, F::from(value), F::zero(), F::zero()]))
+            }
+            Self::Range192 => {
+                Box::new((0..192).map(move |value| [tag, F::from(value), F::zero(), F::zero()]))
             }
             Self::Range256 => {
                 Box::new((0..256).map(move |value| [tag, F::from(value), F::zero(), F::zero()]))

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -587,6 +587,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             32 => ("Range32", FixedTableTag::Range32),
             64 => ("Range64", FixedTableTag::Range64),
             128 => ("Range128", FixedTableTag::Range128),
+            192 => ("Range192", FixedTableTag::Range192),
             256 => ("Range256", FixedTableTag::Range256),
             512 => ("Range512", FixedTableTag::Range512),
             1024 => ("Range1024", FixedTableTag::Range1024),

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
@@ -240,6 +240,7 @@ impl<F: Field, G: MathGadgetContainer<F>> Circuit<F> for UnitTestMathGadgetBaseC
                                         | FixedTableTag::Range32
                                         | FixedTableTag::Range64
                                         | FixedTableTag::Range128
+                                        | FixedTableTag::Range192
                                         | FixedTableTag::Range256
                                         | FixedTableTag::Range512
                                         | FixedTableTag::Range1024

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -113,6 +113,7 @@ impl From<&ExecError> for ExecutionState {
                 OogError::Exp => ExecutionState::ErrorOutOfGasEXP,
                 OogError::Sha3 => ExecutionState::ErrorOutOfGasSHA3,
                 OogError::Call => ExecutionState::ErrorOutOfGasCall,
+                OogError::Precompile => ExecutionState::ErrorOutOfGasPrecompile,
                 OogError::SloadSstore => ExecutionState::ErrorOutOfGasSloadSstore,
                 OogError::Create => ExecutionState::ErrorOutOfGasCREATE,
                 OogError::SelfDestruct => ExecutionState::ErrorOutOfGasSELFDESTRUCT,


### PR DESCRIPTION
### Description

Meant to be part of #811 and may conflict with #815 (as it's also dealing with  precompile call oog).

#### 1. OOG handled in `ErrorOOGPrecompileGadget`
- [x] ecrecover
- [x] identity
- [x] bn254_add
- [x] bn254_mul
- [x] bn254_pairing
#### 2. OOG handled in `ModExpGadget`
- [x] modexp: gas cost calculation is quite complicated

### Issue Link


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update