### PR TITLE
Feat: make row estimation of tx and pi circuits more precise

### DIFF
--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1605,6 +1605,7 @@ impl<F: Field> SubCircuit<F> for PiCircuit<F> {
 
     /// Return the minimum number of rows required to prove the block
     fn min_num_rows_block(block: &witness::Block<F>) -> (usize, usize) {
+        let tx_usage = block.txs.len() as f32 / block.circuits_params.max_txs as f32;
         let max_inner_blocks = block.circuits_params.max_inner_blocks;
         let max_txs = block.circuits_params.max_txs;
 
@@ -1621,8 +1622,10 @@ impl<F: Field> SubCircuit<F> for PiCircuit<F> {
             + N_BYTES_ACCOUNT_ADDRESS
             + N_BYTES_WORD;
 
-        // the number of rows is independent of block
-        (num_rows, num_rows)
+        (
+            (tx_usage * block.circuits_params.max_vertical_circuit_rows as f32).ceil() as usize,
+            num_rows,
+        )
     }
 
     /// Compute the public inputs for this circuit.

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -2722,13 +2722,14 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
 
     /// Return the minimum number of rows required to prove the block
     fn min_num_rows_block(block: &witness::Block<F>) -> (usize, usize) {
-        let tx_usage = block.txs.len() as f32 / block.circuits_params.max_txs as f32;
-        let calldata_usage = block.txs.iter().map(|tx| tx.call_data.len()).sum::<usize>() as f32
+        // Since each call data byte at least takes one row in RLP circuit.
+        // For L2 tx, each call data byte takes two row in RLP circuit.
+        assert!(block.circuits_params.max_calldata < block.circuits_params.max_rlp_rows);
+        let tx_usage = (block.txs.iter().map(|tx| tx.call_data.len()).sum::<usize>()) as f32
             / block.circuits_params.max_calldata as f32;
 
         (
-            (tx_usage.max(calldata_usage) * block.circuits_params.max_vertical_circuit_rows as f32)
-                .ceil() as usize,
+            (tx_usage * block.circuits_params.max_vertical_circuit_rows as f32).ceil() as usize,
             Self::min_num_rows(
                 block.circuits_params.max_txs,
                 block.circuits_params.max_calldata,


### PR DESCRIPTION
### Description

We split the row usage of tx into two category and ask pi circuit to do one measurement.

### Issue Link

The ccc requirement of adding new txs includes
1. `txs.len() < MAX_TXS`;
2. length of txs' call data bytes must be less than `MAX_CALLDATA`.

To meet the requirement we use 
```
max(txs.len() / MAX_TXS, call_data_bytes.len() / MAX_CALLDATA)
```
This method may cause low usage of tx table. Here is an example (let's say MAX_TXS = 100, MAX_CALLDATA= 128k):

> tx `t1`'s call_data_length is quite large, e.g. 12k, then it will cost about 10% of row capacity. It means that the block can only hold 91 txs even the others only have very few call data bytes.


### Type of change

- [x] Improvement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update