### PR TITLE
add sanity check to make sure ComparatorChip only use cur() in RLP

### DIFF
--- a/gadgets/src/comparator.rs
+++ b/gadgets/src/comparator.rs
@@ -42,6 +42,9 @@ impl<F: Field, const N_BYTES: usize> ComparatorConfig<F, N_BYTES> {
         meta: &mut VirtualCells<F>,
         rotation: Option<Rotation>,
     ) -> (Expression<F>, Expression<F>) {
+        let rotation_is_cur = rotation.map_or(true, |r| r == Rotation::cur());
+        assert!(rotation_is_cur);
+
         (
             self.lt_chip.config.is_lt(meta, rotation),
             self.eq_chip.config.is_equal_expression.clone(),


### PR DESCRIPTION
### Description

Add sanity check.

### Issue Link

Check the finding 12 in [Zellic / Kalos Audit Report](https://hackmd.io/4XuxkwHERa6AIPQ6tr2QAg#Finding-12-Common-Gadgets-%E2%80%9CImportance%E2%80%9D-High)

