### PR TITLE
fix: miss fixing to `<= NORMALIZED_ROW_LIMIT` in `add` function

### DIFF
--- a/prover/src/zkevm/capacity_checker.rs
+++ b/prover/src/zkevm/capacity_checker.rs
@@ -108,7 +108,7 @@ impl RowUsage {
             .map(|x| x.row_number)
             .max()
             .unwrap();
-        self.is_ok = self.row_number < NORMALIZED_ROW_LIMIT;
+        self.is_ok = self.row_number <= NORMALIZED_ROW_LIMIT;
     }
 }
 


### PR DESCRIPTION
### Description

Fix to `<= NORMALIZED_ROW_LIMIT` in `add` row-usage function.

Fixed in [from_row_usage_details](https://github.com/scroll-tech/zkevm-circuits/blob/develop/prover/src/zkevm/capacity_checker.rs#L92) function before.
