### PR TITLE
refactor ZktrieState

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -178,7 +178,7 @@ pub struct CircuitInputBuilder {
     pub block_ctx: BlockContext,
     #[cfg(feature = "scroll")]
     /// Initial Zktrie Status for a incremental updating
-    pub mpt_init_state: ZktrieState,
+    pub mpt_state: ZktrieState,
 }
 
 impl<'a> CircuitInputBuilder {
@@ -191,7 +191,7 @@ impl<'a> CircuitInputBuilder {
             block: block.clone(),
             block_ctx: BlockContext::new(),
             #[cfg(feature = "scroll")]
-            mpt_init_state: Default::default(),
+            mpt_state: Default::default(),
         }
     }
     /// Create a new CircuitInputBuilder from the given `eth_block` and

--- a/bus-mapping/src/circuit_input_builder/l2.rs
+++ b/bus-mapping/src/circuit_input_builder/l2.rs
@@ -337,7 +337,7 @@ impl CircuitInputBuilder {
 
         log::debug!(
             "building partial statedb done, root {}",
-            hex::encode(mpt_init_state.root())
+            hex::encode(mpt_init_state.cur_root())
         );
 
         let sdb = StateDB::from(&mpt_init_state);
@@ -355,7 +355,7 @@ impl CircuitInputBuilder {
 
         let mut builder_block = circuit_input_builder::Block::from_headers(&[], circuits_params);
         builder_block.chain_id = chain_id;
-        builder_block.prev_state_root = U256::from(mpt_init_state.root());
+        builder_block.prev_state_root = U256::from(mpt_init_state.cur_root());
         builder_block.start_l1_queue_index = l2_trace.start_l1_queue_index;
         let mut builder = Self {
             sdb,

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -322,7 +322,7 @@ fn trace_config_to_witness_block_l2(
         .expect("could not finalize building block");
     let mut block =
         zkevm_circuits::witness::block_convert(&builder.block, &builder.code_db).unwrap();
-    zkevm_circuits::witness::block_apply_mpt_state(&mut block, &builder.mpt_init_state);
+    zkevm_circuits::witness::block_apply_mpt_state(&mut block, &mut builder.mpt_init_state);
     Ok(Some((block, builder)))
 }
 

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -322,7 +322,7 @@ fn trace_config_to_witness_block_l2(
         .expect("could not finalize building block");
     let mut block =
         zkevm_circuits::witness::block_convert(&builder.block, &builder.code_db).unwrap();
-    zkevm_circuits::witness::block_apply_mpt_state(&mut block, &mut builder.mpt_init_state);
+    zkevm_circuits::witness::block_apply_mpt_state(&mut block, &mut builder.mpt_state);
     Ok(Some((block, builder)))
 }
 

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -57,7 +57,7 @@ fn test_super_circuit<
 
     let mut block = block_convert(&builder.block, &builder.code_db).unwrap();
     block.randomness = Fr::from(MOCK_RANDOMNESS);
-    block_apply_mpt_state(&mut block, &mut builder.mpt_init_state);
+    block_apply_mpt_state(&mut block, &mut builder.mpt_state);
 
     let active_row_num =SuperCircuit::<
         Fr,

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -57,7 +57,7 @@ fn test_super_circuit<
 
     let mut block = block_convert(&builder.block, &builder.code_db).unwrap();
     block.randomness = Fr::from(MOCK_RANDOMNESS);
-    block_apply_mpt_state(&mut block, &builder.mpt_init_state);
+    block_apply_mpt_state(&mut block, &mut builder.mpt_init_state);
 
     let active_row_num =SuperCircuit::<
         Fr,

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -230,7 +230,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
                         .expect("could not finalize building block");
                     let mut block =
                         crate::witness::block_convert(&builder.block, &builder.code_db).unwrap();
-                    crate::witness::block_apply_mpt_state(&mut block, &builder.mpt_init_state);
+                    crate::witness::block_apply_mpt_state(&mut block, &mut builder.mpt_init_state);
                     block
                 }
 

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -230,7 +230,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
                         .expect("could not finalize building block");
                     let mut block =
                         crate::witness::block_convert(&builder.block, &builder.code_db).unwrap();
-                    crate::witness::block_apply_mpt_state(&mut block, &mut builder.mpt_init_state);
+                    crate::witness::block_apply_mpt_state(&mut block, &mut builder.mpt_state);
                     block
                 }
 

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -488,6 +488,6 @@ pub fn block_convert_with_l1_queue_index<F: Field>(
 }
 
 /// Attach witness block with mpt states
-pub fn block_apply_mpt_state<F: Field>(block: &mut Block<F>, mpt_state: &MptState) {
+pub fn block_apply_mpt_state<F: Field>(block: &mut Block<F>, mpt_state: &mut MptState) {
     block.mpt_updates.fill_state_roots(mpt_state);
 }

--- a/zktrie/src/state/witness.rs
+++ b/zktrie/src/state/witness.rs
@@ -132,15 +132,15 @@ impl ActiveZktrieState {
         let trie = self.storages.get_mut(&address).unwrap();
 
         let store_before = {
-            let mut word_buf = [0u8; 32];
-            old_value.to_big_endian(word_buf.as_mut_slice());
+            let mut old_value_in_mpt_update = [0u8; 32];
+            old_value.to_big_endian(old_value_in_mpt_update.as_mut_slice());
             // sanity check
-            let old_value_in_statedb = trie.get_store(key.as_ref()).unwrap_or_default();
-            if word_buf != old_value_in_statedb {
+            let old_value_in_zktrie_state = trie.get_store(key.as_ref()).unwrap_or_default();
+            if old_value_in_mpt_update != old_value_in_zktrie_state {
                 log::error!(
-                    "old value in proof {:?} != old value in partial db {:?}",
-                    hex::encode(word_buf),
-                    hex::encode(old_value_in_statedb)
+                    "old_value_in_mpt_update {:?} != old_value_in_zktrie_state {:?}",
+                    hex::encode(old_value_in_mpt_update),
+                    hex::encode(old_value_in_zktrie_state)
                 );
                 log::error!(
                     "address {:?} key {:?} new_value {:?} old_value {:?}",
@@ -150,10 +150,10 @@ impl ActiveZktrieState {
                     old_value
                 );
             }
-            assert_eq!(word_buf, old_value_in_statedb);
+            assert_eq!(old_value_in_mpt_update, old_value_in_zktrie_state);
             StateData {
                 key,
-                value: HexBytes(word_buf),
+                value: HexBytes(old_value_in_mpt_update),
             }
         };
         let store_after = {


### PR DESCRIPTION
the goal of this PR is, i want to do some testing with ccc.light_mode = false https://github.com/scroll-tech/scroll-prover/blob/df0417e7b044cef7c48c82e6be230b3b391f262a/prover/tests/integration.rs#L86

where we plan to replay storage writes tx by tx.

But the problem is, currently we only have the "ZktrieState"(init state before block).  Although the states inside 'WitnessGenerator' is realtime, but it will be releases after apply_mpt_updates.   So we plan to keep the "active realtime partical zktrie".

Then we can fix some state checks
(1) https://github.com/scroll-tech/zkevm-circuits/blob/86491c2018472f75d3a78d885f7eacde44215497/zktrie/src/state/witness.rs#L133 the trie should be the updated trie, not the trie at the beginning of block.
(2) https://github.com/scroll-tech/zkevm-circuits/blob/86491c2018472f75d3a78d885f7eacde44215497/zktrie/src/state/witness.rs#L225 the account_data_before, same with above.