### PR TITLE
Optimize EVM selectors

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -368,20 +368,18 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     /// Returns (list of constraints, list of first step constraints, stored
     /// expressions, height used).
     #[allow(clippy::type_complexity)]
-    pub(crate) fn build(self) -> (Constraints<F>, Vec<StoredExpression<F>>, usize) {
+    pub(crate) fn build(
+        self,
+    ) -> (
+        Expression<F>,
+        Constraints<F>,
+        Vec<StoredExpression<F>>,
+        usize,
+    ) {
         let exec_state_sel = self.curr.execution_state_selector([self.execution_state]);
-        let mul_exec_state_sel = |c: Vec<(&'static str, Expression<F>)>| {
-            c.into_iter()
-                .map(|(name, constraint)| (name, exec_state_sel.clone() * constraint))
-                .collect()
-        };
         (
-            Constraints {
-                step: mul_exec_state_sel(self.constraints.step),
-                step_first: mul_exec_state_sel(self.constraints.step_first),
-                step_last: mul_exec_state_sel(self.constraints.step_last),
-                not_step_last: mul_exec_state_sel(self.constraints.not_step_last),
-            },
+            exec_state_sel,
+            self.constraints,
             self.stored_expressions,
             self.curr.cell_manager.get_height(),
         )

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
@@ -144,15 +144,15 @@ impl<F: Field, G: MathGadgetContainer<F>> Circuit<F> for UnitTestMathGadgetBaseC
             ExecutionState::STOP,
         );
         let math_gadget_container = G::configure_gadget_container(&mut cb);
-        let (constraints, stored_expressions, _) = cb.build();
+        let (state_selector, constraints, stored_expressions, _) = cb.build();
 
         if !constraints.step.is_empty() {
             let step_constraints = constraints.step;
             meta.create_gate("MathGadgetTestContainer", |meta| {
                 let q_usable = meta.query_selector(q_usable);
-                step_constraints
-                    .into_iter()
-                    .map(move |(name, constraint)| (name, q_usable.clone() * constraint))
+                step_constraints.into_iter().map(move |(name, constraint)| {
+                    (name, q_usable.clone() * state_selector.clone() * constraint)
+                })
             });
         }
 


### PR DESCRIPTION
This PR moves the multiplication of EVM state selectors into a cleaner expression, which cuts the overhead of EVM selectors in half, i.e. one multiplication per constraint and stored expressions.

Factoring in the cost of the constraints themselves, the saving is 20% (mul. count from 27,719 to 22,389).

![image](https://github.com/scroll-tech/zkevm-circuits/assets/8718243/0d8d7e7c-4335-4af9-a528-be2219c8a10a)
