### PR TITLE
fix issue with msg_hash = 0

### DIFF
--- a/zkevm-circuits/src/sig_circuit.rs
+++ b/zkevm-circuits/src/sig_circuit.rs
@@ -104,6 +104,8 @@ impl<F: Field> SubCircuitConfig<F> for SigCircuitConfig<F> {
         // computations
         let num_advice = [calc_required_advices(MAX_NUM_SIG), 1];
 
+        let num_lookup_advice = [calc_required_lookup_advices(MAX_NUM_SIG)];
+
         #[cfg(feature = "onephase")]
         log::info!("configuring ECDSA chip with single phase");
         #[cfg(not(feature = "onephase"))]
@@ -126,7 +128,7 @@ impl<F: Field> SubCircuitConfig<F> for SigCircuitConfig<F> {
             meta,
             FpStrategy::Simple,
             &num_advice,
-            &[8],
+            &num_lookup_advice,
             1,
             LOG_TOTAL_NUM_ROWS - 1,
             88,

--- a/zkevm-circuits/src/sig_circuit/ecdsa.rs
+++ b/zkevm-circuits/src/sig_circuit/ecdsa.rs
@@ -53,12 +53,14 @@ where
     let u1 = scalar_chip.divide(ctx, msghash, s);
     let u2 = scalar_chip.divide(ctx, r, s);
 
+    // FIXME:
+    // this rng is not secure. We need to derive the RNG from Challenge
     let mut rng = thread_rng();
     let u3_fr = SF::random(&mut rng);
     let u3 = scalar_chip.load_private(ctx, FpConfig::<F, SF>::fe_to_witness(&Value::known(u3_fr)));
     let u1_plus_u3 = scalar_chip.add_no_carry(ctx, &u1, &u3);
     let u1_plus_u3 = scalar_chip.carry_mod(ctx, &u1_plus_u3);
-    
+
     // compute (u1+u3) * G
     let u1u3_mul = fixed_base::scalar_multiply::<F, _, _>(
         base_chip,

--- a/zkevm-circuits/src/sig_circuit/test.rs
+++ b/zkevm-circuits/src/sig_circuit/test.rs
@@ -23,8 +23,30 @@ fn sign_verify() {
     use rand_xorshift::XorShiftRng;
     use sha3::{Digest, Keccak256};
     let mut rng = XorShiftRng::seed_from_u64(1);
-    // let max_sigs = [1, 16, MAX_NUM_SIG];
-    let max_sigs = [1, 16];
+
+    // msg_hash == 0
+    {
+        log::debug!("testing for msg_hash = 0");
+        let mut signatures = Vec::new();
+
+        let (sk, pk) = gen_key_pair(&mut rng);
+        let msg = gen_msg(&mut rng);
+        let msg_hash = secp256k1::Fq::zero();
+        let (r, s, v) = sign_with_rng(&mut rng, sk, msg_hash);
+        signatures.push(SignData {
+            signature: (r, s, v),
+            pk,
+            msg: msg.into(),
+            msg_hash,
+        });
+
+        let k = LOG_TOTAL_NUM_ROWS as u32;
+        run::<Fr>(k, 1, signatures);
+
+        log::debug!("end of testing for msg_hash = 0");
+    }
+    // msg_hash != 0
+    let max_sigs = [1, 16, MAX_NUM_SIG];
     for max_sig in max_sigs.iter() {
         log::debug!("testing for {} signatures", max_sig);
         let mut signatures = Vec::new();
@@ -36,9 +58,7 @@ fn sign_verify() {
                 .to_vec()
                 .try_into()
                 .expect("hash length isn't 32 bytes");
-            // let msg_hash = secp256k1::Fq::from_bytes(&msg_hash).unwrap();
-
-            let msg_hash = secp256k1::Fq::zero();
+            let msg_hash = secp256k1::Fq::from_bytes(&msg_hash).unwrap();
             let (r, s, v) = sign_with_rng(&mut rng, sk, msg_hash);
             signatures.push(SignData {
                 signature: (r, s, v),

--- a/zkevm-circuits/src/sig_circuit/test.rs
+++ b/zkevm-circuits/src/sig_circuit/test.rs
@@ -23,7 +23,8 @@ fn sign_verify() {
     use rand_xorshift::XorShiftRng;
     use sha3::{Digest, Keccak256};
     let mut rng = XorShiftRng::seed_from_u64(1);
-    let max_sigs = [1, 16, MAX_NUM_SIG];
+    // let max_sigs = [1, 16, MAX_NUM_SIG];
+    let max_sigs = [1, 16];
     for max_sig in max_sigs.iter() {
         log::debug!("testing for {} signatures", max_sig);
         let mut signatures = Vec::new();
@@ -35,7 +36,9 @@ fn sign_verify() {
                 .to_vec()
                 .try_into()
                 .expect("hash length isn't 32 bytes");
-            let msg_hash = secp256k1::Fq::from_bytes(&msg_hash).unwrap();
+            // let msg_hash = secp256k1::Fq::from_bytes(&msg_hash).unwrap();
+
+            let msg_hash = secp256k1::Fq::zero();
             let (r, s, v) = sign_with_rng(&mut rng, sk, msg_hash);
             signatures.push(SignData {
                 signature: (r, s, v),

--- a/zkevm-circuits/src/sig_circuit/utils.rs
+++ b/zkevm-circuits/src/sig_circuit/utils.rs
@@ -13,16 +13,16 @@ use halo2_proofs::{
 // Hard coded parameters.
 // FIXME: allow for a configurable param.
 pub(super) const MAX_NUM_SIG: usize = 128;
-// Each ecdsa signature requires 565732 cells
-pub(super) const CELLS_PER_SIG: usize = 565732;
-// Each ecdsa signature requires 72888 lookup cells
-pub(super) const LOOKUP_CELLS_PER_SIG: usize = 72888;
+// Each ecdsa signature requires 460456 cells
+pub(super) const CELLS_PER_SIG: usize = 460456;
+// Each ecdsa signature requires 62994 lookup cells
+pub(super) const LOOKUP_CELLS_PER_SIG: usize = 62994;
 // Total number of rows allocated for ecdsa chip
 pub(super) const LOG_TOTAL_NUM_ROWS: usize = 20;
 // Max number of columns allowed
-pub(super) const COLUMN_NUM_LIMIT: usize = 71;
+pub(super) const COLUMN_NUM_LIMIT: usize = 58;
 // Max number of lookup columns allowed
-pub(super) const LOOKUP_COLUMN_NUM_LIMIT: usize = 10;
+pub(super) const LOOKUP_COLUMN_NUM_LIMIT: usize = 8;
 
 pub(super) fn calc_required_advices(num_verif: usize) -> usize {
     let mut num_adv = 1;

--- a/zkevm-circuits/src/sig_circuit/utils.rs
+++ b/zkevm-circuits/src/sig_circuit/utils.rs
@@ -13,13 +13,16 @@ use halo2_proofs::{
 // Hard coded parameters.
 // FIXME: allow for a configurable param.
 pub(super) const MAX_NUM_SIG: usize = 128;
-// Each ecdsa signature requires 456786 cells
-// We set CELLS_PER_SIG = 457000 to allows for a few buffer
-pub(super) const CELLS_PER_SIG: usize = 457000;
+// Each ecdsa signature requires 565732 cells
+pub(super) const CELLS_PER_SIG: usize = 565732;
+// Each ecdsa signature requires 72888 lookup cells
+pub(super) const LOOKUP_CELLS_PER_SIG: usize = 72888;
 // Total number of rows allocated for ecdsa chip
 pub(super) const LOG_TOTAL_NUM_ROWS: usize = 20;
 // Max number of columns allowed
-pub(super) const COLUMN_NUM_LIMIT: usize = 150;
+pub(super) const COLUMN_NUM_LIMIT: usize = 71;
+// Max number of lookup columns allowed
+pub(super) const LOOKUP_COLUMN_NUM_LIMIT: usize = 10;
 
 pub(super) fn calc_required_advices(num_verif: usize) -> usize {
     let mut num_adv = 1;
@@ -37,6 +40,24 @@ pub(super) fn calc_required_advices(num_verif: usize) -> usize {
         num_adv += 1;
     }
     panic!("the required advice columns exceeds {COLUMN_NUM_LIMIT} for {num_verif} signatures");
+}
+
+pub(super) fn calc_required_lookup_advices(num_verif: usize) -> usize {
+    let mut num_adv = 1;
+    let total_cells = num_verif * LOOKUP_CELLS_PER_SIG;
+    let row_num = 1 << LOG_TOTAL_NUM_ROWS;
+    while num_adv < LOOKUP_COLUMN_NUM_LIMIT {
+        if num_adv * row_num > total_cells {
+            log::debug!(
+                "ecdsa chip uses {} lookup advice columns for {} signatures",
+                num_adv,
+                num_verif
+            );
+            return num_adv;
+        }
+        num_adv += 1;
+    }
+    panic!("the required lookup advice columns exceeds {LOOKUP_COLUMN_NUM_LIMIT} for {num_verif} signatures");
 }
 
 /// Chip to handle overflow integers of ECDSA::Fq, the scalar field

--- a/zkevm-circuits/src/sig_circuit/utils.rs
+++ b/zkevm-circuits/src/sig_circuit/utils.rs
@@ -22,7 +22,7 @@ pub(super) const LOG_TOTAL_NUM_ROWS: usize = 20;
 // Max number of columns allowed
 pub(super) const COLUMN_NUM_LIMIT: usize = 58;
 // Max number of lookup columns allowed
-pub(super) const LOOKUP_COLUMN_NUM_LIMIT: usize = 8;
+pub(super) const LOOKUP_COLUMN_NUM_LIMIT: usize = 9;
 
 pub(super) fn calc_required_advices(num_verif: usize) -> usize {
     let mut num_adv = 1;


### PR DESCRIPTION
### Description

This PR temporarily solves the issue when `msg_hash = 0` for ecdsa circuit.

Some remaining issues:
1. should we also handle the case where `r = 0`
2. ecrecovery circuit prob will also need a refactor
3. we prob will want to have different logics for the ecdsa circuit and ecrecovery circuit
-  in ecdsa circuit  `msg_hash` and `r` cannot be 0
-  in ecrecovery circuit  `msg_hash` and `r` can be 0, and ecrecovery circuit needs to return false when it happens
- ~handling those 0s is costly:~
  - do nothing: `456786` cells 
  - handling `msg_hash=0`: `460456` cells
  - handling both `msg_hash` and `r`: ??? cells
4. ~the RNG used in the solution is not secure. We need to derive the RNG from challenge which seems quite complex.~

### Issue Link

https://github.com/scroll-tech/zkevm-circuits/pull/869

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?
```
RUST_LOG=trace cargo test --release sign_verify -- --nocapture 2>&1 | tee ecdas.log
```
