### PR TITLE
fix: add `workspace.package` and `workspace.dependencies` to avoid duplicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ name = "bus-mapping"
 version = "0.1.0"
 dependencies = [
  "ctor",
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "eth-types",
  "ethers-core",
  "ethers-providers",
@@ -666,7 +666,7 @@ version = "0.1.0"
 dependencies = [
  "ark-std 0.3.0",
  "bus-mapping",
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "eth-types",
  "ethers",
  "ethers-signers",
@@ -1505,19 +1505,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -2275,7 +2262,7 @@ dependencies = [
 name = "geth-utils"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "gobuild 0.1.0-alpha.2 (git+https://github.com/scroll-tech/gobuild.git)",
  "log",
 ]
@@ -2875,7 +2862,7 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "bus-mapping",
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "eth-types",
  "ethers",
  "halo2_proofs",
@@ -2992,7 +2979,7 @@ dependencies = [
 name = "keccak256"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "eth-types",
  "halo2_proofs",
  "itertools",
@@ -3267,7 +3254,7 @@ dependencies = [
 name = "mpt-zktrie"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "eth-types",
  "halo2-mpt-circuits",
  "halo2_proofs",
@@ -5144,7 +5131,7 @@ dependencies = [
  "bus-mapping",
  "clap 3.2.25",
  "ctor",
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "eth-types",
  "ethers-core",
  "ethers-signers",
@@ -5948,7 +5935,7 @@ dependencies = [
  "criterion",
  "ctor",
  "either",
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "eth-types",
  "ethers-core",
  "ethers-signers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,18 @@ members = [
     "prover"
 ]
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+env_logger = "0.10"
+halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "develop" }
+itertools = "0.10"
+lazy_static = "1.4"
+log = "0.4"
+
 [patch.crates-io]
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers-etherscan = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "aggregator"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,16 +12,16 @@ zkevm-circuits = { path = "../zkevm-circuits" }
 
 
 ark-std = "0.3.0"
-env_logger = "0.10.0"
+env_logger.workspace = true
 ethers-core = { version = "2.0.7", features = ["scroll"] }
 hex = "0.4.3"
-log = "0.4"
-itertools = "0.10.3"
+log.workspace = true
+itertools.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.8"
 
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5" }
 snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
 

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "bus-mapping"
-version = "0.1.0"
-edition = "2021"
-authors = ["CPerezz <c.perezbaro@gmail.com>"]
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 eth-types = { path = "../eth-types" }
@@ -15,11 +14,11 @@ mock = { path = "../mock", optional = true }
 ethers-core = { version = "2.0.7", features = ["scroll"] }
 ethers-signers = "2.0.7"
 ethers-providers = "2.0.7"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
-itertools = "0.10"
-lazy_static = "1.4"
-log = "0.4.14"
+itertools.workspace = true
+lazy_static.workspace = true
+log.workspace = true
 num = "0.4"
 rand = { version = "0.8", optional = true }
 serde = {version = "1.0.130", features = ["derive"] }
@@ -38,7 +37,7 @@ pretty_assertions = "1.0.0"
 tokio = { version = "1.13", features = ["macros"] }
 url = "2.2.2"
 ctor = "0.1.22"
-env_logger = "0.9.0"
+env_logger.workspace = true
 mock = { path = "../mock" }
 rand = "0.8"
 

--- a/circuit-benchmarks/Cargo.toml
+++ b/circuit-benchmarks/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "circuit-benchmarks"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 ark-std = { version = "0.3" }
 zkevm-circuits = { path = "../zkevm-circuits", features = ["test"]}
 keccak256 = { path = "../keccak256" }
 bus-mapping = { path = "../bus-mapping",  features = ["test"] }
 rand_xorshift = "0.3"
 rand = "0.8"
-itertools = "0.10"
+itertools.workspace = true
 eth-types = { path = "../eth-types" }
-env_logger = "0.9"
+env_logger.workspace = true
 log="0.4"
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 ethers-signers = "2.0.7"

--- a/eth-types/Cargo.toml
+++ b/eth-types/Cargo.toml
@@ -1,23 +1,22 @@
 [package]
 name = "eth-types"
-version = "0.1.0"
-edition = "2021"
-authors = ["The appliedzkp team"]
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 ethers-core = { version = "2.0.7", features = ["scroll"] }
 ethers-signers = "2.0.7"
 hex = "0.4"
-lazy_static = "1.4"
+lazy_static.workspace = true
 once_cell = "1.17.0"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 regex = "1.5.4"
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"
 serde_with = "1.12"
 uint = "0.9.1"
-itertools = "0.10"
+itertools.workspace = true
 libsecp256k1 = "0.7"
 subtle = "2.4"
 sha3 = "0.10"

--- a/external-tracer/Cargo.toml
+++ b/external-tracer/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "external-tracer"
-version = "0.1.0"
-edition = "2021"
-authors = ["The appliedzkp team"]
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 eth-types = { path = "../eth-types" }
 geth-utils = { path = "../geth-utils" }
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"
-log = "0.4.14"
+log.workspace = true
 
 [features]
 default = []

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "gadgets"
-version = "0.1.0"
-edition = "2021"
-authors = ["The appliedzkp team"]
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 sha3 = "0.7.2"
 eth-types = { path = "../eth-types" }
 digest = "0.7.6"

--- a/geth-utils/Cargo.toml
+++ b/geth-utils/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "geth-utils"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [build-dependencies]
 gobuild = { git = "https://github.com/scroll-tech/gobuild.git" }
-log = "0.4.14"
-env_logger = "0.9"
+log.workspace = true
+env_logger.workspace = true
 
 [features]
 default = []

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "integration-tests"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4"
+lazy_static.workspace = true
 ethers = { version = "2.0.7", features = ["ethers-solc"] }
 serde_json = "1.0.66"
 serde = { version = "1.0.130", features = ["derive"] }
@@ -17,9 +17,9 @@ zkevm-circuits = { path = "../zkevm-circuits", default-features = false, feature
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 url = "2.2.2"
 pretty_assertions = "1.0.0"
-log = "0.4.14"
-env_logger = "0.9"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+log.workspace = true
+env_logger.workspace = true
+halo2_proofs.workspace = true
 hex = "0.4.3"
 strum = "0.24.1"
 rand_chacha = "0.3"

--- a/keccak256/Cargo.toml
+++ b/keccak256/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "keccak256"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [features]
 dev-graph = ["halo2_proofs/dev-graph", "plotters"]
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
-itertools = "0.10.1"
+halo2_proofs.workspace = true
+itertools.workspace = true
 num-bigint = "0.4.2"
 num-traits = "0.2.14"
 plotters = { version = "0.3.0", optional = true }
 eth-types = { path = "../eth-types" }
-lazy_static = "1.4"
-log = "0.4.14"
-env_logger = "0.9"
+lazy_static.workspace = true
+log.workspace = true
+env_logger.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,20 +1,19 @@
 [package]
 name = "mock"
-version = "0.1.0"
-edition = "2021"
-authors = ["The appliedzkp team"]
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 eth-types = { path = "../eth-types" }
 external-tracer = { path = "../external-tracer" }
-lazy_static = "1.4"
-itertools = "0.10.3"
+lazy_static.workspace = true
+itertools.workspace = true
 ethers-signers = "2.0.7"
 ethers-core = { version = "2.0.7", features = ["scroll"] }
 rand_chacha = "0.3"
 rand = "0.8"
-log = "0.4"
+log.workspace = true
 
 [features]
 default = []

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "prover"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 
 aggregator = { path = "../aggregator" }
 bus-mapping = { path = "../bus-mapping" }
@@ -23,8 +24,8 @@ dotenvy = "0.15.7"
 ethers-core = { version = "2.0.7", features = ["scroll"] }
 git-version = "0.3.5"
 hex = "0.4.3"
-itertools = "0.10.5"
-log = "0.4"
+itertools.workspace = true
+log.workspace = true
 log4rs = { version = "1.2.0", default_features = false, features = ["console_appender", "file_appender"] }
 num-bigint = "0.4.3"
 once_cell = "1.8.0"

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "testool"
 description="tools for doing tests"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1"
 bus-mapping = { path = "../bus-mapping" }
 clap = { version = "3.1", features = ["derive"] }
-env_logger = "0.9"
+env_logger.workspace = true
 eth-types = { path="../eth-types" }
 ethers-core = { version = "2.0.7", features = ["scroll"] }
 ethers-signers = "2.0.7"
@@ -17,8 +18,8 @@ glob = "0.3"
 handlebars = "4.3"
 hex = "0.4.3"
 keccak256 = { path = "../keccak256" }
-log = "0.4"
-itertools = "0.10"
+log.workspace = true
+itertools.workspace = true
 mock = { path = "../mock" }
 once_cell = "1.10"
 prettytable-rs = "0.10"
@@ -35,7 +36,7 @@ yaml-rust = "0.4.5"
 zkevm-circuits = { path="../zkevm-circuits", features=["test"] }
 rand_chacha = "0.3"
 rand = "0.8"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 urlencoding = "2.1.2"
 ctor = "0.1.22"
 

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "zkevm-circuits"
-version = "0.1.0"
-authors = ["therealyingtong <yingtong@z.cash>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 num = "0.4"
 sha3 = "0.10"
 array-init = "2.0.0"
@@ -23,12 +22,12 @@ strum = "0.24"
 strum_macros = "0.24"
 rand_xorshift = "0.3"
 rand = "0.8"
-itertools = "0.10.3"
-lazy_static = "1.4"
+itertools.workspace = true
+lazy_static.workspace = true
 mpt-zktrie = { path = "../zktrie" }
 keccak256 = { path = "../keccak256"}
-log = "0.4"
-env_logger = "0.9"
+log.workspace = true
+env_logger.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.78"
 
@@ -56,7 +55,6 @@ criterion = "0.3"
 ctor = "0.1.22"
 ethers-signers = "2.0.7"
 hex = "0.4.3"
-itertools = "0.10.1"
 mock = { path = "../mock" }
 pretty_assertions = "1.0.0"
 cli-table = "0.4"

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "mpt-zktrie"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
+halo2_proofs.workspace = true
 mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", tag = "v0.7.0" }
 zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "v0.7"}
 hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
 eth-types = { path = "../eth-types" }
-lazy_static = "1.4"
+lazy_static.workspace = true
 num-bigint = { version = "0.4" }
-log = "0.4"
+log.workspace = true
 hex = "0.4"
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger.workspace = true
 serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
### Description

Reference [rust-rfc-workspace-duplicate](https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html), [workspace-package](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-package-table) and [workspace-dependecies](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-dependencies-table), add `workspace.package` and `workspace.dependencies` to root `Cargo.toml`:
```
[workspace.package]
version = "0.1.0"
edition = "2021"
license = "MIT OR Apache-2.0"

[workspace.dependencies]
env_logger = "0.10"
halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "develop" }
log = "0.4"
...
```
So we could update `Cargo.toml` in sub-projects as:
```
[package]
name = "zkevm-circuits"
version.workspace = true
edition.workspace = true
license.workspace = true

[dependencies]
halo2_proofs.workspace = true
env_logger.workspace = true
log.workspace = true
...
```

If it's OK, suppose to move more common dependencies to `workspace.dependencies` in following PRs.