### PR TITLE
Simplify exp lookup

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -795,8 +795,6 @@ impl From<(Word, Word, Word)> for ExpStep {
 /// Event representating an exponentiation `a ^ b == d (mod 2^256)`.
 #[derive(Clone, Debug)]
 pub struct ExpEvent {
-    /// Identifier for the exponentiation trace.
-    pub identifier: usize,
     /// Base `a` for the exponentiation.
     pub base: Word,
     /// Exponent `b` for the exponentiation.
@@ -810,7 +808,6 @@ pub struct ExpEvent {
 impl Default for ExpEvent {
     fn default() -> Self {
         Self {
-            identifier: 0,
             base: 2.into(),
             exponent: 2.into(),
             exponentiation: 4.into(),

--- a/bus-mapping/src/evm/opcodes/exp.rs
+++ b/bus-mapping/src/evm/opcodes/exp.rs
@@ -57,7 +57,6 @@ impl Opcode for Exponentiation {
         let exponentiation_calc = exp_by_squaring(base, exponent, &mut steps);
         debug_assert_eq!(exponentiation, exponentiation_calc);
         state.push_exponentiation(ExpEvent {
-            identifier: state.block_ctx.rwc.0,
             base,
             exponent,
             exponentiation,

--- a/docs/EVM_Circuit.md
+++ b/docs/EVM_Circuit.md
@@ -235,7 +235,7 @@ For the EVM Circuit, there are internal and external lookup tables. We summarize
 |BlockTable|tag, index, value|
 |CopyTable|is_first, src_id, src_tag, dst_id, dst_tag, src_addr, src_addr_end, dst_addr, length, rlc_acc, rw_counter, rw_inc|
 |KeccakTable|is_enabled (=1), input_rlc, input_len, output_rlc|
-|ExpTable|is_step (=1), identifier, is_last, base_limbs[0], base_limbs[1], base_limbs[2], base_limbs[3], exp_lo_hi[0], exp_lo_hi[1], exponentiation_lo_hi[0],  exponentiation_lo_hi[1]|
+|ExpTable|q_enable (=1), is_step (=1), base_limbs[0], base_limbs[1], base_limbs[2], base_limbs[3], exponent_lo_hi[0], exponent_lo_hi[1], exponentiation_lo_hi[0],  exponentiation_lo_hi[1]|
 |SigTable|msg_hash_rlc, sig_v, sig_r_rlc, sig_s_rlc, recovered_addr, is_valid|
 
 

--- a/zkevm-circuits/src/evm_circuit/execution/exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/exp.rs
@@ -1,7 +1,7 @@
 use bus_mapping::evm::OpcodeId;
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar, U256};
-use gadgets::util::{and, not, split_u256, sum, Expr};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
+use gadgets::util::{and, not, split_u256, Expr};
+use halo2_proofs::plonk::Error;
 
 use crate::evm_circuit::{
     step::ExecutionState,
@@ -12,7 +12,7 @@ use crate::evm_circuit::{
         },
         from_bytes,
         math_gadget::{ByteOrWord, ByteSizeGadget, IsEqualGadget, IsZeroGadget},
-        CachedRegion, Cell, Word,
+        CachedRegion, Word,
     },
     witness::{Block, Call, ExecStep, Transaction},
 };
@@ -131,7 +131,7 @@ impl<F: Field> ExecutionGadget<F> for ExponentiationGadget<F> {
                 ];
                 // lookup (base, exponent, exponentiation)
                 cb.exp_table_lookup(
-                    base_limbs.clone(),
+                    base_limbs,
                     [exponent_lo.clone(), exponent_hi.clone()],
                     [exponentiation_lo.clone(), exponentiation_hi.clone()],
                 );

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -302,8 +302,6 @@ pub(crate) enum Lookup<F> {
     },
     /// Lookup to exponentiation table.
     ExpTable {
-        identifier: Expression<F>,
-        is_last: Expression<F>,
         base_limbs: [Expression<F>; 4],
         exponent_lo_hi: [Expression<F>; 2],
         exponentiation_lo_hi: [Expression<F>; 2],
@@ -462,16 +460,12 @@ impl<F: Field> Lookup<F> {
                 output_rlc.clone(),
             ],
             Self::ExpTable {
-                identifier,
-                is_last,
                 base_limbs,
                 exponent_lo_hi,
                 exponentiation_lo_hi,
             } => vec![
                 1.expr(), // q_enable
                 1.expr(), // is_step
-                identifier.clone(),
-                is_last.clone(),
                 base_limbs[0].clone(),
                 base_limbs[1].clone(),
                 base_limbs[2].clone(),

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1357,8 +1357,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn exp_table_lookup(
         &mut self,
-        identifier: Expression<F>,
-        is_last: Expression<F>,
         base_limbs: [Expression<F>; 4],
         exponent_lo_hi: [Expression<F>; 2],
         exponentiation_lo_hi: [Expression<F>; 2],
@@ -1366,8 +1364,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         self.add_lookup(
             "exponentiation lookup",
             Lookup::ExpTable {
-                identifier,
-                is_last,
                 base_limbs,
                 exponent_lo_hi,
                 exponentiation_lo_hi,

--- a/zkevm-circuits/src/exp_circuit.rs
+++ b/zkevm-circuits/src/exp_circuit.rs
@@ -124,13 +124,6 @@ impl<F: Field> SubCircuitConfig<F> for ExpCircuitConfig<F> {
                 d_hi_next,
             );
 
-            // Identifier does not change over the steps of an exponentiation trace.
-            cb.require_equal(
-                "identifier does not change",
-                meta.query_advice(exp_table.identifier, Rotation::cur()),
-                meta.query_advice(exp_table.identifier, Rotation(OFFSET_INCREMENT as i32)),
-            );
-
             // The circuit must end with a last step. Since there is a fixed 1 in is_final_event,
             // eventually is_last=1.
             cb.require_zero(

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -2059,8 +2059,6 @@ impl<F: Field> LookupTable<F> for ExpTable {
         vec![
             meta.query_fixed(self.q_enable, Rotation::cur()),
             meta.query_fixed(self.is_step, Rotation::cur()),
-            meta.query_advice(self.identifier, Rotation::cur()),
-            meta.query_advice(self.is_last, Rotation::cur()),
             meta.query_advice(self.base_limb, Rotation::cur()),
             meta.query_advice(self.base_limb, Rotation::next()),
             meta.query_advice(self.base_limb, Rotation(2)),

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1863,10 +1863,6 @@ pub struct ExpTable {
     pub q_enable: Column<Fixed>,
     /// Whether the row is the start of a step.
     pub is_step: Column<Fixed>,
-    /// An identifier for every exponentiation trace, at the moment this is the
-    /// read-write counter at the time of the lookups done to the
-    /// exponentiation table.
-    pub identifier: Column<Advice>,
     /// Whether this row is the last row in the exponentiation operation's
     /// trace.
     pub is_last: Column<Advice>,
@@ -1884,7 +1880,6 @@ impl ExpTable {
         Self {
             q_enable: meta.fixed_column(),
             is_step: meta.fixed_column(),
-            identifier: meta.advice_column(),
             is_last: meta.advice_column(),
             base_limb: meta.advice_column(),
             exponent_lo_hi: meta.advice_column(),
@@ -1894,10 +1889,9 @@ impl ExpTable {
 
     /// Given an exponentiation event and randomness, get assignments to the
     /// exponentiation table.
-    pub fn assignments<F: Field>(exp_event: &ExpEvent) -> Vec<[F; 5]> {
+    pub fn assignments<F: Field>(exp_event: &ExpEvent) -> Vec<[F; 4]> {
         let mut assignments = Vec::new();
         let base_limbs = split_u256_limb64(&exp_event.base);
-        let identifier = F::from(exp_event.identifier as u64);
         let mut exponent = exp_event.exponent;
         for (step_idx, exp_step) in exp_event.steps.iter().rev().enumerate() {
             let is_last = if step_idx == exp_event.steps.len() - 1 {
@@ -1910,7 +1904,6 @@ impl ExpTable {
 
             // row 1
             assignments.push([
-                identifier,
                 is_last,
                 base_limbs[0].as_u64().into(),
                 exponent_lo
@@ -1922,7 +1915,6 @@ impl ExpTable {
             ]);
             // row 2
             assignments.push([
-                identifier,
                 F::zero(),
                 base_limbs[1].as_u64().into(),
                 exponent_hi
@@ -1934,7 +1926,6 @@ impl ExpTable {
             ]);
             // row 3
             assignments.push([
-                identifier,
                 F::zero(),
                 base_limbs[2].as_u64().into(),
                 F::zero(),
@@ -1942,14 +1933,13 @@ impl ExpTable {
             ]);
             // row 4
             assignments.push([
-                identifier,
                 F::zero(),
                 base_limbs[3].as_u64().into(),
                 F::zero(),
                 F::zero(),
             ]);
             for _ in ROWS_PER_STEP..OFFSET_INCREMENT {
-                assignments.push([F::zero(), F::zero(), F::zero(), F::zero(), F::zero()]);
+                assignments.push([F::zero(), F::zero(), F::zero(), F::zero()]);
             }
 
             // update intermediate exponent.
@@ -2008,7 +1998,7 @@ impl ExpTable {
                 }
 
                 // pad an empty row
-                let row = [F::from_u128(0); 5];
+                let row = [F::from_u128(0); 4];
                 region.assign_fixed(
                     || format!("exponentiation table row {offset}"),
                     self.q_enable,
@@ -2035,7 +2025,6 @@ impl<F: Field> LookupTable<F> for ExpTable {
         vec![
             self.q_enable.into(),
             self.is_step.into(),
-            self.identifier.into(),
             self.is_last.into(),
             self.base_limb.into(),
             self.exponent_lo_hi.into(),
@@ -2047,7 +2036,6 @@ impl<F: Field> LookupTable<F> for ExpTable {
         vec![
             String::from("q_enable"),
             String::from("is_step"),
-            String::from("identifier"),
             String::from("is_last"),
             String::from("base_limb"),
             String::from("exponent_lo_hi"),


### PR DESCRIPTION
Task: https://app.asana.com/0/1203078612788501/1205364106497221/f

Remove:
- the "lookup for last step" `exp_table_lookup` call,
- the `single_step` unconstrained cell,
- the `is_last` expression from the ExpTable lookup,
- the `identifier` from the Exp circuit,
- the unused `zero_rlc` cells (TOB-SCROLL-20).

The above is replaced by https://github.com/scroll-tech/zkevm-circuits/pull/837
