### PR TITLE
DON'T MERGE: check block.rwc equals block.rws.len

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -493,6 +493,8 @@ impl<'a> CircuitInputBuilder {
             ),
         )?;
 
+        assert_eq!(state.block_ctx.rwc.0 - 1, state.block.container.size());
+
         let mut push_op = |step: &mut ExecStep, rwc: RWCounter, rw: RW, op: StartOp| {
             let op_ref = state.block.container.insert(Operation::new(rwc, rw, op));
             step.bus_mapping_instance.push(op_ref);

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -82,6 +82,19 @@ impl OperationContainer {
         self.insert_op_enum(rwc, rw, reversible, op.op.into_enum())
     }
 
+    pub(crate) fn size(&self) -> usize {
+        self.memory.len()
+            + self.stack.len()
+            + self.storage.len()
+            + self.tx_access_list_account.len()
+            + self.tx_access_list_account_storage.len()
+            + self.tx_refund.len()
+            + self.account.len()
+            + self.call_context.len()
+            + self.tx_receipt.len()
+            + self.tx_log.len()
+    }
+
     /// Inserts an [`OpEnum`] into the  container returning a lightweight
     /// reference to it in the form of an [`OperationRef`] which points to the
     /// location of the inserted operation inside the corresponding container


### PR DESCRIPTION
### Description

Check the `total_rws = cb.curr.state.rw_counter - 1` at `EndBlock` matches to block's `RWs.len()`.