### PR TITLE
Bug fix: fixed part of tx table must have is_calldata = false

### DIFF
--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -436,6 +436,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
 
             cb.gate(and::expr([
                 meta.query_fixed(q_enable, Rotation::cur()),
+                // not::expr(meta.query_advice(is_calldata, Rotation::cur())),
                 not::expr(meta.query_advice(is_calldata, Rotation::next())),
             ]))
         });

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -436,7 +436,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
 
             cb.gate(and::expr([
                 meta.query_fixed(q_enable, Rotation::cur()),
-                // not::expr(meta.query_advice(is_calldata, Rotation::cur())),
+                not::expr(meta.query_advice(is_calldata, Rotation::cur())),
                 not::expr(meta.query_advice(is_calldata, Rotation::next())),
             ]))
         });


### PR DESCRIPTION
### Description

The original condition for testing if a row belongs to the fixed part of tx table is not enough:

1. `cur.q_enable = 1`;
2. `next.is_calldata = false`;

It's easy to see that the last row of calldata part also meet these two conditions.

Therefore we propose to add one more condition:

3. `cur.is_calldata = false`;

### Issue Link

#850 CI failed for `serial_test_super_circuit_precompile_oog`. In that test case, the calldata part of tx table is full. The last row of calldata part is not for padding (tx_id != 0).

https://github.com/scroll-tech/zkevm-circuits/actions/runs/6153673927/job/16697923976

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update