### PR TITLE
Fix: first 12 rows are dummy (not 300)

### DIFF
--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -1039,7 +1039,7 @@ impl<F: Field> SubCircuit<F> for KeccakCircuit<F> {
                 .iter()
                 .map(|bytes| (bytes.len() as f64 / 136.0).ceil() as usize * rows_per_chunk)
                 .sum::<usize>()
-                + rows_per_chunk, // reserved for first dummy chunk
+                + 12, // reserved for first 12 dummy rows
             max(
                 block.circuits_params.max_keccak_rows,
                 *(aux_tables_rows.iter().max().unwrap()),

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -1039,7 +1039,7 @@ impl<F: Field> SubCircuit<F> for KeccakCircuit<F> {
                 .iter()
                 .map(|bytes| (bytes.len() as f64 / 136.0).ceil() as usize * rows_per_chunk)
                 .sum::<usize>()
-                + 12, // reserved for first 12 dummy rows
+                + get_num_rows_per_round(), // reserved for first 12 dummy rows
             max(
                 block.circuits_params.max_keccak_rows,
                 *(aux_tables_rows.iter().max().unwrap()),


### PR DESCRIPTION
### Description

The first 12 rows are dummy rows!.

### Issue Link

https://github.com/scroll-tech/zkevm-circuits/pull/940 was not right.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update