### PR TITLE
Fix: gas cost of ec_pairing precompile 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,9 +2364,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
@@ -3879,8 +3879,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66837781605c6dcb7f07ad87604eeab3119dae9149d69d8839073dd6f188673d"
+source = "git+https://github.com/scroll-tech/revm?tag=2.0.0-fix#c4b174589f1d48cc003c46fb21b9a68c5a276c29"
 dependencies = [
  "k256",
  "num",
@@ -3895,12 +3894,10 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304d998f466ffef72d76c7f20b05bf08a96801736a6fb1fdef47d49a292618df"
+version = "1.0.0"
+source = "git+https://github.com/scroll-tech/revm?tag=2.0.0-fix#c4b174589f1d48cc003c46fb21b9a68c5a276c29"
 dependencies = [
  "auto_impl",
- "bitvec 1.0.1",
  "bytes",
  "derive_more",
  "enumn",
@@ -3908,7 +3905,6 @@ dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "hex-literal",
- "primitive-types 0.12.1",
  "rlp",
  "ruint",
  "sha3 0.10.8",

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4.3"
 strum_macros = "0.24"
 
 # precompile related crates
-revm-precompile = "=2.0.0"
+revm-precompile = { git = "https://github.com/scroll-tech/revm", tag = "2.0.0-fix" }
 once_cell = "1.17.0"
 
 [dev-dependencies]


### PR DESCRIPTION
### Description

Fix the `ecpairing_bad_length_191_d0_g1_v0` test failure in 
https://circuit-release.s3.us-west-2.amazonaws.com/testool/nightly.1693234652.4a88495.html.

### Issue Link

pairing gas cost is not calculated correctly in revm 2.0.0. https://github.com/bluealloy/revm/issues/658

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update