### PR TITLE
Precompile (non-static) calls with (non-zero) value

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1121,6 +1121,8 @@ impl<'a> CircuitInputStateRef<'a> {
                     op,
                 );
                 let idx = if from_precompile_call {
+                    // prev step is callop or begin_tx.
+                    // the failed transfer should be reverted there.
                     step_index - 1
                 } else {
                     step_index
@@ -1204,8 +1206,11 @@ impl<'a> CircuitInputStateRef<'a> {
 
         // Handle reversion if this call doesn't end successfully
         if !call.is_success {
-            let was_precompile_failure =
-                exec_step.is_precompiled() || exec_step.is_precompile_oog_err();
+            // ecadd/ecmul/ecpairing/ecrecover/identity
+            let is_precompile_oog_err = exec_step.is_precompile_oog_err();
+            // modexp
+            let is_precompiled = exec_step.is_precompiled();
+            let was_precompile_failure = is_precompile_oog_err || is_precompiled;
             self.handle_reversion(was_precompile_failure);
         }
 

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -96,7 +96,10 @@ pub enum OogError {
     SloadSstore,
     /// Out of Gas for CALL, CALLCODE, DELEGATECALL and STATICCALL
     Call,
-    /// Out of Gas for Precompile
+    /// Out of Gas for Precompile.
+    /// ecrecover/ecadd/ecmul/ecpairing/identity oog can should be handled by this.
+    /// modexp oog is handled inside modexp gadget.
+    /// disabled precompiles are handled by PrecompileFailedGadget.
     Precompile,
     /// Out of Gas for CREATE and CREATE2
     Create,

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -841,7 +841,7 @@ pub fn gen_begin_tx_ops(
     // TODO:
     // Move it to code of generating precompiled operations when implemented.
     if is_precompile && !state.call().unwrap().is_success {
-        state.handle_reversion();
+        state.handle_reversion(is_precompile);
     }
 
     Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -792,6 +792,7 @@ mod test {
                     call_data_length: 769.into(),
                     ret_offset: 0xC0.into(),
                     ret_size: 0x20.into(),
+                    value: 1.into(),
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()
                 },
@@ -802,6 +803,7 @@ mod test {
                     call_data_length: 191.into(),
                     ret_offset: 191.into(),
                     ret_size: 0x20.into(),
+                    value: 1.into(),
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()
                 },
@@ -812,6 +814,7 @@ mod test {
                     call_data_length: 193.into(),
                     ret_offset: 193.into(),
                     ret_size: 0x20.into(),
+                    value: 1.into(),
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()
                 },
@@ -871,6 +874,7 @@ mod test {
                     call_data_length: 0x180.into(),
                     ret_offset: 0x180.into(),
                     ret_size: 0x20.into(),
+                    value: 1.into(),
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()
                 },

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -1124,6 +1124,7 @@ mod test {
                     ret_offset: 0x180.into(),
                     ret_size: 0x20.into(),
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    value: 1.into(),
                     gas: (PrecompileCalls::Bn128Pairing.base_gas_cost().as_u64()
                         + 2* GasCost::PRECOMPILE_BN256PAIRING_PER_PAIR.as_u64() - 1).to_word(),
                     ..Default::default()

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
@@ -406,6 +406,43 @@ mod test {
                 },
             ]
         };
+
+        static ref OOG_TEST_VECTOR: Vec<PrecompileCallArgs> = {
+            vec![
+                PrecompileCallArgs {
+                    name: "ecrecover (oog)",
+                    setup_code: bytecode! {
+                        // msg hash from 0x00
+                        PUSH32(word!("0x456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3"))
+                        PUSH1(0x00)
+                        MSTORE
+                        // signature v from 0x20
+                        PUSH1(28)
+                        PUSH1(0x20)
+                        MSTORE
+                        // signature r from 0x40
+                        PUSH32(word!("0x9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608"))
+                        PUSH1(0x40)
+                        MSTORE
+                        // signature s from 0x60
+                        PUSH32(word!("0x4f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada"))
+                        PUSH1(0x60)
+                        MSTORE
+                    },
+                    // copy 128 bytes from memory addr 0. Address is recovered and the signature is
+                    // valid.
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x80.into(),
+                    // return 32 bytes and write from memory addr 128
+                    ret_offset: 0x80.into(),
+                    ret_size: 0x20.into(),
+                    gas: 0.into(),
+                    value: 2.into(),
+                    address: PrecompileCalls::Ecrecover.address().to_word(),
+                    ..Default::default()
+                },
+            ]
+        };
     }
 
     #[test]
@@ -429,5 +466,17 @@ mod test {
                 )
                 .run();
             })
+    }
+
+    #[test]
+    fn precompile_ecrecover_oog_test() {
+        OOG_TEST_VECTOR.iter().for_each(|test_vector| {
+            let bytecode = test_vector.with_call_op(OpcodeId::CALL);
+
+            CircuitTestBuilder::new_from_test_ctx(
+                TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
+            )
+            .run();
+        })
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
@@ -470,13 +470,24 @@ mod test {
 
     #[test]
     fn precompile_ecrecover_oog_test() {
-        OOG_TEST_VECTOR.iter().for_each(|test_vector| {
-            let bytecode = test_vector.with_call_op(OpcodeId::CALL);
+        let call_kinds = vec![
+            OpcodeId::CALL,
+            OpcodeId::STATICCALL,
+            OpcodeId::DELEGATECALL,
+            OpcodeId::CALLCODE,
+        ];
 
-            CircuitTestBuilder::new_from_test_ctx(
-                TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
-            )
-            .run();
-        })
+        OOG_TEST_VECTOR
+            .iter()
+            .cartesian_product(&call_kinds)
+            .par_bridge()
+            .for_each(|(test_vector, &call_kind)| {
+                let bytecode = test_vector.with_call_op(call_kind);
+
+                CircuitTestBuilder::new_from_test_ctx(
+                    TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
+                )
+                .run();
+            })
     }
 }

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -7,10 +7,7 @@ use crate::{
     util::{log2_ceil, SubCircuit},
     witness::{Block, Rw},
 };
-use bus_mapping::{
-    circuit_input_builder::{CircuitInputBuilder, CircuitsParams},
-    mock::BlockData,
-};
+use bus_mapping::{circuit_input_builder::CircuitsParams, mock::BlockData};
 use eth_types::geth_types::GethData;
 
 use halo2_proofs::{
@@ -19,6 +16,9 @@ use halo2_proofs::{
     halo2curves::bn256::Fr,
 };
 use mock::TestContext;
+
+#[cfg(feature = "scroll")]
+use bus_mapping::circuit_input_builder::CircuitInputBuilder;
 
 #[cfg(test)]
 #[ctor::ctor]


### PR DESCRIPTION
Reproduce:

```
RUST_LOG=debug cargo test --release -p zkevm-circuits --features test evm_circuit::execution::precompiles::ecrecover::test::precompile_ecrecover_oog_test
```

### Summary

The error from `CallEcrecover0_NoGas_d0_g0_v0` is a bit more complicated than simply related to "precompiles".

The error is that, when we do a non-static `CALL` to a precompiled contract that also has non-zero value, and if it results in OOG then we push reversible operations (for balance increase and balance decrease of the non-zero value). These reversible ops get pushed with index: `(tx.steps.len(), op)`.

In the same step, i.e. `CALL` step, we then process the `handle_reversion` (because we know that there is OOG), here: [link](https://github.com/scroll-tech/zkevm-circuits/blob/develop/bus-mapping/src/circuit_input_builder/input_state_ref.rs#L1123). During this `handle_reversion`, the `tx.steps_mut[step_index]` is accessed (which panics, since there are `n` steps, and `step_index == n`  as well).

Overall in `bus-mapping`, we have always assumed that *since we are generating the associated ops for the current step, there is no error in the current step. An error can only be in the following steps*. We need to update this logic to support precompile calls, since in precompile calls, the current call itself could fail.

There should be similar such errors with all precompile non-static calls with non-zero value if they fail, i.e. `call.is_success == false`