### PR TITLE
ec pairing simplify

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -1199,67 +1199,14 @@ impl EcPairingPair {
             .collect()
     }
 
-    /// Padding pair for ECC circuit. The pairing check is done with a constant number
-    /// `N_PAIRING_PER_OP` of (G1, G2) pairs. The ECC circuit under the hood uses halo2-lib to
-    /// compute the multi-miller loop, which allows `(G1::Infinity, G2::Generator)` pair to skip
-    /// the loop for that pair. So in case the EVM inputs are less than `N_PAIRING_PER_OP` we pad
-    /// the ECC Circuit inputs by this pair. Any EVM input of `(G1::Infinity, G2)` or
-    /// `(G1, G2::Infinity)` is also transformed into `(G1::Infinity, G2::Generator)`.
-    pub fn ecc_padding() -> Self {
-        Self {
-            g1_point: (U256::zero(), U256::zero()),
-            g2_point: (
-                U256([
-                    0x97e485b7aef312c2,
-                    0xf1aa493335a9e712,
-                    0x7260bfb731fb5d25,
-                    0x198e9393920d483a,
-                ]),
-                U256([
-                    0x46debd5cd992f6ed,
-                    0x674322d4f75edadd,
-                    0x426a00665e5c4479,
-                    0x1800deef121f1e76,
-                ]),
-                U256([
-                    0x55acdadcd122975b,
-                    0xbc4b313370b38ef3,
-                    0xec9e99ad690c3395,
-                    0x090689d0585ff075,
-                ]),
-                U256([
-                    0x4ce6cc0166fa7daa,
-                    0xe3d1e7690c43d37b,
-                    0x4aab71808dcb408f,
-                    0x12c85ea5db8c6deb,
-                ]),
-            ),
-        }
-    }
-
-    /// Padding pair for EVM circuit. The pairing check is done with a constant number
+    /// Padding pair for EcPairing operation. The pairing check is done with a constant number
     /// `N_PAIRING_PER_OP` of (G1, G2) pairs. In case EVM inputs are less in number, we pad them
     /// with `(G1::Infinity, G2::Infinity)` for simplicity.
-    pub fn evm_padding() -> Self {
+    pub fn padding_pair() -> Self {
         Self {
             g1_point: (U256::zero(), U256::zero()),
             g2_point: (U256::zero(), U256::zero(), U256::zero(), U256::zero()),
         }
-    }
-
-    /// Whether or not we swap the EVM pair with ECC pair. We do this iff:
-    /// - G1 is (0, 0)
-    /// - G2 is (0, 0, 0, 0)
-    ///
-    /// because for the above case, we have:
-    /// - (G1::identity, G2::identity) as inputs from the EVM.
-    /// - (G1::identity, G2::generator) as inputs to ECC Circuit.
-    pub fn swap(&self) -> bool {
-        (self.g1_point.0.is_zero() && self.g1_point.1.is_zero())
-            && (self.g2_point.0.is_zero()
-                && self.g2_point.1.is_zero()
-                && self.g2_point.2.is_zero()
-                && self.g2_point.3.is_zero())
     }
 
     fn is_valid(&self) -> bool {

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -21,7 +21,11 @@ use ethers_core::k256::elliptic_curve::subtle::CtOption;
 use gadgets::impl_expr;
 use halo2_proofs::{
     arithmetic::{CurveAffine, Field},
-    halo2curves::bn256::{Fq, Fq2, Fr, G1Affine, G2Affine},
+    circuit::Value,
+    halo2curves::{
+        bn256::{Fq, Fq2, Fr, G1Affine, G2Affine},
+        group::prime::PrimeCurveAffine,
+    },
     plonk::Expression,
 };
 
@@ -1175,6 +1179,28 @@ impl EcPairingPair {
             .collect()
     }
 
+    /// ...
+    pub fn to_g1_affine_tuple(&self) -> (Value<Fq>, Value<Fq>) {
+        (
+            Value::known(Fq::from_bytes(&self.g1_point.0.to_le_bytes()).unwrap()),
+            Value::known(Fq::from_bytes(&self.g1_point.1.to_le_bytes()).unwrap()),
+        )
+    }
+
+    /// ...
+    pub fn to_g2_affine_tuple(&self) -> (Value<Fq2>, Value<Fq2>) {
+        (
+            Value::known(Fq2 {
+                c0: Fq::from_bytes(&self.g2_point.1.to_le_bytes()).unwrap(),
+                c1: Fq::from_bytes(&self.g2_point.0.to_le_bytes()).unwrap(),
+            }),
+            Value::known(Fq2 {
+                c0: Fq::from_bytes(&self.g2_point.3.to_le_bytes()).unwrap(),
+                c1: Fq::from_bytes(&self.g2_point.2.to_le_bytes()).unwrap(),
+            }),
+        )
+    }
+
     /// Returns the big-endian representation of the G2 point in the pair.
     pub fn g2_bytes_be(&self) -> Vec<u8> {
         std::iter::empty()
@@ -1312,8 +1338,8 @@ impl EcPairingOp {
             pairs: [
                 EcPairingPair::new(g1_neg, g2),
                 EcPairingPair::new(other_g1, other_g2),
-                EcPairingPair::padding_pair(),
-                EcPairingPair::padding_pair(),
+                EcPairingPair::new(G1Affine::identity(), G2Affine::generator()),
+                EcPairingPair::new(G1Affine::identity(), G2Affine::generator()),
             ],
             output: 1.into(),
         }

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -2,7 +2,7 @@
 
 use std::{
     marker::PhantomData,
-    ops::{Add, Mul},
+    ops::{Add, Mul, Neg},
 };
 
 use crate::{
@@ -1299,6 +1299,24 @@ impl EcPairingOp {
     /// Whether the EVM inputs are valid or not, i.e. does the precompile succeed or fail.
     pub fn is_valid(&self) -> bool {
         self.pairs.iter().all(|pair| pair.is_valid())
+    }
+
+    /// Dummy pairing op that satisfies the pairing check.
+    pub fn dummy_pairing_check_ok() -> Self {
+        let g1 = G1Affine::from(G1Affine::generator() * Fr::from(2));
+        let g1_neg = g1.neg();
+        let g2 = G2Affine::from(G2Affine::generator() * Fr::from(3));
+        let other_g1 = G1Affine::from(G1Affine::generator() * Fr::from(6));
+        let other_g2 = G2Affine::generator();
+        Self {
+            pairs: [
+                EcPairingPair::new(g1_neg, g2),
+                EcPairingPair::new(other_g1, other_g2),
+                EcPairingPair::padding_pair(),
+                EcPairingPair::padding_pair(),
+            ],
+            output: 1.into(),
+        }
     }
 }
 

--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -995,6 +995,21 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
             QuantumCell::Existing(is_valid),
             QuantumCell::Existing(success),
         );
+        // if all inputs were zeroes, i.e. either:
+        // - G1 == (0, 0) and G2 == random valid point on G2
+        // - G2 == (0, 0, 0, 0) and G1 == random valid point on G1
+        //
+        // then success == true, i.e. success - all_pairs_zero == boolean
+        let success_minus_all_pairs_zero = ecc_chip
+            .field_chip()
+            .range()
+            .gate()
+            .load_witness(ctx, success.value - all_pairs_zero.value);
+        ecc_chip
+            .field_chip()
+            .range()
+            .gate()
+            .assert_bit(ctx, success_minus_all_pairs_zero);
 
         let op_output = ecc_chip.field_chip().range().gate().load_witness(
             ctx,

--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -856,16 +856,16 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         });
         let dummy_pair_check_ok = EcPairingOp::dummy_pairing_check_ok();
         let dummy_pair_check_ok_g1s = [
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[0].g1_point),
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[1].g1_point),
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[2].g1_point),
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[3].g1_point),
+            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[0].to_g1_affine_tuple()),
+            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[1].to_g1_affine_tuple()),
+            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[2].to_g1_affine_tuple()),
+            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[3].to_g1_affine_tuple()),
         ];
         let dummy_pair_check_ok_g2s = [
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[0].g2_point),
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[1].g2_point),
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[2].g2_point),
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[3].g2_point),
+            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[0].to_g2_affine_tuple()),
+            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[1].to_g2_affine_tuple()),
+            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[2].to_g2_affine_tuple()),
+            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[3].to_g2_affine_tuple()),
         ];
 
         // process pairs so that we pass only valid input to the multi_miller_loop.
@@ -912,8 +912,6 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
                         .range()
                         .gate()
                         .not(ctx, QuantumCell::Existing(*is_pair_valid));
-                    log::trace!("should swap valid?   {:?}", should_swap_valid.value);
-                    log::trace!("should swap invalid? {:?}", should_swap_invalid.value);
                     (
                         {
                             let swapped_g1 =

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -243,8 +243,8 @@ mod valid_invalid_cases {
                     let pairs = [
                         EcPairingPair::new(point_p_negated, point_q),
                         EcPairingPair::new(point_s, point_t),
-                        EcPairingPair::ecc_padding(),
-                        EcPairingPair::ecc_padding(),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
                     ];
                     EcPairingOp {
                         pairs,
@@ -273,8 +273,8 @@ mod valid_invalid_cases {
                                 U256::from_little_endian(&point_t.y.c0.to_bytes()),
                             ),
                         },
-                        EcPairingPair::ecc_padding(),
-                        EcPairingPair::ecc_padding(),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
                     ];
                     EcPairingOp {
                         pairs,
@@ -298,16 +298,54 @@ mod valid_invalid_cases {
                     let pairs = [
                         EcPairingPair::new(point_p_negated, point_q),
                         EcPairingPair::new(point_s, point_t),
-                        EcPairingPair::ecc_padding(),
-                        EcPairingPair::ecc_padding(),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
                     ];
                     EcPairingOp {
                         pairs,
                         output: U256::zero(),
                     }
                 },
-                // 4. TODO: invalid: not on curve G1.
-                // 5. TODO: invalid: not on curve G2.
+                // 4. invalid: not on curve G1.
+                EcPairingOp {
+                    pairs: [
+                        EcPairingPair {
+                            g1_point: (U256::from(3), U256::from(4)),
+                            g2_point: (U256::zero(), U256::zero(), U256::zero(), U256::zero()),
+                        },
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                    ],
+                    output: 0.into(),
+                },
+            ]
+        };
+        pub(crate) static ref EC_PAIRING_OPS3: Vec<EcPairingOp> = {
+            vec![
+                // 5. invalid: not on curve G2.
+                EcPairingOp {
+                    pairs: [
+                        EcPairingPair {
+                            g1_point: (U256::zero(), U256::zero()),
+                            g2_point: (U256::from(3), U256::from(4), U256::from(5), U256::from(6)),
+                        },
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                    ],
+                    output: 0.into(),
+                },
+                // 6. valid: all zero.
+                EcPairingOp {
+                    pairs: [
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                    ],
+                    output: 1.into(),
+                },
             ]
         };
     }
@@ -317,7 +355,9 @@ mod valid_invalid_cases {
 fn test_ecc_circuit_valid_invalid() {
     use crate::ecc_circuit::util::LOG_TOTAL_NUM_ROWS;
     use halo2_proofs::halo2curves::bn256::Fr;
-    use valid_invalid_cases::{EC_ADD_OPS, EC_MUL_OPS, EC_PAIRING_OPS1, EC_PAIRING_OPS2};
+    use valid_invalid_cases::{
+        EC_ADD_OPS, EC_MUL_OPS, EC_PAIRING_OPS1, EC_PAIRING_OPS2, EC_PAIRING_OPS3,
+    };
 
     run::<Fr, false>(
         LOG_TOTAL_NUM_ROWS,
@@ -337,6 +377,18 @@ fn test_ecc_circuit_valid_invalid() {
         vec![],
         vec![],
         EC_PAIRING_OPS2.clone(),
+    );
+
+    run::<Fr, false>(
+        LOG_TOTAL_NUM_ROWS,
+        PrecompileEcParams {
+            ec_add: 0,
+            ec_mul: 0,
+            ec_pairing: 2,
+        },
+        vec![],
+        vec![],
+        EC_PAIRING_OPS3.clone(),
     );
 }
 


### PR DESCRIPTION
### Description

EVM behaviour is as follows:
1. Process G1 and G2 bytes
2. If G1 is invalid, i.e. point not on curve then `is_success == false`
3. If G2 is invalid, i.e. point not on curve then `is_success == false`
4. If G1 and G2 both are valid
    - If G1 is `G1::identity` (with random valid G2) then skip pair while computing miller loop
    - If G2 is `G2::identity` (with random valid G1) then skip pair while computing miller loop

#### Before PR
Before this PR, the inputs to the ECC Circuit were possibly different from the inputs to EVM. Specifically, in the case where `(G1::identity, G2::identity)` were input to EVM, we replaced them with `(G1::identity, G2::generator)` for the ECC Circuit.

**The problem with this approach:**
We were struggling to handle valid vs invalid inputs. The case where `(G1::identity, G2::random)` or `(G1::random, G2::identity)` was not covered

#### After PR
The Ecc Circuit now handles the exact same input as provided to EVM. There is no "swapping" of inputs. The padded pair (to make 4 pairs) is also `(G1::identity, G2::identity)`.

We use several conditions to appropriately pass `pairs` to the multi miller loop algorithm, so that we avoid panic in all cases.

* `is_zero_pair` covers:
    - `G1: (0, 0)` and `G2: random valid`
    - `G2: (0, 0, 0, 0)` and `G1: random valid`
* `are_pairs_zero` represents whether all pairs satisfy `is_zero_pair`
* If either G1 is invalid (not on curve) or G2 is invalid (not on curve):
    - Swap the pair with `(G1::random, G2::random)`
    - EVM would interpret this as a failure case, hence `pairing_check == false`
    - However if we use the invalid points, the `multi_miller_loop` would panic
    - So we swap with random points, expecting the pairing check  to fail
    - And we add an assertion that `pairing_check == false` if `is_valid == false`
* if `G1: (0, 0)` and `G2: random valid` or `G2: (0, 0, 0, 0)` and `G1: random valid` then
    - Swap the pair with `(G1::identity, G2::generator)`
* If all the pairs are zero, i.e. `are_pairs_zero == true` then
    - Swap the pairs with dummy pairs that satisfy the pairing check
    - This is done because EVM interprets this as `pairing_check == 1` although `multi_miller_loop` panics

### Issue Link

Closes #868 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update