### PR TITLE
fix-tob-xxx: add a missing boolean constraint for chunk_is_valid cells

### DIFF
--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -523,12 +523,14 @@ pub(crate) fn conditional_constraints(
                 // ====================================================
                 let chunk_is_valid_cells = chunks_are_valid
                     .iter()
-                    .map(|chunk_is_valid| {
-                        rlc_config.load_private(
+                    .map(|chunk_is_valid| -> Result<_, halo2_proofs::plonk::Error> {
+                        let cell = rlc_config.load_private(
                             &mut region,
                             &Fr::from(*chunk_is_valid as u64),
                             &mut offset,
-                        )
+                        )?;
+                        rlc_config.enforce_binary(&mut region, &cell, &mut offset)?;
+                        Ok(cell)
                     })
                     .collect::<Result<Vec<_>, halo2_proofs::plonk::Error>>()?;
                 let num_valid_snarks =


### PR DESCRIPTION
### Description

- finding from TOB auditing
- add a missing boolean constraint for `chunk_is_valid` cells

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

within aggregator crate
```
cargo test --release agg -- --nocapture
```
<hr>
