### PR TITLE
feat: add inner-prove and chunk-prove to testool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,6 +4877,7 @@ dependencies = [
  "mock",
  "once_cell",
  "prettytable-rs",
+ "prover",
  "rand",
  "rand_chacha",
  "rayon",

--- a/prover/src/common/prover/utils.rs
+++ b/prover/src/common/prover/utils.rs
@@ -73,4 +73,8 @@ impl Prover {
     pub fn raw_vk(&self, id: &str) -> Option<Vec<u8>> {
         self.pk_map.get(id).map(|pk| serialize_vk(pk.get_vk()))
     }
+
+    pub fn clear_pks(&mut self) {
+        self.pk_map.clear();
+    }
 }

--- a/prover/src/common/verifier/utils.rs
+++ b/prover/src/common/verifier/utils.rs
@@ -14,4 +14,8 @@ impl<C: CircuitExt<Fr>> Verifier<C> {
     pub fn vk(&self) -> &VerifyingKey<G1Affine> {
         &self.vk
     }
+
+    pub fn set_vk(&mut self, vk: VerifyingKey<G1Affine>) {
+        self.vk = vk;
+    }
 }

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -31,6 +31,8 @@ pub static AGG_DEGREES: Lazy<Vec<u32>> =
 
 #[derive(Clone, Copy, Debug)]
 pub enum LayerId {
+    /// Super (inner) circuit layer
+    Inner,
     /// Compression wide layer
     Layer1,
     /// Compression thin layer (to generate chunk-proof)
@@ -50,6 +52,7 @@ impl fmt::Display for LayerId {
 impl LayerId {
     pub fn id(&self) -> &str {
         match self {
+            Self::Inner => "inner",
             Self::Layer1 => "layer1",
             Self::Layer2 => "layer2",
             Self::Layer3 => "layer3",
@@ -59,6 +62,7 @@ impl LayerId {
 
     pub fn degree(&self) -> u32 {
         match self {
+            Self::Inner => *INNER_DEGREE,
             Self::Layer1 => *LAYER1_DEGREE,
             Self::Layer2 => *LAYER2_DEGREE,
             Self::Layer3 => *LAYER3_DEGREE,
@@ -72,6 +76,7 @@ impl LayerId {
             Self::Layer2 => &LAYER2_CONFIG_PATH,
             Self::Layer3 => &LAYER3_CONFIG_PATH,
             Self::Layer4 => &LAYER4_CONFIG_PATH,
+            Self::Inner => unreachable!("No config file for super (inner) circuit"),
         }
     }
 }

--- a/prover/src/zkevm/prover.rs
+++ b/prover/src/zkevm/prover.rs
@@ -44,6 +44,7 @@ impl Prover {
         &mut self,
         chunk_trace: Vec<BlockTrace>,
         name: Option<&str>,
+        inner_id: Option<&str>,
         output_dir: Option<&str>,
     ) -> Result<ChunkProof> {
         assert!(!chunk_trace.is_empty());
@@ -64,9 +65,12 @@ impl Prover {
             |name| name.to_string(),
         );
 
-        let snark = self
-            .inner
-            .load_or_gen_final_chunk_snark(&name, &witness_block, output_dir)?;
+        let snark = self.inner.load_or_gen_final_chunk_snark(
+            &name,
+            &witness_block,
+            inner_id,
+            output_dir,
+        )?;
 
         self.check_and_clear_raw_vk();
 

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -22,6 +22,7 @@ itertools = "0.10"
 mock = { path = "../mock" }
 once_cell = "1.10"
 prettytable-rs = "0.10"
+prover = { path = "../prover", optional = true }
 rayon = "1.5"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
@@ -43,5 +44,8 @@ default = ["ignore-test-docker", "skip-self-destruct", "shanghai"]
 onephase = ["zkevm-circuits/onephase"]
 ignore-test-docker = []
 skip-self-destruct = []
-shanghai = ["bus-mapping/shanghai", "eth-types/shanghai", "mock/shanghai", "zkevm-circuits/shanghai"]
-scroll = ["bus-mapping/scroll", "eth-types/scroll", "external-tracer/scroll", "mock/scroll", "zkevm-circuits/scroll"]
+shanghai = ["bus-mapping/shanghai", "eth-types/shanghai", "mock/shanghai", "zkevm-circuits/shanghai", "prover?/shanghai"]
+scroll = ["bus-mapping/scroll", "eth-types/scroll", "external-tracer/scroll", "mock/scroll", "zkevm-circuits/scroll", "prover?/scroll"]
+parallel_syn = ["halo2_proofs/parallel_syn", "zkevm-circuits/parallel_syn", "prover?/parallel_syn"]
+inner-prove = ["prover", "parallel_syn", "scroll", "shanghai"]
+chunk-prove = ["prover", "parallel_syn", "scroll", "shanghai"]

--- a/testool/Makefile
+++ b/testool/Makefile
@@ -1,0 +1,6 @@
+.PHONY: download-setup
+
+# Could be called as `make download-setup -e degree=DEGREE params_dir=PARAMS_DIR`.
+# As default `degree=26` and `params_dir=./test_params`.
+download-setup:
+	sh download_setup.sh ${degree} ${params_dir}

--- a/testool/download_setup.sh
+++ b/testool/download_setup.sh
@@ -1,0 +1,15 @@
+set -x
+set -e
+
+# Set degree to env AGG_DEGREE, first input or default value 26.
+degree="${AGG_DEGREE:-${1:-26}}"
+
+# Set the output dir to second input or default as `./test_params`.
+params_dir="${2:-"./test_params"}"
+mkdir -p "$params_dir"
+
+output_file="$params_dir"/params"${degree}"
+rm -f "$output_file"
+
+# degree 1 - 26
+axel -ac https://circuit-release.s3.us-west-2.amazonaws.com/setup/params"$degree" -o "$output_file"

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -804,7 +804,7 @@ fn inner_prove(test_id: &str, coinbase: &Address, witness_block: &Block<Fr>) {
 
     // Reset VK if coinbase address changed.
     if coinbase_changed {
-        let pk = prover.pk(&coinbase).unwrap_or_else(|| {
+        let pk = prover.pk(LayerId::Layer2.id()).unwrap_or_else(|| {
             panic!("{test_id}: failed to get inner-prove PK, coinbase = {coinbase}")
         });
         let vk = pk.get_vk().clone();

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -727,7 +727,7 @@ pub fn run_test(
             inner_prove(&test_id, &st.env.current_coinbase, &witness_block);
             #[cfg(feature = "chunk-prove")]
             chunk_prove(&test_id, &st.env.current_coinbase, &witness_block);
-            #[cfg(not(all(feature = "inner-prove", feature = "chunk-prove")))]
+            #[cfg(not(any(feature = "inner-prove", feature = "chunk-prove")))]
             mock_prove(&test_id, &witness_block);
         }
     };
@@ -767,7 +767,7 @@ pub fn run_test(
     Ok(())
 }
 
-#[cfg(not(all(feature = "inner-prove", feature = "chunk-prove")))]
+#[cfg(not(any(feature = "inner-prove", feature = "chunk-prove")))]
 fn mock_prove(test_id: &str, witness_block: &Block<Fr>) {
     log::info!("{test_id}: mock-prove BEGIN");
     // TODO: do we need to automatically adjust this k?

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -804,7 +804,7 @@ fn inner_prove(test_id: &str, coinbase: &Address, witness_block: &Block<Fr>) {
 
     // Reset VK if coinbase address changed.
     if coinbase_changed {
-        let pk = prover.pk(LayerId::Layer2.id()).unwrap_or_else(|| {
+        let pk = prover.pk(&coinbase).unwrap_or_else(|| {
             panic!("{test_id}: failed to get inner-prove PK, coinbase = {coinbase}")
         });
         let vk = pk.get_vk().clone();
@@ -819,6 +819,8 @@ fn inner_prove(test_id: &str, coinbase: &Address, witness_block: &Block<Fr>) {
 
 #[cfg(feature = "chunk-prove")]
 fn chunk_prove(test_id: &str, coinbase: &Address, witness_block: &Block<Fr>) {
+    use prover::config::LayerId;
+
     let coinbase = coinbase.to_string();
     log::info!("{test_id}: chunk-prove BEGIN, coinbase = {coinbase}");
 
@@ -839,7 +841,7 @@ fn chunk_prove(test_id: &str, coinbase: &Address, witness_block: &Block<Fr>) {
 
     // Reset VK if coinbase address changed.
     if coinbase_changed {
-        let pk = prover.pk(&coinbase).unwrap_or_else(|| {
+        let pk = prover.pk(LayerId::Layer2.id()).unwrap_or_else(|| {
             panic!("{test_id}: failed to get inner-prove PK, coinbase = {coinbase}")
         });
         let vk = pk.get_vk().clone();


### PR DESCRIPTION
### Summary

- add feature `inner-prove` and `chunk-prove` to testool.
- reset pk/vk in real prover and verifier according to coinbase address.

### Test

Set `TESTOOL_IDS_START=1000` and `TESTOOL_IDS_LEN=5`:
- for `inner-prove`, the first case costs about `16-mins`, and others cost about `11-mins`.
- for `chunk-prove`, the first case costs about `20-mins`, and others cost about `15-mins`.

[inner-prove.log.tar.gz](https://github.com/scroll-tech/zkevm-circuits/files/12564435/inner-prove.log.tar.gz)
[chunk-prove.log.tar.gz](https://github.com/scroll-tech/zkevm-circuits/files/12560421/chunk-prove.log.tar.gz)

50-cases of `inner-prove`:

<img width="600" alt="Screen Shot 2023-09-10 at 11 13 42 AM" src="https://github.com/scroll-tech/zkevm-circuits/assets/31645658/6ed46225-b696-44f1-ab05-63207d9f4608">


