### PR TITLE
Fix: post state check should fail for hash precompile tests

### DIFF
--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -751,6 +751,9 @@ pub mod tests {
                 address: Word::from(0x2),
                 stack_value: vec![(
                     Word::from(0x20),
+                    #[cfg(feature = "scroll")]
+                    Word::zero(),
+                    #[cfg(not(feature = "scroll"))]
                     word!("a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89"),
                 )],
                 ..Default::default()
@@ -769,6 +772,9 @@ pub mod tests {
                 address: Word::from(0x3),
                 stack_value: vec![(
                     Word::from(0x20),
+                    #[cfg(feature = "scroll")]
+                    Word::zero(),
+                    #[cfg(not(feature = "scroll"))]
                     word!("2c0c45d3ecab80fe060e5f1d7057cd2f8de5e557"),
                 )],
                 ..Default::default()
@@ -958,10 +964,16 @@ pub mod tests {
                 stack_value: vec![
                     (
                         Word::from(0x20),
+                        #[cfg(feature = "scroll")]
+                        word!("3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e13"),
+                        #[cfg(not(feature = "scroll"))]
                         word!("d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b"),
                     ),
                     (
                         Word::from(0x0),
+                        #[cfg(feature = "scroll")]
+                        word!("0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f"),
+                        #[cfg(not(feature = "scroll"))]
                         word!("8c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5"),
                     ),
                 ],

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -4,7 +4,7 @@ use eth_types::{evm_types::GasCost, Address, ToBigEndian, Word};
 use revm_precompile::{Precompile, PrecompileError, Precompiles};
 use strum::EnumIter;
 
-use crate::circuit_input_builder::{EcMulOp, EcPairingOp};
+use crate::circuit_input_builder::{EcMulOp, EcPairingOp, N_BYTES_PER_PAIR, N_PAIRING_PER_OP};
 
 /// Check if address is a precompiled or not.
 pub fn is_precompiled(address: &Address) -> bool {
@@ -37,7 +37,7 @@ pub(crate) fn execute_precompiled(
                     | PrecompileCalls::Sha256
                     | PrecompileCalls::Ripemd160 => (vec![], gas, false, false),
                     PrecompileCalls::Bn128Pairing => {
-                        if input.len() > 4 * 192 {
+                        if input.len() > N_PAIRING_PER_OP * N_BYTES_PER_PAIR {
                             (vec![], gas, false, false)
                         } else {
                             (return_value, gas_cost, false, true)

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -30,9 +30,19 @@ pub(crate) fn execute_precompiled(
     let (return_data, gas_cost, is_oog, is_ok) = match precompile_fn(input, gas) {
         Ok((gas_cost, return_value)) => {
             if cfg!(feature = "scroll") {
+                // Revm behavior is different from scroll evm,
+                // so we need to override the behavior of invalid input
                 match PrecompileCalls::from(address.0[19]) {
-                    // Revm behavior is different from scroll evm,
-                    // so we need to override the behavior of invalid input
+                    PrecompileCalls::Blake2F
+                    | PrecompileCalls::Sha256
+                    | PrecompileCalls::Ripemd160 => (vec![], gas, false, false),
+                    PrecompileCalls::Bn128Pairing => {
+                        if input.len() > 4 * 192 {
+                            (vec![], gas, false, false)
+                        } else {
+                            (return_value, gas_cost, false, true)
+                        }
+                    }
                     PrecompileCalls::Modexp => {
                         let (input_valid, [_, _, modulus_len]) = ModExpAuxData::check_input(input);
                         if input_valid {

--- a/external-tracer/src/lib.rs
+++ b/external-tracer/src/lib.rs
@@ -70,8 +70,10 @@ impl LoggerConfig {
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ChainConfig {
+    /// Archimedes switch time (nil = no fork, 0 = already on)
+    pub archimedes_block: Option<u64>,
     /// Shanghai switch time (nil = no fork, 0 = already on shanghai)
-    pub shanghai_time: Option<u64>,
+    pub shanghai_block: Option<u64>,
     /// TerminalTotalDifficulty is the amount of total difficulty reached by
     /// the network that triggers the consensus upgrade.
     pub terminal_total_difficulty: Option<u64>,
@@ -85,7 +87,8 @@ impl ChainConfig {
     /// Create a chain config for Shanghai fork.
     pub fn shanghai() -> Self {
         Self {
-            shanghai_time: Some(0),
+            archimedes_block: None,
+            shanghai_block: Some(0),
             terminal_total_difficulty: Some(0),
             terminal_total_difficulty_passed: true,
         }
@@ -111,8 +114,19 @@ pub fn trace(config: &TraceConfig) -> Result<Vec<GethExecTrace>, Error> {
 /// Creates a l2-trace for the specified config
 #[cfg(feature = "scroll")]
 pub fn l2trace(config: &TraceConfig) -> Result<BlockTrace, Error> {
+    let mut l2_config = config.clone();
+    if let Some(chain_config) = l2_config.chain_config.as_mut() {
+        (*chain_config).archimedes_block = Some(0);
+    } else {
+        l2_config.chain_config = Some(ChainConfig {
+            archimedes_block: Some(0),
+            shanghai_block: None,
+            terminal_total_difficulty: None,
+            terminal_total_difficulty_passed: false,
+        });
+    }
     // Get the trace
-    let trace_string = geth_utils::trace(&serde_json::to_string(&config).unwrap()).map_err(
+    let trace_string = geth_utils::trace(&serde_json::to_string(&l2_config).unwrap()).map_err(
         |error| match error {
             geth_utils::Error::TracingError(error) => Error::TracingError(error),
         },
@@ -122,7 +136,7 @@ pub fn l2trace(config: &TraceConfig) -> Result<BlockTrace, Error> {
 
     let mut trace: BlockTrace = serde_json::from_str(&trace_string).map_err(Error::SerdeError)?;
     // l2 geth returns nil base_fee even if it is not 0..
-    trace.header.base_fee_per_gas = Some(config.block_constants.base_fee);
+    trace.header.base_fee_per_gas = Some(l2_config.block_constants.base_fee);
     Ok(trace)
 }
 

--- a/external-tracer/src/lib.rs
+++ b/external-tracer/src/lib.rs
@@ -73,7 +73,8 @@ pub struct ChainConfig {
     /// Archimedes switch time (nil = no fork, 0 = already on)
     pub archimedes_block: Option<u64>,
     /// Shanghai switch time (nil = no fork, 0 = already on shanghai)
-    pub shanghai_block: Option<u64>,
+    /// Scroll EVM use the name `ShanghaiBlock` instead
+    pub shanghai_time: Option<u64>,
     /// TerminalTotalDifficulty is the amount of total difficulty reached by
     /// the network that triggers the consensus upgrade.
     pub terminal_total_difficulty: Option<u64>,
@@ -88,7 +89,7 @@ impl ChainConfig {
     pub fn shanghai() -> Self {
         Self {
             archimedes_block: None,
-            shanghai_block: Some(0),
+            shanghai_time: Some(0),
             terminal_total_difficulty: Some(0),
             terminal_total_difficulty_passed: true,
         }
@@ -120,7 +121,7 @@ pub fn l2trace(config: &TraceConfig) -> Result<BlockTrace, Error> {
     } else {
         l2_config.chain_config = Some(ChainConfig {
             archimedes_block: Some(0),
-            shanghai_block: None,
+            shanghai_time: None,
             terminal_total_difficulty: None,
             terminal_total_difficulty_passed: false,
         });

--- a/external-tracer/src/lib.rs
+++ b/external-tracer/src/lib.rs
@@ -116,7 +116,7 @@ pub fn trace(config: &TraceConfig) -> Result<Vec<GethExecTrace>, Error> {
 pub fn l2trace(config: &TraceConfig) -> Result<BlockTrace, Error> {
     let mut l2_config = config.clone();
     if let Some(chain_config) = l2_config.chain_config.as_mut() {
-        (*chain_config).archimedes_block = Some(0);
+        chain_config.archimedes_block = Some(0);
     } else {
         l2_config.chain_config = Some(ChainConfig {
             archimedes_block: Some(0),

--- a/geth-utils/l2geth/trace.go
+++ b/geth-utils/l2geth/trace.go
@@ -147,9 +147,9 @@ func Trace(config TraceConfig) (*types.BlockTrace, error) {
 		mergo.Merge(&chainConfig, config.ChainConfig, mergo.WithOverride)
 	}
 
-	// Debug for Shanghai
-	// fmt.Printf("geth-utils: ShanghaiTime = %d\n", *chainConfig.ShanghaiTime)
-	fmt.Printf("geth-utils: ArchimedesBlock = %d\n", chainConfig.ArchimedesBlock)
+	// Debug for Shanghai (Shanghai block is named as Shanghai time in go-ethereum v1.11.5 :))
+	// fmt.Printf("geth-utils: ShanghaiBlock = %d\n", chainConfig.ShanghaiBlock)
+	// fmt.Printf("geth-utils: ArchimedesBlock = %d\n", chainConfig.ArchimedesBlock)
 
 	txs := transferTxs(config.Transactions)
 

--- a/geth-utils/l2geth/trace.go
+++ b/geth-utils/l2geth/trace.go
@@ -138,7 +138,6 @@ func Trace(config TraceConfig) (*types.BlockTrace, error) {
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
-		ArchimedesBlock:     big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
 		ShanghaiBlock:       big.NewInt(0),
@@ -150,6 +149,7 @@ func Trace(config TraceConfig) (*types.BlockTrace, error) {
 
 	// Debug for Shanghai
 	// fmt.Printf("geth-utils: ShanghaiTime = %d\n", *chainConfig.ShanghaiTime)
+	fmt.Printf("geth-utils: ArchimedesBlock = %d\n", chainConfig.ArchimedesBlock)
 
 	txs := transferTxs(config.Transactions)
 

--- a/geth-utils/l2geth/trace.go
+++ b/geth-utils/l2geth/trace.go
@@ -138,6 +138,7 @@ func Trace(config TraceConfig) (*types.BlockTrace, error) {
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		ArchimedesBlock:     big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
 		ShanghaiBlock:       big.NewInt(0),

--- a/testool/Config.toml
+++ b/testool/Config.toml
@@ -6,6 +6,20 @@ max_steps = 1000
 ignore_tests = []
 
 [[suite]]
+id="precompile"
+path="tests/src/GeneralStateTestsFiller/stPreCompiledContracts/*"
+max_gas = 500000
+max_steps = 1000
+ignore_tests = []
+
+[[suite]]
+id="precompile2"
+path="tests/src/GeneralStateTestsFiller/stPreCompiledContracts2/*"
+max_gas = 500000
+max_steps = 1000
+ignore_tests = []
+
+[[suite]]
 id="nightly"
 path="tests/src/GeneralStateTestsFiller/**/*"
 max_gas = 0

--- a/testool/run.sh
+++ b/testool/run.sh
@@ -1,11 +1,13 @@
 C="modexpRandomInput_d0_g0_v0"
 C="ecadd_0-0_0-0_21000_0_d0_g0_v0"
 C="CALLBlake2f_d4_g0_v0"
+C="ecmul_7827-6598_5616_21000_96_d0_g2_v0"
 
 #CHECK_RW_LOOKUP=true 
 FLAG=" --features=scroll"
+export CIRCUIT=ecc
 
-RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite precompile2 --inspect "${C}" 2>&1 | tee inspect.log
+RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite nightly --inspect "${C}" 2>&1 | tee inspect.log
 #RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite precompile2 2>&1 | tee precompile2.log
 #RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite precompile 2>&1 | tee precompile.log
 #RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits sc --inspect "${C}" 2>&1 | tee one_sc.log

--- a/testool/run.sh
+++ b/testool/run.sh
@@ -1,8 +1,11 @@
 C="modexpRandomInput_d0_g0_v0"
 C="ecadd_0-0_0-0_21000_0_d0_g0_v0"
+C="CALLBlake2f_d4_g0_v0"
 
 #CHECK_RW_LOOKUP=true 
 FLAG=" --features=scroll"
 
-RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --inspect "${C}" 2>&1 | tee one.log
+RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite precompile2 --inspect "${C}" 2>&1 | tee inspect.log
+#RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite precompile2 2>&1 | tee precompile2.log
+#RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite precompile 2>&1 | tee precompile.log
 #RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits sc --inspect "${C}" 2>&1 | tee one_sc.log

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -20,8 +20,9 @@ use once_cell::sync::Lazy;
 use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
 use zkevm_circuits::{
-    bytecode_circuit::circuit::BytecodeCircuit, modexp_circuit::ModExpCircuit,
-    super_circuit::SuperCircuit, test_util::CircuitTestBuilder, util::SubCircuit, witness::Block,
+    bytecode_circuit::circuit::BytecodeCircuit, ecc_circuit::EccCircuit,
+    modexp_circuit::ModExpCircuit, super_circuit::SuperCircuit, test_util::CircuitTestBuilder,
+    util::SubCircuit, witness::Block,
 };
 
 /// Read env var with default value
@@ -619,6 +620,7 @@ pub fn run_test(
             let prover = match (*CIRCUIT).as_str() {
                 "modexp" => test_with::<ModExpCircuit<Fr>>(&witness_block),
                 "bytecode" => test_with::<BytecodeCircuit<Fr>>(&witness_block),
+                "ecc" => test_with::<EccCircuit<Fr, 9>>(&witness_block),
                 _ => unimplemented!(),
             };
             prover.assert_satisfied_par();

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -1778,6 +1778,9 @@ mod test_precompiles {
             address: Word::from(0x2),
             stack_value: vec![(
                 Word::from(0x20),
+                #[cfg(feature = "scroll")]
+                Word::zero(),
+                #[cfg(not(feature = "scroll"))]
                 word!("a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89"),
             )],
             ..Default::default()
@@ -1796,6 +1799,9 @@ mod test_precompiles {
             address: Word::from(0x3),
             stack_value: vec![(
                 Word::from(0x20),
+                #[cfg(feature = "scroll")]
+                Word::zero(),
+                #[cfg(not(feature = "scroll"))]
                 word!("2c0c45d3ecab80fe060e5f1d7057cd2f8de5e557"),
             )],
             ..Default::default()
@@ -2009,10 +2015,16 @@ mod test_precompiles {
             stack_value: vec![
                 (
                     Word::from(0x20),
+                    #[cfg(feature = "scroll")]
+                    word!("3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e13"),
+                    #[cfg(not(feature = "scroll"))]
                     word!("d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b"),
                 ),
                 (
                     Word::from(0x0),
+                    #[cfg(feature = "scroll")]
+                    word!("0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f"),
+                    #[cfg(not(feature = "scroll"))]
                     word!("8c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5"),
                 ),
             ],

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -564,6 +564,18 @@ mod test {
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()
                 },
+                #[cfg(feature = "scroll")]
+                PrecompileCallArgs {
+                    name: "ecPairing (invalid): all zero bytes, len(input) == 5 * 192",
+                    setup_code: bytecode! {},
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x3C0.into(),
+                    ret_offset: 0x3C0.into(),
+                    ret_size: 0x20.into(),
+                    value: 1.into(),
+                    address: PrecompileCalls::Bn128Pairing.address().to_word(),
+                    ..Default::default()
+                },
                 PrecompileCallArgs {
                     name: "ecPairing (pairing true): 2 pairs",
                     setup_code: bytecode! {
@@ -785,6 +797,7 @@ mod test {
                     address: PrecompileCalls::Bn128Pairing.address().to_word(),
                     ..Default::default()
                 },
+                #[cfg(feature = "scroll")]
                 PrecompileCallArgs {
                     name: "ecPairing (invalid): len(input) > 768",
                     setup_code: bytecode! {},


### PR DESCRIPTION
### Description

A few hash precompile tests in testool should fail the post state check.

### Issue Link

see the comments here https://github.com/scroll-tech/zkevm-circuits/issues/820#issuecomment-1699170561

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
