### PR TITLE
fix: refactor and extract pairing-check code to a function

### DIFF
--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -1,10 +1,7 @@
 use ark_std::{end_timer, start_timer};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
-    halo2curves::{
-        bn256::{Bn256, Fq, Fr, G1Affine},
-        pairing::Engine,
-    },
+    halo2curves::bn256::{Bn256, Fr, G1Affine},
     plonk::{Circuit, ConstraintSystem, Error, Selector},
     poly::{commitment::ParamsProver, kzg::commitment::ParamsKZG},
 };
@@ -14,6 +11,7 @@ use std::{env, fs::File};
 
 #[cfg(not(feature = "disable_proof_aggregation"))]
 use snark_verifier::loader::halo2::halo2_ecc::halo2_base;
+use snark_verifier::pcs::kzg::KzgSuccinctVerifyingKey;
 #[cfg(not(feature = "disable_proof_aggregation"))]
 use snark_verifier::{
     loader::halo2::{
@@ -22,11 +20,6 @@ use snark_verifier::{
     },
     pcs::kzg::{Bdfg21, Kzg},
 };
-use snark_verifier::{
-    loader::native::NativeLoader,
-    pcs::kzg::{KzgAccumulator, KzgSuccinctVerifyingKey},
-    util::arithmetic::fe_to_limbs,
-};
 #[cfg(not(feature = "disable_proof_aggregation"))]
 use snark_verifier_sdk::{aggregate, flatten_accumulator};
 use snark_verifier_sdk::{CircuitExt, Snark, SnarkWitness};
@@ -34,8 +27,8 @@ use zkevm_circuits::util::Challenges;
 
 use crate::{
     batch::BatchHash,
-    constants::{ACC_LEN, BITS, DIGEST_LEN, LIMBS, MAX_AGG_SNARKS},
-    core::{assign_batch_hashes, extract_accumulators_and_proof},
+    constants::{ACC_LEN, DIGEST_LEN, MAX_AGG_SNARKS},
+    core::{assign_batch_hashes, extract_proof_and_instances_with_pairing_check},
     util::parse_hash_digest_cells,
     ConfigParams,
 };
@@ -94,33 +87,11 @@ impl AggregationCircuit {
 
         // extract the accumulators and proofs
         let svk = params.get_g()[0].into();
+
         // this aggregates MULTIPLE snarks
         //  (instead of ONE as in proof compression)
-        let (accumulator, as_proof) = extract_accumulators_and_proof(
-            params,
-            snarks_with_padding,
-            rng,
-            &params.g2(),
-            &params.s_g2(),
-        )?;
-        let KzgAccumulator::<G1Affine, NativeLoader> { lhs, rhs } = accumulator;
-
-        // sanity check on the accumulator
-        {
-            let left = Bn256::pairing(&lhs, &params.g2());
-            let right = Bn256::pairing(&rhs, &params.s_g2());
-            log::trace!("aggregation circuit acc check: left {:?}", left);
-            log::trace!("aggregation circuit acc check: right {:?}", right);
-            if left != right {
-                return Err(snark_verifier::Error::AssertionFailure(format!(
-                    "accumulator check failed {left:?} {right:?}",
-                )));
-            }
-        }
-
-        let acc_instances = [lhs.x, lhs.y, rhs.x, rhs.y]
-            .map(fe_to_limbs::<Fq, Fr, LIMBS, BITS>)
-            .concat();
+        let (as_proof, acc_instances) =
+            extract_proof_and_instances_with_pairing_check(params, snarks_with_padding, rng)?;
 
         // extract batch's public input hash
         let public_input_hash = &batch_hash.instances_exclude_acc()[0];

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -2,7 +2,7 @@ use ark_std::{end_timer, start_timer};
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region, Value},
     halo2curves::{
-        bn256::{Bn256, Fr, G1Affine, G2Affine},
+        bn256::{Bn256, Fq, Fr, G1Affine, G2Affine},
         pairing::Engine,
     },
     poly::{commitment::ParamsProver, kzg::commitment::ParamsKZG},
@@ -15,6 +15,7 @@ use snark_verifier::{
         kzg::{Bdfg21, Kzg, KzgAccumulator, KzgAs},
         AccumulationSchemeProver,
     },
+    util::arithmetic::fe_to_limbs,
     verifier::PlonkVerifier,
     Error,
 };
@@ -37,7 +38,7 @@ use crate::{
         assert_conditional_equal, assert_equal, assert_exist, get_indices, get_max_keccak_updates,
         parse_hash_digest_cells, parse_hash_preimage_cells, parse_pi_hash_rlc_cells,
     },
-    AggregationConfig, RlcConfig, CHUNK_DATA_HASH_INDEX, POST_STATE_ROOT_INDEX,
+    AggregationConfig, RlcConfig, BITS, CHUNK_DATA_HASH_INDEX, LIMBS, POST_STATE_ROOT_INDEX,
     PREV_STATE_ROOT_INDEX, WITHDRAW_ROOT_INDEX,
 };
 
@@ -103,6 +104,46 @@ pub(crate) fn extract_accumulators_and_proof(
             rng,
         )?;
     Ok((accumulator, transcript_write.finalize()))
+}
+
+/// Subroutine for the witness generations.
+/// Extract proof from previous snarks and check pairing for accumulation.
+pub fn extract_proof_and_instances_with_pairing_check(
+    params: &ParamsKZG<Bn256>,
+    snarks: &[Snark],
+    rng: impl Rng + Send,
+) -> Result<(Vec<u8>, Vec<Fr>), snark_verifier::Error> {
+    // (old_accumulator, public inputs) -> (new_accumulator, public inputs)
+    let (accumulator, as_proof) =
+        extract_accumulators_and_proof(params, snarks, rng, &params.g2(), &params.s_g2())?;
+
+    // the instance for the outer circuit is
+    // - new accumulator, consists of 12 elements
+    // - inner circuit's instance, flattened (old accumulator is stripped out if exists)
+    //
+    // it is important that new accumulator is the first 12 elements
+    // as specified in CircuitExt::accumulator_indices()
+    let KzgAccumulator::<G1Affine, NativeLoader> { lhs, rhs } = accumulator;
+
+    // sanity check on the accumulator
+    {
+        let left = Bn256::pairing(&lhs, &params.g2());
+        let right = Bn256::pairing(&rhs, &params.s_g2());
+        log::trace!("circuit acc check: left {:?}", left);
+        log::trace!("circuit acc check: right {:?}", right);
+
+        if left != right {
+            return Err(snark_verifier::Error::AssertionFailure(format!(
+                "accumulator check failed {left:?} {right:?}",
+            )));
+        }
+    }
+
+    let acc_instances = [lhs.x, lhs.y, rhs.x, rhs.y]
+        .map(fe_to_limbs::<Fq, Fr, { LIMBS }, { BITS }>)
+        .concat();
+
+    Ok((as_proof, acc_instances))
 }
 
 #[derive(Default)]

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -20,6 +20,7 @@ mod util;
 #[cfg(test)]
 mod tests;
 
+pub use self::core::extract_proof_and_instances_with_pairing_check;
 pub use aggregation::*;
 pub use batch::BatchHash;
 pub use chunk::ChunkHash;


### PR DESCRIPTION
### Description

- Extract pairing-check code to function `extract_proof_and_instances_with_pairing_check`.
- Call this function in new of Aggregation and Compression circuits.
- Suppose to call this function after generates snark of Super circuit in scroll-prover.

