### PR TITLE
fix: load constants wherever applicable

### DIFF
--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -10,7 +10,7 @@ use bus_mapping::{
 use eth_types::{Field, ToLittleEndian, ToScalar, U256};
 use halo2_base::{
     gates::{GateInstructions, RangeInstructions},
-    utils::{decompose_bigint_option, modulus},
+    utils::{decompose_bigint_option, fe_to_biguint, modulus},
     AssignedValue, Context, QuantumCell, SKIP_FIRST_PASS,
 };
 use halo2_ecc::{
@@ -854,28 +854,49 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         // dummy G1, G2 points and G1::identity, G2::generator.
         let dummy_g1 = ecc_chip.load_random_point::<G1Affine>(ctx);
         let dummy_g2 = ecc2_chip.load_random_point::<G2Affine>(ctx);
-        let identity_g1 = ecc_chip.load_private(ctx, {
-            let identity_g1 = G1Affine::identity();
-            (Value::known(identity_g1.x), Value::known(identity_g1.y))
-        });
-        let generator_g2 = ecc2_chip.load_private(ctx, {
-            let generator_g2 = G2Affine::generator();
-            (Value::known(generator_g2.x), Value::known(generator_g2.y))
-        });
+        let identity_g1 = EcPoint::construct(
+            ecc_chip
+                .field_chip()
+                .load_constant(ctx, fe_to_biguint(&Fq::zero())),
+            ecc_chip
+                .field_chip()
+                .load_constant(ctx, fe_to_biguint(&Fq::zero())),
+        );
+        let generator_g2 = {
+            let g2_gen = G2Affine::generator();
+            EcPoint::<F, FieldExtPoint<CRTInteger<F>>>::construct(
+                ecc2_chip.field_chip().load_constant(ctx, g2_gen.x),
+                ecc2_chip.field_chip().load_constant(ctx, g2_gen.y),
+            )
+        };
         // A pairing op satisfying the pairing check.
-        let dummy_pair_check_ok = EcPairingOp::dummy_pairing_check_ok();
-        let dummy_pair_check_ok_g1s = [
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[0].to_g1_affine_tuple()),
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[1].to_g1_affine_tuple()),
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[2].to_g1_affine_tuple()),
-            ecc_chip.load_private(ctx, dummy_pair_check_ok.pairs[3].to_g1_affine_tuple()),
-        ];
-        let dummy_pair_check_ok_g2s = [
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[0].to_g2_affine_tuple()),
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[1].to_g2_affine_tuple()),
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[2].to_g2_affine_tuple()),
-            ecc2_chip.load_private(ctx, dummy_pair_check_ok.pairs[3].to_g2_affine_tuple()),
-        ];
+        type TupleG1sG2s<F> = (
+            Vec<EcPoint<F, CRTInteger<F>>>,
+            Vec<EcPoint<F, FieldExtPoint<CRTInteger<F>>>>,
+        );
+        let (dummy_pair_check_ok_g1s, dummy_pair_check_ok_g2s): TupleG1sG2s<F> =
+            EcPairingOp::dummy_pairing_check_ok()
+                .pairs
+                .iter()
+                .map(|pair| {
+                    let (g1_point, g2_point) =
+                        pair.as_g1_g2().expect("dummy pairing check OK pair");
+                    (
+                        EcPoint::<F, CRTInteger<F>>::construct(
+                            ecc_chip
+                                .field_chip()
+                                .load_constant(ctx, fe_to_biguint(&g1_point.x)),
+                            ecc_chip
+                                .field_chip()
+                                .load_constant(ctx, fe_to_biguint(&g1_point.y)),
+                        ),
+                        EcPoint::<F, FieldExtPoint<CRTInteger<F>>>::construct(
+                            ecc2_chip.field_chip().load_constant(ctx, g2_point.x),
+                            ecc2_chip.field_chip().load_constant(ctx, g2_point.y),
+                        ),
+                    )
+                })
+                .unzip();
 
         // process pairs so that we pass only valid input to the multi_miller_loop.
         let pairs = decomposed_pairs

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -348,6 +348,30 @@ mod valid_invalid_cases {
                 },
             ]
         };
+        pub(crate) static ref EC_PAIRING_OPS4: Vec<EcPairingOp> = {
+            vec![
+                // 7. valid: [(G1::gen, G2::gen), (-G1::gen, G2::gen)]
+                EcPairingOp {
+                    pairs: [
+                        EcPairingPair::new(G1Affine::generator(), G2Affine::generator()),
+                        EcPairingPair::new(G1Affine::generator().neg(), G2Affine::generator()),
+                        EcPairingPair::padding_pair(),
+                        EcPairingPair::padding_pair(),
+                    ],
+                    output: 1.into(),
+                },
+                // 8. valid: [(G1::gen, G2::gen), (-G1::gen, G2::gen); 2]
+                EcPairingOp {
+                    pairs: [
+                        EcPairingPair::new(G1Affine::generator(), G2Affine::generator()),
+                        EcPairingPair::new(G1Affine::generator().neg(), G2Affine::generator()),
+                        EcPairingPair::new(G1Affine::generator(), G2Affine::generator()),
+                        EcPairingPair::new(G1Affine::generator().neg(), G2Affine::generator()),
+                    ],
+                    output: 1.into(),
+                },
+            ]
+        };
     }
 }
 
@@ -356,7 +380,7 @@ fn test_ecc_circuit_valid_invalid() {
     use crate::ecc_circuit::util::LOG_TOTAL_NUM_ROWS;
     use halo2_proofs::halo2curves::bn256::Fr;
     use valid_invalid_cases::{
-        EC_ADD_OPS, EC_MUL_OPS, EC_PAIRING_OPS1, EC_PAIRING_OPS2, EC_PAIRING_OPS3,
+        EC_ADD_OPS, EC_MUL_OPS, EC_PAIRING_OPS1, EC_PAIRING_OPS2, EC_PAIRING_OPS3, EC_PAIRING_OPS4,
     };
 
     run::<Fr, false>(
@@ -389,6 +413,18 @@ fn test_ecc_circuit_valid_invalid() {
         vec![],
         vec![],
         EC_PAIRING_OPS3.clone(),
+    );
+
+    run::<Fr, false>(
+        LOG_TOTAL_NUM_ROWS,
+        PrecompileEcParams {
+            ec_add: 0,
+            ec_mul: 0,
+            ec_pairing: 2,
+        },
+        vec![],
+        vec![],
+        EC_PAIRING_OPS4.clone(),
     );
 }
 


### PR DESCRIPTION
### Description

We need some constant points to constrain special cases in `EcPairing`. They need to be loaded as constants.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update