### PR TITLE
optim-invert: cache the inversion of step height

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/is_zero.rs
@@ -49,13 +49,14 @@ impl<F: Field> IsZeroGadget<F> {
         offset: usize,
         value: F,
     ) -> Result<F, Error> {
-        let inverse = value.invert().unwrap_or(F::zero());
-        self.inverse.assign(region, offset, Value::known(inverse))?;
-        Ok(if value.is_zero().into() {
-            F::one()
-        } else {
+        let is_zero = value.is_zero_vartime();
+        let inverse = if is_zero {
             F::zero()
-        })
+        } else {
+            value.invert().unwrap()
+        };
+        self.inverse.assign(region, offset, Value::known(inverse))?;
+        Ok(F::from(is_zero))
     }
 
     pub(crate) fn assign_value(


### PR DESCRIPTION
This PR replaces a million field inversions by … one. Field inversions are costly (~400 multiplications). 

The EVM circuit assignment does a field inversion per row for the "step height" logic. This is a small set of values which can be precomputed. This PR does it in the form of a preloaded cache.

There is the same issue with the IsZeroGadget but it is harder to fix. This PR at least avoids the inversions of the common value 0.