### PR TITLE
bump l2geth; support sig circuit in testool

### DIFF
--- a/bus-mapping/src/evm/opcodes/precompiles/mod.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/mod.rs
@@ -46,7 +46,7 @@ pub fn gen_associated_ops(
             (None, None)
         }
     };
-
+    log::trace!("precompile event {opt_event:?}, aux data {aux_data:?}");
     if let Some(event) = opt_event {
         state.push_precompile_event(event);
     }

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -61,7 +61,10 @@ pub(crate) fn execute_precompiled(
         }
         Err(err) => match err {
             PrecompileError::OutOfGas => (vec![], gas, true, false),
-            _ => (vec![], gas, false, false),
+            _ => {
+                log::warn!("unknown precompile err {err:?}");
+                (vec![], gas, false, false)
+            }
         },
     };
     log::trace!("called precompile with is_ok {is_ok} is_oog {is_oog}, gas_cost {gas_cost}, return_data len {}, return_data {}", return_data.len(), hex::encode(&return_data));

--- a/geth-utils/l2geth/go.mod
+++ b/geth-utils/l2geth/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/holiman/uint256 v1.2.0
 	github.com/imdario/mergo v0.3.15
-	github.com/scroll-tech/go-ethereum v1.10.14-0.20230831124140-1886e26ca628
+	github.com/scroll-tech/go-ethereum v1.10.14-0.20230901060443-e1eebd17067c
 )
 
 require (

--- a/geth-utils/l2geth/go.sum
+++ b/geth-utils/l2geth/go.sum
@@ -123,6 +123,8 @@ github.com/scroll-tech/go-ethereum v1.10.14-0.20230831061745-fb38e6f91ef9 h1:hx0
 github.com/scroll-tech/go-ethereum v1.10.14-0.20230831061745-fb38e6f91ef9/go.mod h1:DiN3p2inoXOxGffxSswDKqWjQ7bU+Mp0c9v0XQXKmaA=
 github.com/scroll-tech/go-ethereum v1.10.14-0.20230831124140-1886e26ca628 h1:6onjmb7sdIPbjcZKkS7bczukMvpO1DHvbWjx3m33KdU=
 github.com/scroll-tech/go-ethereum v1.10.14-0.20230831124140-1886e26ca628/go.mod h1:DiN3p2inoXOxGffxSswDKqWjQ7bU+Mp0c9v0XQXKmaA=
+github.com/scroll-tech/go-ethereum v1.10.14-0.20230901060443-e1eebd17067c h1:GuAO5grBLrB+IcmIA1RpOfpqlpxv3bP36kXV5gYEO4o=
+github.com/scroll-tech/go-ethereum v1.10.14-0.20230901060443-e1eebd17067c/go.mod h1:DiN3p2inoXOxGffxSswDKqWjQ7bU+Mp0c9v0XQXKmaA=
 github.com/scroll-tech/zktrie v0.6.0 h1:xLrMAO31Yo2BiPg1jtYKzcjpEFnXy8acbB7iIsyshPs=
 github.com/scroll-tech/zktrie v0.6.0/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible h1:Bn1aCHHRnjv4Bl16T8rcaFjYSrGrIZvpiGO6P3Q4GpU=

--- a/testool/src/main.rs
+++ b/testool/src/main.rs
@@ -122,7 +122,7 @@ fn write_test_ids(test_ids: &[String]) -> Result<()> {
 }
 
 fn run_single_test(test: StateTest, circuits_config: CircuitsConfig) -> Result<()> {
-    log::info!("{}", &test);
+    log::info!("run single test {}", &test);
     let circuits_config = CircuitsConfig {
         verbose: true,
         super_circuit: circuits_config.super_circuit,

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -23,8 +23,8 @@ use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
 use zkevm_circuits::{
     bytecode_circuit::circuit::BytecodeCircuit, ecc_circuit::EccCircuit,
-    modexp_circuit::ModExpCircuit, super_circuit::SuperCircuit, test_util::CircuitTestBuilder,
-    util::SubCircuit, witness::Block, sig_circuit::SigCircuit,
+    modexp_circuit::ModExpCircuit, sig_circuit::SigCircuit, super_circuit::SuperCircuit,
+    test_util::CircuitTestBuilder, util::SubCircuit, witness::Block,
 };
 
 /// Read env var with default value
@@ -557,7 +557,7 @@ pub fn run_test(
             return Err(StateTestError::SkipTestBalanceOverflow);
         }
     }
-
+    log::debug!("trace_config generated");
     let circuits_params = if !circuits_config.super_circuit {
         get_params_for_sub_circuit_test()
     } else {

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 use zkevm_circuits::{
     bytecode_circuit::circuit::BytecodeCircuit, ecc_circuit::EccCircuit,
     modexp_circuit::ModExpCircuit, super_circuit::SuperCircuit, test_util::CircuitTestBuilder,
-    util::SubCircuit, witness::Block,
+    util::SubCircuit, witness::Block, sig_circuit::SigCircuit,
 };
 
 /// Read env var with default value
@@ -625,6 +625,7 @@ pub fn run_test(
                 "modexp" => test_with::<ModExpCircuit<Fr>>(&witness_block),
                 "bytecode" => test_with::<BytecodeCircuit<Fr>>(&witness_block),
                 "ecc" => test_with::<EccCircuit<Fr, 9>>(&witness_block),
+                "sig" => test_with::<SigCircuit<Fr>>(&witness_block),
                 _ => unimplemented!(),
             };
             prover.assert_satisfied_par();

--- a/zkevm-circuits/src/sig_circuit.rs
+++ b/zkevm-circuits/src/sig_circuit.rs
@@ -338,6 +338,7 @@ impl<F: Field> SigCircuit<F> {
             msg_hash,
         } = sign_data;
         let (sig_r, sig_s, v) = signature;
+        log::trace!("v         : {:?}", v);
         log::trace!("sig_r     : {:?}", sig_r);
         log::trace!("sig_s     : {:?}", sig_s);
         log::trace!("msg_hash  : {:?}", msg_hash);


### PR DESCRIPTION
maybe due to msg_hash is 0?

```
C="ecrecoverWeirdV_d1(good)_g0_v0"
FLAG=" --features=scroll"
export CIRCUIT=sig
RUST_BACKTRACE=1 RUST_LOG=trace cargo run --release $FLAG -- --circuits basic --suite nightly --inspect "${C}" 2>&1 | tee one.log
```
output:
```
error: lookup input does not exist in table
  (L0) ∉ ("F2")

  Lookup 'lookup wo selector' inputs:
    L0 = x0
    ^

    | Cell layout in region 'ecdsa chip verification':
    |   | Offset | A70|
    |   +--------+----+
    |   | 124925 | x0 | <--{ Lookup 'lookup wo selector' inputs queried here
    |
    | Assigned cell values:
    |   x0 = 0x1e9e780

Equality constraint not satisfied by cell (Column('Advice', 13 - ), in Region 1 ('ecdsa chip verification') at offset 913815)

Equality constraint not satisfied by cell (Column('Advice', 13 - ), in Region 1 ('ecdsa chip verification') at offset 913836)

thread 'main' panicked at 'circuit was not satisfied', /home/ubuntu/.cargo/git/checkouts/halo2-189ea3cf7f17e3ad/01f0b52
/halo2_proofs/src/dev.rs:1691:13
```