### PR TITLE
fix(ecMul): handle case for P == -R

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -1040,6 +1040,15 @@ pub struct EcMulOp {
     pub r: Option<G1Affine>,
 }
 
+/// Constant representing the modulus
+/// r = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+pub const BN256_FR_MODULUS: Fr = Fr::from_raw([
+    0x43e1f593f0000001,
+    0x2833e84879b97091,
+    0xb85045b68181585d,
+    0x30644e72e131a029,
+]);
+
 impl Default for EcMulOp {
     fn default() -> Self {
         let p = G1Affine::generator();
@@ -1096,8 +1105,15 @@ impl EcMulOp {
     }
 
     /// A check on the op to tell the ECC Circuit whether or not to skip the op.
+    ///
+    /// We skip an EcMul op from being processed by ECC circuit if:
+    /// - P == (0, 0)
+    /// - s == 0
+    /// - s == Fr::MODULUS - 1, i.e. P == -R
     pub fn skip_by_ecc_circuit(&self) -> bool {
-        (self.p.0.is_zero() && self.p.1.is_zero()) || self.s.is_zero().into()
+        (self.p.0.is_zero() && self.p.1.is_zero())
+            || self.s.is_zero().into()
+            || self.s.eq(&BN256_FR_MODULUS.sub(&Fr::one()))
     }
 
     /// Whether the EVM inputs are valid or not, i.e. does the precompile succeed or fail.

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -1041,9 +1041,10 @@ pub struct EcMulOp {
 }
 
 /// Constant representing the modulus
-/// r = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
-pub const BN256_FR_MODULUS: Fr = Fr::from_raw([
-    0x43e1f593f0000001,
+/// r     = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+/// r - 1 = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000
+pub const BN256_FR_MODULUS_MINUS_1: Fr = Fr::from_raw([
+    0x43e1f593f0000000,
     0x2833e84879b97091,
     0xb85045b68181585d,
     0x30644e72e131a029,
@@ -1113,7 +1114,7 @@ impl EcMulOp {
     pub fn skip_by_ecc_circuit(&self) -> bool {
         (self.p.0.is_zero() && self.p.1.is_zero())
             || self.s.is_zero().into()
-            || self.s.eq(&BN256_FR_MODULUS.sub(&Fr::one()))
+            || self.s.eq(&BN256_FR_MODULUS_MINUS_1)
     }
 
     /// Whether the EVM inputs are valid or not, i.e. does the precompile succeed or fail.

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -77,7 +77,10 @@ impl GenRand for EcAddOp {
 impl GenRand for EcMulOp {
     fn gen_rand<R: RngCore + CryptoRng>(mut r: &mut R, is_neg: bool) -> Self {
         let p = G1Affine::random(&mut r);
-        let s = <Fr as halo2_proofs::arithmetic::Field>::random(&mut r);
+        let s = match r.gen::<bool>() {
+            true => <Fr as halo2_proofs::arithmetic::Field>::random(&mut r),
+            false => Fr::one(),
+        };
         let r = if is_neg {
             G1Affine::random(&mut r)
         } else {


### PR DESCRIPTION
### Description

ECC Circuit panicked while handling `EcMul` operation where: `s == Fr::MODULUS - 1`, i.e. `P == -R`.

This PR fixes the above issue by:
- skipping ECC Circuit assignment for such an `EcMul` operation
- Handling this special case within EVM Circuit's `EcMulGadget` by (only for `is_success == true`):
    - storing cells for raw `P_y` value
    - storing cells for raw `R_y` value
    - comparing raw `P_y` and `R_y` against Phase2 cells with `P_y_rlc` and `R_y_rlc`
    - `IsEqual` gadget to compare `s` against `Fr::MODULUS - 1`
    - If `s == Fr::MODULUS - 1` then: `P_x == R_x` and `P_y + R_y == Fq::MODULUS`