### PR TITLE
fix(prover): delete `StorageTrace` from `ChunkProof`

### DIFF
--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -12,7 +12,7 @@ pub mod utils;
 pub mod zkevm;
 
 pub use common::{ChunkHash, CompressionCircuit};
-pub use eth_types::l2_types::{BlockTrace, StorageTrace};
+pub use eth_types::l2_types::BlockTrace;
 pub use proof::{BatchProof, ChunkProof, EvmProof, Proof};
 pub use snark_verifier_sdk::{CircuitExt, Snark};
 pub use types::WitnessBlock;

--- a/prover/src/proof/chunk.rs
+++ b/prover/src/proof/chunk.rs
@@ -2,7 +2,6 @@ use super::{dump_as_json, dump_data, dump_vk, from_json_file, Proof};
 use crate::types::base64;
 use aggregator::ChunkHash;
 use anyhow::Result;
-use eth_types::l2_types::StorageTrace;
 use halo2_proofs::{halo2curves::bn256::G1Affine, plonk::ProvingKey};
 use serde_derive::{Deserialize, Serialize};
 use snark_verifier::Protocol;
@@ -10,8 +9,6 @@ use snark_verifier_sdk::Snark;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ChunkProof {
-    #[serde(with = "base64")]
-    pub storage_trace: Vec<u8>,
     #[serde(with = "base64")]
     pub protocol: Vec<u8>,
     #[serde(flatten)]
@@ -23,16 +20,13 @@ pub struct ChunkProof {
 impl ChunkProof {
     pub fn new(
         snark: Snark,
-        storage_trace: StorageTrace,
         pk: Option<&ProvingKey<G1Affine>>,
         chunk_hash: Option<ChunkHash>,
     ) -> Result<Self> {
-        let storage_trace = serde_json::to_vec(&storage_trace)?;
         let protocol = serde_json::to_vec(&snark.protocol)?;
         let proof = Proof::new(snark.proof, &snark.instances, pk);
 
         Ok(Self {
-            storage_trace,
             protocol,
             proof,
             chunk_hash,

--- a/prover/src/zkevm/circuit.rs
+++ b/prover/src/zkevm/circuit.rs
@@ -15,7 +15,7 @@ mod super_circuit;
 pub use self::builder::{
     block_traces_to_witness_block, block_traces_to_witness_block_with_updated_state,
     calculate_row_usage_of_trace, calculate_row_usage_of_witness_block, check_batch_capacity,
-    get_super_circuit_params, normalize_withdraw_proof, validite_block_traces,
+    get_super_circuit_params, validite_block_traces,
 };
 pub use super_circuit::SuperCircuit;
 

--- a/prover/src/zkevm/circuit/l1_builder.rs
+++ b/prover/src/zkevm/circuit/l1_builder.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use bus_mapping::circuit_input_builder::{CircuitInputBuilder, CircuitsParams};
-use eth_types::l2_types::{BlockTrace, StorageTrace};
+use eth_types::l2_types::BlockTrace;
 use halo2_proofs::halo2curves::bn256::Fr;
-use zkevm_circuits::{evm_circuit::witness::Block, witness::WithdrawProof};
+use zkevm_circuits::evm_circuit::witness::Block;
 
 pub fn get_super_circuit_params() -> CircuitsParams {
     unimplemented!("Must build with feature scroll")
@@ -37,9 +37,5 @@ pub fn block_traces_to_witness_block_with_updated_state(
     _builder: &mut CircuitInputBuilder,
     _light_mode: bool,
 ) -> Result<Block<Fr>> {
-    unimplemented!("Must build with feature scroll")
-}
-
-pub fn normalize_withdraw_proof(_proof: &WithdrawProof) -> StorageTrace {
     unimplemented!("Must build with feature scroll")
 }

--- a/prover/src/zkevm/prover.rs
+++ b/prover/src/zkevm/prover.rs
@@ -4,7 +4,6 @@ use crate::{
     consts::CHUNK_VK_FILENAME,
     io::try_to_read,
     utils::chunk_trace_to_witness_block,
-    zkevm::circuit::normalize_withdraw_proof,
     ChunkProof,
 };
 use aggregator::ChunkHash;
@@ -79,15 +78,8 @@ impl Prover {
             None => {
                 let chunk_hash = ChunkHash::from_witness_block(&witness_block, false);
 
-                let storage_trace =
-                    normalize_withdraw_proof(&witness_block.mpt_updates.withdraw_proof);
-
-                let result = ChunkProof::new(
-                    snark,
-                    storage_trace,
-                    self.inner.pk(LayerId::Layer2.id()),
-                    Some(chunk_hash),
-                );
+                let result =
+                    ChunkProof::new(snark, self.inner.pk(LayerId::Layer2.id()), Some(chunk_hash));
 
                 if let (Some(output_dir), Ok(proof)) = (output_dir, &result) {
                     proof.dump(output_dir, &name)?;


### PR DESCRIPTION
### Description

`StorageTrace` was used to generate padding chunks before, but we use different method to generate for now.

Related scroll PR https://github.com/scroll-tech/scroll/pull/953

