### PR TITLE
ecrecover soundness (address not recovered)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "log",
  "mock",
  "mpt-zktrie",
+ "num",
  "once_cell",
  "poseidon-circuit",
  "pretty_assertions",

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -20,6 +20,7 @@ poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git"
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"
+num = "0.4"
 rand = { version = "0.8", optional = true }
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"

--- a/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
@@ -63,24 +63,6 @@ pub(crate) fn opt_data(
             Some(PrecompileAuxData::Ecrecover(aux_data)),
         )
     } else {
-        let sign_data = SignData {
-            signature: (
-                Fq::from_bytes(&aux_data.sig_r.to_le_bytes()).unwrap(),
-                Fq::from_bytes(&aux_data.sig_s.to_le_bytes()).unwrap(),
-                aux_data.sig_v.byte(0),
-            ),
-            pk: Secp256k1Affine::identity(),
-            msg: Bytes::default(),
-            msg_hash: {
-                let msg_hash = BigUint::from_bytes_be(&aux_data.msg_hash.to_be_bytes());
-                let msg_hash = msg_hash.mod_floor(&*SECP256K1_Q);
-                let msg_hash_le = biguint_to_32bytes_le(msg_hash);
-                Fq::from_repr(msg_hash_le).unwrap()
-            },
-        };
-        (
-            Some(PrecompileEvent::Ecrecover(sign_data)),
-            Some(PrecompileAuxData::Ecrecover(aux_data)),
-        )
+        (None, Some(PrecompileAuxData::Ecrecover(aux_data)))
     }
 }

--- a/eth-types/src/sign_types.rs
+++ b/eth-types/src/sign_types.rs
@@ -15,6 +15,7 @@ use halo2_proofs::{
     halo2curves::{
         group::{
             ff::{Field as GroupField, PrimeField},
+            prime::PrimeCurveAffine,
             Curve,
         },
         secp256k1::{self, Secp256k1Affine},
@@ -101,6 +102,9 @@ pub fn get_dummy_tx() -> (TransactionRequest, Signature) {
 impl SignData {
     /// Recover address of the signature
     pub fn get_addr(&self) -> Address {
+        if self.pk == Secp256k1Affine::identity() {
+            return Address::zero();
+        }
         let pk_le = pk_bytes_le(&self.pk);
         let pk_be = pk_bytes_swap_endianness(&pk_le);
         let pk_hash = keccak256(pk_be);

--- a/zkevm-circuits/src/ecc_circuit.rs
+++ b/zkevm-circuits/src/ecc_circuit.rs
@@ -622,10 +622,10 @@ impl<F: Field, const XI_0: i64> EccCircuit<F, XI_0> {
         let infinity = EcPoint::construct(
             ecc_chip
                 .field_chip()
-                .load_private(ctx, Value::known(0.into())),
+                .load_constant(ctx, fe_to_biguint(&Fq::zero())),
             ecc_chip
                 .field_chip()
-                .load_private(ctx, Value::known(0.into())),
+                .load_constant(ctx, fe_to_biguint(&Fq::zero())),
         );
         // for invalid case, take a random point.
         let dummy_g1 = ecc_chip.load_random_point::<G1Affine>(ctx);

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
@@ -1,10 +1,10 @@
-use array_init::array_init;
 use bus_mapping::precompile::PrecompileAuxData;
-
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
-use gadgets::util::{select, Expr};
-use halo2_proofs::{circuit::Value, plonk::Error};
-use itertools::Itertools;
+use eth_types::{evm_types::GasCost, word, Field, ToLittleEndian, ToScalar, U256};
+use gadgets::util::{and, not, select, Expr};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 use crate::{
     evm_circuit::{
@@ -14,12 +14,20 @@ use crate::{
         util::{
             common_gadget::RestoreContextGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            from_bytes, rlc, CachedRegion, Cell, RandomLinearCombination,
+            from_bytes,
+            math_gadget::{LtWordGadget, ModGadget},
+            rlc, CachedRegion, Cell, RandomLinearCombination, Word,
         },
     },
     table::CallContextFieldTag,
     witness::{Block, Call, ExecStep, Transaction},
 };
+
+lazy_static::lazy_static! {
+    static ref FQ_MODULUS: U256 = {
+        word!("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141")
+    };
+}
 
 #[derive(Clone, Debug)]
 pub struct EcrecoverGadget<F> {
@@ -30,9 +38,15 @@ pub struct EcrecoverGadget<F> {
     sig_s_keccak_rlc: Cell<F>,
     recovered_addr_keccak_rlc: RandomLinearCombination<F, N_BYTES_ACCOUNT_ADDRESS>,
 
-    msg_hash: [Cell<F>; N_BYTES_WORD],
-    sig_r: [Cell<F>; N_BYTES_WORD],
-    sig_s: [Cell<F>; N_BYTES_WORD],
+    msg_hash_raw: Word<F>,
+    msg_hash: Word<F>,
+    fq_modulus: Word<F>,
+    msg_hash_mod: ModGadget<F, true>,
+
+    sig_r: Word<F>,
+    sig_r_canonical: LtWordGadget<F>,
+    sig_s: Word<F>,
+    sig_s_canonical: LtWordGadget<F>,
 
     is_success: Cell<F>,
     callee_address: Cell<F>,
@@ -66,24 +80,60 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
             cb.query_keccak_rlc(),
         );
 
-        let msg_hash = array_init(|_| cb.query_byte());
-        let sig_r = array_init(|_| cb.query_byte());
-        let sig_s = array_init(|_| cb.query_byte());
+        let msg_hash_raw = cb.query_word_rlc();
+        let msg_hash = cb.query_word_rlc();
+        let fq_modulus = cb.query_word_rlc();
+        let msg_hash_mod = ModGadget::construct(cb, [&msg_hash_raw, &fq_modulus, &msg_hash]);
+
+        let sig_r = cb.query_word_rlc();
+        let sig_r_canonical = LtWordGadget::construct(cb, &sig_r, &fq_modulus);
+        let sig_s = cb.query_word_rlc();
+        let sig_s_canonical = LtWordGadget::construct(cb, &sig_s, &fq_modulus);
+        let r_s_canonical = and::expr([sig_r_canonical.expr(), sig_s_canonical.expr()]);
 
         cb.require_equal(
             "msg hash cells assigned incorrectly",
             msg_hash_keccak_rlc.expr(),
-            cb.keccak_rlc(msg_hash.clone().map(|x| x.expr())),
+            cb.keccak_rlc::<N_BYTES_WORD>(
+                msg_hash_raw
+                    .cells
+                    .iter()
+                    .map(Expr::expr)
+                    .collect::<Vec<Expression<F>>>()
+                    .try_into()
+                    .expect("msg hash is 32 bytes"),
+            ),
         );
         cb.require_equal(
             "sig_r cells assigned incorrectly",
             sig_r_keccak_rlc.expr(),
-            cb.keccak_rlc(sig_r.clone().map(|x| x.expr())),
+            cb.keccak_rlc::<N_BYTES_WORD>(
+                sig_r
+                    .cells
+                    .iter()
+                    .map(Expr::expr)
+                    .collect::<Vec<Expression<F>>>()
+                    .try_into()
+                    .expect("msg hash is 32 bytes"),
+            ),
         );
         cb.require_equal(
             "sig_s cells assigned incorrectly",
             sig_s_keccak_rlc.expr(),
-            cb.keccak_rlc(sig_s.clone().map(|x| x.expr())),
+            cb.keccak_rlc::<N_BYTES_WORD>(
+                sig_s
+                    .cells
+                    .iter()
+                    .map(Expr::expr)
+                    .collect::<Vec<Expression<F>>>()
+                    .try_into()
+                    .expect("msg hash is 32 bytes"),
+            ),
+        );
+        cb.require_equal(
+            "Secp256k1::Fq modulus assigned correctly",
+            fq_modulus.expr(),
+            cb.word_rlc::<N_BYTES_WORD>(FQ_MODULUS.to_le_bytes().map(|b| b.expr())),
         );
 
         let [is_success, callee_address, caller_id, call_data_offset, call_data_length, return_data_offset, return_data_length] =
@@ -104,20 +154,35 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
             cb.curr.state.gas_left.expr(),
         );
 
-        // lookup to the sign_verify table
-        // || v | r | s | msg_hash | recovered_addr ||
-        cb.sig_table_lookup(
-            cb.word_rlc(msg_hash.clone().map(|x| x.expr())),
-            sig_v_keccak_rlc.expr() - 27.expr(),
-            cb.word_rlc(sig_r.clone().map(|x| x.expr())),
-            cb.word_rlc(sig_s.clone().map(|x| x.expr())),
-            select::expr(
+        // lookup to the sign_verify table:
+        //
+        // || msg_hash | v | r | s | recovered_addr | recovered ||
+        cb.condition(r_s_canonical.expr(), |cb| {
+            cb.sig_table_lookup(
+                msg_hash.expr(),
+                sig_v_keccak_rlc.expr() - 27.expr(),
+                sig_r.expr(),
+                sig_s.expr(),
+                select::expr(
+                    recovered.expr(),
+                    from_bytes::expr(&recovered_addr_keccak_rlc.cells),
+                    0.expr(),
+                ),
                 recovered.expr(),
-                from_bytes::expr(&recovered_addr_keccak_rlc.cells),
-                0.expr(),
-            ),
-            recovered.expr(),
-        );
+            );
+        });
+        cb.condition(not::expr(r_s_canonical.expr()), |cb| {
+            cb.require_zero(
+                "recovered == false if r or s not canonical",
+                recovered.expr(),
+            );
+        });
+        cb.condition(not::expr(recovered.expr()), |cb| {
+            cb.require_zero(
+                "address == 0 if address could not be recovered",
+                recovered_addr_keccak_rlc.expr(),
+            );
+        });
 
         cb.precompile_info_lookup(
             cb.execution_state().as_u64().expr(),
@@ -144,9 +209,15 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
             sig_s_keccak_rlc,
             recovered_addr_keccak_rlc,
 
+            msg_hash_raw,
             msg_hash,
+            fq_modulus,
+            msg_hash_mod,
+
             sig_r,
+            sig_r_canonical,
             sig_s,
+            sig_s_canonical,
 
             is_success,
             callee_address,
@@ -204,15 +275,30 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
                     .keccak_input()
                     .map(|r| rlc::value(&aux_data.sig_s.to_le_bytes(), r)),
             )?;
-            for (cells, value) in [
-                (&self.msg_hash, aux_data.msg_hash),
+            for (word_rlc, value) in [
+                (&self.msg_hash_raw, aux_data.msg_hash),
                 (&self.sig_r, aux_data.sig_r),
                 (&self.sig_s, aux_data.sig_s),
             ] {
-                for (cell, &byte_value) in cells.iter().zip_eq(value.to_le_bytes().iter()) {
-                    cell.assign(region, offset, Value::known(F::from(byte_value as u64)))?;
-                }
+                word_rlc.assign(region, offset, Some(value.to_le_bytes()))?;
             }
+            let (quotient, remainder) = aux_data.msg_hash.div_mod(*FQ_MODULUS);
+            self.msg_hash
+                .assign(region, offset, Some(remainder.to_le_bytes()))?;
+            self.fq_modulus
+                .assign(region, offset, Some(FQ_MODULUS.to_le_bytes()))?;
+            self.msg_hash_mod.assign(
+                region,
+                offset,
+                aux_data.msg_hash,
+                *FQ_MODULUS,
+                remainder,
+                quotient,
+            )?;
+            self.sig_r_canonical
+                .assign(region, offset, aux_data.sig_r, *FQ_MODULUS)?;
+            self.sig_s_canonical
+                .assign(region, offset, aux_data.sig_s, *FQ_MODULUS)?;
             self.recovered_addr_keccak_rlc.assign(
                 region,
                 offset,
@@ -281,37 +367,7 @@ mod test {
         static ref TEST_VECTOR: Vec<PrecompileCallArgs> = {
             vec![
                 PrecompileCallArgs {
-                    name: "ecrecover (invalid sig, addr not recovered)",
-                    setup_code: bytecode! {
-                        // msg hash from 0x00
-                        PUSH32(word!("0x456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3"))
-                        PUSH1(0x00)
-                        MSTORE
-                        // signature v from 0x20
-                        PUSH1(28)
-                        PUSH1(0x20)
-                        MSTORE
-                        // signature r from 0x40
-                        PUSH32(word!("0x9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608"))
-                        PUSH1(0x40)
-                        MSTORE
-                        // signature s from 0x60
-                        PUSH32(word!("0x4f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada"))
-                        PUSH1(0x60)
-                        MSTORE
-                    },
-                    // copy 96 bytes from memory addr 0. This is insufficient to recover an
-                    // address, and so the return data length from the precompile call will be 0.
-                    call_data_offset: 0x00.into(),
-                    call_data_length: 0x60.into(),
-                    // return 32 bytes and write from memory addr 128
-                    ret_offset: 0x80.into(),
-                    ret_size: 0x20.into(),
-                    address: PrecompileCalls::Ecrecover.address().to_word(),
-                    ..Default::default()
-                },
-                PrecompileCallArgs {
-                    name: "ecrecover (invalid sig, addr recovered)",
+                    name: "ecrecover (padded bytes, addr recovered)",
                     setup_code: bytecode! {
                         // msg hash from 0x00
                         PUSH32(word!("0x456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3"))
@@ -396,6 +452,87 @@ mod test {
                     call_data_offset: 0x00.into(),
                     call_data_length: 0x85.into(),
                     // return 32 bytes and write from memory addr 128
+                    ret_offset: 0x80.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Ecrecover.address().to_word(),
+                    ..Default::default()
+                },
+                PrecompileCallArgs {
+                    name: "ecrecover (overflowing msg_hash)",
+                    setup_code: bytecode! {
+                        // msg hash from 0x00
+                        PUSH32(word!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffee"))
+                        PUSH1(0x00)
+                        MSTORE
+                        // signature v from 0x20
+                        PUSH1(28)
+                        PUSH1(0x20)
+                        MSTORE
+                        // signature r from 0x40
+                        PUSH32(word!("0x9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608"))
+                        PUSH1(0x40)
+                        MSTORE
+                        // signature s from 0x60
+                        PUSH32(word!("0x4f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada"))
+                        PUSH1(0x60)
+                        MSTORE
+                    },
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x80.into(),
+                    ret_offset: 0x80.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Ecrecover.address().to_word(),
+                    ..Default::default()
+                },
+                PrecompileCallArgs {
+                    name: "ecrecover (overflowing sig_r)",
+                    setup_code: bytecode! {
+                        // msg hash from 0x00
+                        PUSH32(word!("0x456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3"))
+                        PUSH1(0x00)
+                        MSTORE
+                        // signature v from 0x20
+                        PUSH1(28)
+                        PUSH1(0x20)
+                        MSTORE
+                        // signature r from 0x40
+                        PUSH32(word!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffee"))
+                        PUSH1(0x40)
+                        MSTORE
+                        // signature s from 0x60
+                        PUSH32(word!("0x4f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada"))
+                        PUSH1(0x60)
+                        MSTORE
+                    },
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x80.into(),
+                    ret_offset: 0x80.into(),
+                    ret_size: 0x20.into(),
+                    address: PrecompileCalls::Ecrecover.address().to_word(),
+                    ..Default::default()
+                },
+                PrecompileCallArgs {
+                    name: "ecrecover (overflowing sig_s)",
+                    setup_code: bytecode! {
+                        // msg hash from 0x00
+                        PUSH32(word!("0x456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3"))
+                        PUSH1(0x00)
+                        MSTORE
+                        // signature v from 0x20
+                        PUSH1(28)
+                        PUSH1(0x20)
+                        MSTORE
+                        // signature r from 0x40
+                        PUSH32(word!("0x9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608"))
+                        PUSH1(0x40)
+                        MSTORE
+                        // signature s from 0x60
+                        PUSH32(word!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffee"))
+                        PUSH1(0x60)
+                        MSTORE
+                    },
+                    call_data_offset: 0x00.into(),
+                    call_data_length: 0x80.into(),
                     ret_offset: 0x80.into(),
                     ret_size: 0x20.into(),
                     address: PrecompileCalls::Ecrecover.address().to_word(),

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -312,6 +312,7 @@ pub(crate) enum Lookup<F> {
         sig_r_rlc: Expression<F>,
         sig_s_rlc: Expression<F>,
         recovered_addr: Expression<F>,
+        is_valid: Expression<F>,
     },
     ModExpTable {
         base_limbs: [Expression<F>; 3],
@@ -481,6 +482,7 @@ impl<F: Field> Lookup<F> {
                 sig_r_rlc,
                 sig_s_rlc,
                 recovered_addr,
+                is_valid,
             } => vec![
                 1.expr(), // q_enable
                 msg_hash_rlc.clone(),
@@ -488,6 +490,7 @@ impl<F: Field> Lookup<F> {
                 sig_r_rlc.clone(),
                 sig_s_rlc.clone(),
                 recovered_addr.clone(),
+                is_valid.clone(),
             ],
             Self::ModExpTable {
                 base_limbs,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1379,6 +1379,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         sig_r_rlc: Expression<F>,
         sig_s_rlc: Expression<F>,
         recovered_addr: Expression<F>,
+        is_valid: Expression<F>,
     ) {
         self.add_lookup(
             "sig table",
@@ -1388,6 +1389,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 sig_r_rlc: sig_r_rlc.expr(),
                 sig_s_rlc: sig_s_rlc.expr(),
                 recovered_addr: recovered_addr.expr(),
+                is_valid: is_valid.expr(),
             },
         );
     }

--- a/zkevm-circuits/src/sig_circuit/ecdsa.rs
+++ b/zkevm-circuits/src/sig_circuit/ecdsa.rs
@@ -3,7 +3,7 @@
 
 use halo2_base::{
     gates::{GateInstructions, RangeInstructions},
-    utils::{modulus, CurveAffineExt},
+    utils::{fe_to_biguint, modulus, CurveAffineExt},
     AssignedValue, Context,
     QuantumCell::Existing,
 };
@@ -31,7 +31,12 @@ pub(crate) fn ecdsa_verify_no_pubkey_check<F: PrimeField, CF: PrimeField, SF: Pr
     msghash: &CRTInteger<F>,
     var_window_bits: usize,
     fixed_window_bits: usize,
-) -> (AssignedValue<F>, CRTInteger<F>)
+) -> (
+    AssignedValue<F>,
+    AssignedValue<F>,
+    CRTInteger<F>,
+    AssignedValue<F>,
+)
 where
     GA: CurveAffineExt<Base = CF, ScalarExt = SF>,
 {
@@ -46,7 +51,7 @@ where
 
     // check whether the pubkey is (0, 0), i.e. in the case of ecrecover, no pubkey could be
     // recovered.
-    let is_pubkey_not_zero = {
+    let (is_pubkey_zero, is_pubkey_not_zero) = {
         let is_pubkey_x_zero = ecc_chip.field_chip().is_zero(ctx, &pubkey.x);
         let is_pubkey_y_zero = ecc_chip.field_chip().is_zero(ctx, &pubkey.y);
         let is_pubkey_zero = ecc_chip.field_chip().range().gate().and(
@@ -54,24 +59,48 @@ where
             Existing(is_pubkey_x_zero),
             Existing(is_pubkey_y_zero),
         );
-        ecc_chip
-            .field_chip()
-            .range()
-            .gate()
-            .not(ctx, Existing(is_pubkey_zero))
+        (
+            is_pubkey_zero,
+            ecc_chip
+                .field_chip()
+                .range()
+                .gate()
+                .not(ctx, Existing(is_pubkey_zero)),
+        )
     };
 
     // check r,s are in [1, n - 1]
-    let r_valid = scalar_chip.is_soft_nonzero(ctx, r);
-    let s_valid = scalar_chip.is_soft_nonzero(ctx, s);
+    let r_is_zero = scalar_chip.is_soft_zero(ctx, r);
+    let r_in_range = scalar_chip.is_soft_nonzero(ctx, r);
+    let r_is_valid = base_chip
+        .range()
+        .gate()
+        .or(ctx, Existing(r_is_zero), Existing(r_in_range));
+    let s_is_zero = scalar_chip.is_soft_zero(ctx, s);
+    let s_in_range = scalar_chip.is_soft_nonzero(ctx, s);
+    let s_is_valid = base_chip
+        .range()
+        .gate()
+        .or(ctx, Existing(s_is_zero), Existing(s_in_range));
 
-    // compute u1 = m s^{-1} mod n and u2 = r s^{-1} mod n
-    let u1 = scalar_chip.divide(ctx, msghash, s);
-    let u2 = scalar_chip.divide(ctx, r, s);
-    let u1_is_one = scalar_field_element_is_one(&scalar_chip, ctx, &u1);
-
-    let neg_one = scalar_chip.load_constant(ctx, FpConfig::<F, SF>::fe_to_constant(-SF::one()));
+    // load required constants
+    let zero = scalar_chip.load_constant(ctx, FpConfig::<F, SF>::fe_to_constant(SF::zero()));
     let one = scalar_chip.load_constant(ctx, FpConfig::<F, SF>::fe_to_constant(SF::one()));
+    let neg_one = scalar_chip.load_constant(ctx, FpConfig::<F, SF>::fe_to_constant(-SF::one()));
+
+    // compute u1 = m * s^{-1} mod n
+    let s2 = scalar_chip.select(ctx, &one, s, &s_is_zero);
+    let u1 = scalar_chip.divide(ctx, msghash, &s2);
+    let u1 = scalar_chip.select(ctx, &zero, &u1, &s_is_zero);
+    let u1_is_one = {
+        let diff = scalar_chip.sub_no_carry(ctx, &u1, &one);
+        let diff = scalar_chip.carry_mod(ctx, &diff);
+        scalar_chip.is_zero(ctx, &diff)
+    };
+
+    // compute u2 = r * s^{-1} mod n
+    let u2 = scalar_chip.divide(ctx, r, &s2);
+    let u2 = scalar_chip.select(ctx, &zero, &u2, &s_is_zero);
 
     // u3 = 1 if u1 == 1
     // u3 = -1 if u1 != 1
@@ -91,14 +120,31 @@ where
         fixed_window_bits,
     );
     // compute u2 * pubkey
+    let u2_prime = scalar_chip.select(ctx, &one, &u2, &s_is_zero);
+    let pubkey_prime = ecc_chip.load_random_point::<GA>(ctx);
+    let pubkey_prime = ecc_chip.select(ctx, &pubkey_prime, pubkey, &is_pubkey_zero);
     let u2_mul = scalar_multiply::<F, _>(
         base_chip,
         ctx,
-        pubkey,
-        &u2.truncation.limbs,
+        &pubkey_prime,
+        &u2_prime.truncation.limbs,
         base_chip.limb_bits,
         var_window_bits,
     );
+    let point_at_infinity = EcPoint::construct(
+        ecc_chip
+            .field_chip()
+            .load_constant(ctx, fe_to_biguint(&CF::zero())),
+        ecc_chip
+            .field_chip()
+            .load_constant(ctx, fe_to_biguint(&CF::zero())),
+    );
+    let u2_is_zero =
+        base_chip
+            .range()
+            .gate()
+            .or(ctx, Existing(s_is_zero), Existing(is_pubkey_zero));
+    let u2_mul = ecc_chip.select(ctx, &point_at_infinity, &u2_mul, &u2_is_zero);
     // compute u3*G this is directly assigned for G so no scalar_multiply is required
     let u3_mul = {
         let generator = GA::generator();
@@ -125,14 +171,16 @@ where
     // WARNING: For optimization reasons, does not reduce x1 mod n, which is
     //          invalid unless p is very close to n in size.
     //
-    // WARNING: this may be trigger errors if
-    //  u1u3_mul == u2_mul
+    // WARNING: this may be trigger errors if:
+    // - u1u3_mul == u2_mul
+    //
     // if r is sampled truly from random then this will not happen
     // to completely ensure the correctness we may need to sample u3 from random, but it is quite
     // costly.
     let sum = ec_add_unequal(base_chip, ctx, &u1u3_mul, &u2_mul, false);
-    // safe: we have already checked u1G + u2 pk != 0
-    // so u1G + u3G + u2pk != u3G
+
+    // safe: we have already checked u1.G + u2.pk != 0
+    // so u1.G + u3.G + u2.pk != u3.G
     let sum = ec_sub_unequal(base_chip, ctx, &sum, &u3_mul, false);
     let equal_check = base_chip.is_equal(ctx, &sum.x, r);
 
@@ -154,12 +202,17 @@ where
         base_chip.limb_bases[1],
     );
 
-    // check (r in [1, n - 1]) and (s in [1, n - 1]) and (u1_mul != - u2_mul) and (r == x1 mod n)
+    // check
+    // - (r in [0, n - 1])
+    // - (s in [0, n - 1])
+    // - (u1_mul != - u2_mul)
+    // - (r == x1 mod n)
+    // - pk != (0, 0)
     let res = base_chip.range().gate().and_many(
         ctx,
         vec![
-            Existing(r_valid),
-            Existing(s_valid),
+            Existing(r_is_valid),
+            Existing(s_is_valid),
             Existing(u1_small),
             Existing(u2_small),
             Existing(u1_u2_not_eq),
@@ -167,16 +220,7 @@ where
             Existing(is_pubkey_not_zero),
         ],
     );
-    (res, sum.y)
-}
 
-fn scalar_field_element_is_one<F: PrimeField, SF: PrimeField>(
-    scalar_chip: &FpConfig<F, SF>,
-    ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-) -> AssignedValue<F> {
-    let one = scalar_chip.load_constant(ctx, FpConfig::<F, SF>::fe_to_constant(SF::one()));
-    let diff = scalar_chip.sub_no_carry(ctx, a, &one);
-    let diff = scalar_chip.carry_mod(ctx, &diff);
-    scalar_chip.is_zero(ctx, &diff)
+    let y_is_zero = scalar_chip.is_soft_zero(ctx, &sum.y);
+    (res, is_pubkey_zero, sum.y, y_is_zero)
 }

--- a/zkevm-circuits/src/sig_circuit/test.rs
+++ b/zkevm-circuits/src/sig_circuit/test.rs
@@ -103,14 +103,7 @@ fn test_edge_cases() {
             good_ecrecover_data.2,
             1 - good_ecrecover_data.3,
         ),
-        // 8. v invalid (not boolean)
-        (
-            good_ecrecover_data.0,
-            good_ecrecover_data.1,
-            good_ecrecover_data.2,
-            123u8,
-        ),
-        // 9. msg_hash outside FQ::MODULUS
+        // 8. msg_hash outside FQ::MODULUS
         (
             Word::MAX,
             good_ecrecover_data.1,
@@ -136,7 +129,7 @@ fn test_edge_cases() {
     log::debug!("signatures=");
     log::debug!("{:#?}", signatures);
 
-    run::<Fr>(LOG_TOTAL_NUM_ROWS as u32, 9, signatures);
+    run::<Fr>(LOG_TOTAL_NUM_ROWS as u32, 8, signatures);
 }
 
 #[test]

--- a/zkevm-circuits/src/sig_circuit/utils.rs
+++ b/zkevm-circuits/src/sig_circuit/utils.rs
@@ -67,6 +67,7 @@ pub(super) type FpChip<F> = FpConfig<F, Fp>;
 
 pub(crate) struct AssignedECDSA<F: Field, FC: FieldChip<F>> {
     pub(super) pk: EcPoint<F, FC::FieldPoint>,
+    pub(super) pk_is_zero: AssignedValue<F>,
     pub(super) msg_hash: CRTInteger<F>,
     pub(super) integer_r: CRTInteger<F>,
     pub(super) integer_s: CRTInteger<F>,

--- a/zkevm-circuits/src/sig_circuit/utils.rs
+++ b/zkevm-circuits/src/sig_circuit/utils.rs
@@ -96,10 +96,3 @@ pub(super) struct SignDataDecomposed<F: Field> {
     pub(super) s_cells: Vec<QuantumCell<F>>,
     //v:  AssignedValue<'v, F>, // bool
 }
-
-// FIXME: is this correct? not used anywhere?
-pub(crate) fn pub_key_hash_to_address<F: Field>(pk_hash: &[u8]) -> F {
-    pk_hash[32 - 20..]
-        .iter()
-        .fold(F::zero(), |acc, b| acc * F::from(256) + F::from(*b as u64))
-}

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -2209,7 +2209,6 @@ pub struct SigTable {
     /// Random-linear combination of the Keccak256 hash of the message that's signed.
     pub msg_hash_rlc: Column<Advice>,
     /// should be in range [0, 1]
-    /// TODO: we need to constrain v <=> pub.y oddness
     pub sig_v: Column<Advice>,
     /// Random-linear combination of the signature's `r` component.
     pub sig_r_rlc: Column<Advice>,
@@ -2323,20 +2322,6 @@ impl<F: Field> LookupTable<F> for SigTable {
             String::from("sig_s_rlc"),
             String::from("recovered_addr"),
             String::from("is_valid"),
-        ]
-    }
-
-    fn table_exprs(&self, meta: &mut VirtualCells<F>) -> Vec<Expression<F>> {
-        vec![
-            // ignore the is_valid field as the EVM circuit's use-case (Ecrecover precompile) does
-            // not care whether the signature is valid or not. It only cares about the recovered
-            // address.
-            meta.query_fixed(self.q_enable, Rotation::cur()),
-            meta.query_advice(self.msg_hash_rlc, Rotation::cur()),
-            meta.query_advice(self.sig_v, Rotation::cur()),
-            meta.query_advice(self.sig_r_rlc, Rotation::cur()),
-            meta.query_advice(self.sig_s_rlc, Rotation::cur()),
-            meta.query_advice(self.recovered_addr, Rotation::cur()),
         ]
     }
 }

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -2268,7 +2268,6 @@ impl SigTable {
                     });
                     let sig_v = Value::known(F::from(sign_data.signature.2 as u64));
                     let recovered_addr = Value::known(sign_data.get_addr().to_scalar().unwrap());
-
                     region.assign_fixed(
                         || format!("sig table q_enable {offset}"),
                         self.q_enable,
@@ -2281,7 +2280,11 @@ impl SigTable {
                         ("sig_r_rlc", self.sig_r_rlc, sig_r_rlc),
                         ("sig_s_rlc", self.sig_s_rlc, sig_s_rlc),
                         ("recovered_addr", self.recovered_addr, recovered_addr),
-                        ("is_valid", self.is_valid, Value::known(F::one())),
+                        (
+                            "is_valid",
+                            self.is_valid,
+                            Value::known(F::from(!sign_data.get_addr().is_zero())),
+                        ),
                     ] {
                         region.assign_advice(
                             || format!("sig table {column_name} {offset}"),


### PR DESCRIPTION
### Description

Ecrecover "address not recovered" case to be supported by `SigCircuit`.

##### Key Changes
- SigCircuit processes all ecrecover inputs except:
    - `sig_r` overflowing (not canonical)
    - `sig_s` overflowing (not canonical)
    - `sig_v` is invalid, i.e. `sig_v != 27 && sig_v != 28`
    - The 2 above cases are handled directly in EVM circuit by the ecrecover gadget
- We add more tests for SigCircuit to check panic issues because of these edge cases
    - msg_hash == 0
    - sig_r == 0
    - sig_s == 0
    - address could not be recovered
- EVM Circuit's ecrecover gadget does a lookup to SigTable in all cases except:
    - `sig_r` overflowing (not canonical)
    - `sig_s` overflowing (not canonical)
    - `sig_v` is invalid, i.e. `sig_v != 27 && sig_v != 28`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update