### PR TITLE
Fix: witness gen panic in modexp

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
@@ -1,5 +1,5 @@
 use bus_mapping::precompile::{PrecompileAuxData, MODEXP_INPUT_LIMIT, MODEXP_SIZE_LIMIT};
-use eth_types::{evm_types::GasCost, Field, ToScalar, U256};
+use eth_types::{evm_types::GasCost, Field, ToBigEndian, ToScalar, U256};
 use gadgets::util::{self, not, select, Expr};
 use halo2_proofs::{
     circuit::Value,
@@ -639,6 +639,15 @@ impl<F: Field> ModExpGasCost<F> {
         m_size: &U256,
         exponent: &[u8; MODEXP_SIZE_LIMIT],
     ) -> Result<u64, Error> {
+        let mut base_len = [0u8; 32];
+        base_len[(32 - SIZE_REPRESENT_BYTES)..]
+            .copy_from_slice(&b_size.to_be_bytes()[(32 - SIZE_REPRESENT_BYTES)..]);
+        let mut mod_len = [0u8; 32];
+        mod_len[(32 - SIZE_REPRESENT_BYTES)..]
+            .copy_from_slice(&m_size.to_be_bytes()[(32 - SIZE_REPRESENT_BYTES)..]);
+        let b_size = U256::from_big_endian(&base_len);
+        let m_size = U256::from_big_endian(&mod_len);
+
         self.max_length.assign(
             region,
             offset,


### PR DESCRIPTION
### Description

Use truncated `(base_len, exp_len, mod_len)` to assign GasCostGadget.

### Issue Link

Panics in modexp

- [x] modexp_d28_g1_v0
- [x] modexp_d28_g2_v0
- [x] modexp_d28_g3_v0
- [x] modexp_d2_g1_v0
- [x] modexp_d2_g2_v0
- [x] modexp_d2_g3_v0

https://circuit-release.s3.us-west-2.amazonaws.com/testool/default.1693387901.1558981.html

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update