### PR TITLE
minor refactor of testool

### DIFF
--- a/zkevm-circuits/src/sig_circuit.rs
+++ b/zkevm-circuits/src/sig_circuit.rs
@@ -358,8 +358,8 @@ impl<F: Field> SigCircuit<F> {
             fq_chip.load_private(ctx, FqChip::<F>::fe_to_witness(&Value::known(*sig_s)));
         let msg_hash =
             fq_chip.load_private(ctx, FqChip::<F>::fe_to_witness(&Value::known(*msg_hash)));
-        log::trace!("integer_r : {:?}", integer_r);
-        log::trace!("integer_s : {:?}", integer_s);
+        //log::trace!("integer_r : {:?}", integer_r);
+        //log::trace!("integer_s : {:?}", integer_s);
 
         // returns the verification result of ecdsa signature
         //


### PR DESCRIPTION
```
FLAG=" --features=scroll"
LIST=/home/ubuntu/zzhang/testool_reports/0906_ecrecover.csv # super2
export CIRCUIT=sig
RUST_BACKTRACE=1 RUST_LOG=trace  cargo run --release $FLAG -- --circuits basic --test-ids $LIST --suite nightly 2>&1 | tee list.log
```

then `grep 'no ec recover' list.log` we will find many edge case ec recover skipped. Soundness issue.