### PR TITLE
fix: move common dependencies to `workspace.dependencies`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,22 +440,12 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-dependencies = [
- "arrayref",
- "byte-tools",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -464,7 +454,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -527,12 +517,6 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "bytemuck"
@@ -807,7 +791,7 @@ dependencies = [
  "bech32",
  "bs58",
  "digest 0.10.7",
- "generic-array 0.14.7",
+ "generic-array",
  "hex",
  "ripemd",
  "serde",
@@ -1049,7 +1033,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core",
  "subtle",
  "zeroize",
@@ -1061,7 +1045,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core",
  "subtle",
  "zeroize",
@@ -1073,7 +1057,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -1083,7 +1067,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
 ]
 
@@ -1285,20 +1269,11 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-dependencies = [
- "generic-array 0.9.1",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1410,7 +1385,7 @@ dependencies = [
  "der 0.6.1",
  "digest 0.10.7",
  "ff 0.12.1",
- "generic-array 0.14.7",
+ "generic-array",
  "group 0.12.1",
  "rand_core",
  "sec1 0.3.0",
@@ -1428,7 +1403,7 @@ dependencies = [
  "crypto-bigint 0.5.3",
  "digest 0.10.7",
  "ff 0.13.0",
- "generic-array 0.14.7",
+ "generic-array",
  "group 0.13.0",
  "pkcs8",
  "rand_core",
@@ -1737,7 +1712,7 @@ dependencies = [
  "chrono",
  "elliptic-curve 0.13.5",
  "ethabi",
- "generic-array 0.14.7",
+ "generic-array",
  "hex",
  "k256 0.13.1",
  "num_enum 0.6.1",
@@ -2229,22 +2204,12 @@ dependencies = [
 name = "gadgets"
 version = "0.1.0"
 dependencies = [
- "digest 0.7.6",
  "eth-types",
  "halo2_proofs",
  "rand",
  "rand_xorshift",
- "sha3 0.7.3",
+ "sha3 0.10.8",
  "strum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d00328cedcac5e81c683e5620ca6a30756fc23027ebf9bff405c0e8da1fbb7e"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -2630,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.7",
+ "generic-array",
  "hmac 0.8.1",
 ]
 
@@ -2845,7 +2810,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -4536,7 +4501,7 @@ checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct 0.1.1",
  "der 0.6.1",
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
  "zeroize",
 ]
@@ -4549,7 +4514,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.8",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -4757,18 +4722,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64dcef59ed4290b9fb562b53df07f564690d6539e8ecdd4728cf392477530bc"
-dependencies = [
- "block-buffer 0.3.3",
- "byte-tools",
- "digest 0.7.6",
- "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,41 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+anyhow = "1.0"
+ark-std = "0.3"
+ctor = "0.1"
 env_logger = "0.10"
+ethers = { version = "2.0.7", features = ["ethers-solc"] }
+ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7", features = ["scroll"] }
+ethers-providers = "2.0.7"
+ethers-signers = "2.0.7"
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "develop" }
+hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
+hex = "0.4"
 itertools = "0.10"
 lazy_static = "1.4"
+libsecp256k1 = "0.7"
 log = "0.4"
+num = "0.4"
+num-bigint = "0.4"
+num-traits = "0.2"
+once_cell = "1.17"
+pretty_assertions = "1.0"
+rand = "0.8"
+rand_chacha = "0.3"
+rand_xorshift = "0.3"
+rayon = "1.5"
+regex = "1.5"
+serde = {version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha3 = "0.10"
+snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5" }
+snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5", default-features = false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+strum = "0.24"
+strum_macros = "0.24"
+subtle = "2.4"
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
+url = "2.2"
 
 [patch.crates-io]
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -11,19 +11,19 @@ eth-types = { path = "../eth-types" }
 zkevm-circuits = { path = "../zkevm-circuits" }
 
 
-ark-std = "0.3.0"
+ark-std.workspace = true
 env_logger.workspace = true
-ethers-core = { version = "2.0.7", features = ["scroll"] }
-hex = "0.4.3"
+ethers-core.workspace = true
+hex.workspace = true
 log.workspace = true
 itertools.workspace = true
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-rand = "0.8"
+serde.workspace = true
+serde_json.workspace = true
+rand.workspace = true
 
 halo2_proofs.workspace = true
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+snark-verifier.workspace = true
+snark-verifier-sdk.workspace = true
 
 
 [features]

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -11,35 +11,35 @@ keccak256 = { path = "../keccak256" }
 mpt-zktrie = {path = "../zktrie"}
 mock = { path = "../mock", optional = true }
 
-ethers-core = { version = "2.0.7", features = ["scroll"] }
-ethers-signers = "2.0.7"
-ethers-providers = "2.0.7"
+ethers-core.workspace = true
+ethers-signers.workspace = true
+ethers-providers.workspace = true
 halo2_proofs.workspace = true
-poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
+hash-circuit.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-num = "0.4"
-rand = { version = "0.8", optional = true }
-serde = {version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.66"
-strum = "0.24"
-hex = "0.4.3"
-strum_macros = "0.24"
+num.workspace = true
+rand = { workspace = true, optional = true }
+serde.workspace = true
+serde_json.workspace = true
+strum.workspace = true
+hex.workspace = true
+strum_macros.workspace = true
 
 # precompile related crates
 revm-precompile = { git = "https://github.com/scroll-tech/revm", branch = "scroll-fix" }
-once_cell = "1.17.0"
+once_cell.workspace = true
 
 [dev-dependencies]
-hex = "0.4.3"
-pretty_assertions = "1.0.0"
-tokio = { version = "1.13", features = ["macros"] }
-url = "2.2.2"
-ctor = "0.1.22"
+hex.workspace = true
+pretty_assertions.workspace = true
+tokio.workspace = true
+url.workspace = true
+ctor.workspace = true
 env_logger.workspace = true
 mock = { path = "../mock" }
-rand = "0.8"
+rand.workspace = true
 
 [features]
 default = ["test"]

--- a/bus-mapping/src/util.rs
+++ b/bus-mapping/src/util.rs
@@ -33,7 +33,7 @@ pub fn hash_code_keccak(code: &[u8]) -> Hash {
 
 /// Poseidon code hash
 pub fn hash_code_poseidon(code: &[u8]) -> Hash {
-    use poseidon_circuit::hash::{Hashable, MessageHashable, HASHABLE_DOMAIN_SPEC};
+    use hash_circuit::hash::{Hashable, MessageHashable, HASHABLE_DOMAIN_SPEC};
 
     let bytes_in_field = POSEIDON_HASH_BYTES_IN_FIELD;
     let fls = (0..(code.len() / bytes_in_field))

--- a/circuit-benchmarks/Cargo.toml
+++ b/circuit-benchmarks/Cargo.toml
@@ -8,22 +8,22 @@ license.workspace = true
 
 [dependencies]
 halo2_proofs.workspace = true
-ark-std = { version = "0.3" }
+ark-std.workspace = true
 zkevm-circuits = { path = "../zkevm-circuits", features = ["test"]}
 keccak256 = { path = "../keccak256" }
 bus-mapping = { path = "../bus-mapping",  features = ["test"] }
-rand_xorshift = "0.3"
-rand = "0.8"
+rand_xorshift.workspace = true
+rand.workspace = true
 itertools.workspace = true
 eth-types = { path = "../eth-types" }
 env_logger.workspace = true
-log="0.4"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
-ethers-signers = "2.0.7"
-ethers = { version = "2.0.7", features = ["ethers-solc"] }
+log.workspace = true
+tokio.workspace = true
+ethers-signers.workspace = true
+ethers.workspace = true
 mock = { path="../mock" }
-rand_chacha = "0.3"
-url="2.2.2"
+rand_chacha.workspace = true
+url.workspace = true
 
 [features]
 default = []

--- a/eth-types/Cargo.toml
+++ b/eth-types/Cargo.toml
@@ -5,26 +5,26 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-ethers-core = { version = "2.0.7", features = ["scroll"] }
-ethers-signers = "2.0.7"
-hex = "0.4"
+ethers-core.workspace = true
+ethers-signers.workspace = true
+hex.workspace = true
 lazy_static.workspace = true
-once_cell = "1.17.0"
+once_cell.workspace = true
 halo2_proofs.workspace = true
-regex = "1.5.4"
-serde = {version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.66"
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 serde_with = "1.12"
 uint = "0.9.1"
 itertools.workspace = true
-libsecp256k1 = "0.7"
-subtle = "2.4"
-sha3 = "0.10"
-num = "0.4"
-num-bigint = { version = "0.4" }
-strum_macros = "0.24"
-strum = "0.24"
-poseidon-circuit = { git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
+libsecp256k1.workspace = true
+subtle.workspace = true
+sha3.workspace = true
+num.workspace = true
+num-bigint.workspace = true
+strum_macros.workspace = true
+strum.workspace = true
+hash-circuit.workspace = true
 [features]
 default = ["warn-unimplemented"]
 warn-unimplemented = []

--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -52,7 +52,7 @@ pub trait Field:
     FieldExt
     + Halo2Field
     + PrimeField<Repr = [u8; 32]>
-    + poseidon_circuit::hash::Hashable
+    + hash_circuit::hash::Hashable
     + std::convert::From<Fr>
 {
 }

--- a/external-tracer/Cargo.toml
+++ b/external-tracer/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 [dependencies]
 eth-types = { path = "../eth-types" }
 geth-utils = { path = "../geth-utils" }
-serde = {version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.66"
+serde.workspace = true
+serde_json.workspace = true
 log.workspace = true
 
 [features]

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -6,11 +6,10 @@ license.workspace = true
 
 [dependencies]
 halo2_proofs.workspace = true
-sha3 = "0.7.2"
+sha3.workspace = true
 eth-types = { path = "../eth-types" }
-digest = "0.7.6"
-strum = "0.24"
+strum.workspace = true
 
 [dev-dependencies]
-rand_xorshift = "0.3"
-rand = "0.8"
+rand_xorshift.workspace = true
+rand.workspace = true

--- a/gadgets/src/evm_word.rs
+++ b/gadgets/src/evm_word.rs
@@ -7,7 +7,6 @@
 //! looked up. Instead, it will be folded into the bus mapping lookup.
 
 use crate::Variable;
-use digest::{FixedOutput, Input};
 use eth_types::Field;
 use halo2_proofs::{
     circuit::{Region, Value},
@@ -24,10 +23,10 @@ use halo2_proofs::circuit::Layouter;
 pub fn r<F: Field>() -> F {
     let mut hasher = Keccak256::new();
     for byte in 0..=u8::MAX {
-        hasher.process(&[byte]);
+        hasher.update([byte]);
     }
     let mut r = [0; 64];
-    r[..32].copy_from_slice(hasher.fixed_result().as_slice());
+    r[..32].copy_from_slice(hasher.finalize().as_slice());
     F::from_bytes_wide(&r)
 }
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,28 +8,25 @@ license.workspace = true
 
 [dependencies]
 lazy_static.workspace = true
-ethers = { version = "2.0.7", features = ["ethers-solc"] }
-serde_json = "1.0.66"
-serde = { version = "1.0.130", features = ["derive"] }
+ethers.workspace = true
+serde_json.workspace = true
+serde.workspace = true
 bus-mapping = { path = "../bus-mapping", features = ["test"] }
 eth-types = { path = "../eth-types" }
 zkevm-circuits = { path = "../zkevm-circuits", default-features = false, features = ["test", "test-circuits","shanghai","debug-annotations"] }
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
-url = "2.2.2"
-pretty_assertions = "1.0.0"
+tokio.workspace = true
+url.workspace = true
+pretty_assertions.workspace = true
 log.workspace = true
 env_logger.workspace = true
 halo2_proofs.workspace = true
-hex = "0.4.3"
-strum = "0.24.1"
-rand_chacha = "0.3"
+hex.workspace = true
+strum.workspace = true
+rand_chacha.workspace = true
 paste = "1.0"
-rand_xorshift = "0.3.0"
+rand_xorshift.workspace = true
 rand_core = "0.6.4"
 mock = { path = "../mock" }
-
-[dev-dependencies]
-pretty_assertions = "1.0.0"
 
 [features]
 default = ["circuits"]

--- a/keccak256/Cargo.toml
+++ b/keccak256/Cargo.toml
@@ -10,8 +10,8 @@ dev-graph = ["halo2_proofs/dev-graph", "plotters"]
 [dependencies]
 halo2_proofs.workspace = true
 itertools.workspace = true
-num-bigint = "0.4.2"
-num-traits = "0.2.14"
+num-bigint.workspace = true
+num-traits.workspace = true
 plotters = { version = "0.3.0", optional = true }
 eth-types = { path = "../eth-types" }
 lazy_static.workspace = true
@@ -19,5 +19,5 @@ log.workspace = true
 env_logger.workspace = true
 
 [dev-dependencies]
-pretty_assertions = "1.0"
-rand = "0.8"
+pretty_assertions.workspace = true
+rand.workspace = true

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -9,10 +9,10 @@ eth-types = { path = "../eth-types" }
 external-tracer = { path = "../external-tracer" }
 lazy_static.workspace = true
 itertools.workspace = true
-ethers-signers = "2.0.7"
-ethers-core = { version = "2.0.7", features = ["scroll"] }
-rand_chacha = "0.3"
-rand = "0.8"
+ethers-signers.workspace = true
+ethers-core.workspace = true
+rand_chacha.workspace = true
+rand.workspace = true
 log.workspace = true
 
 [features]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -13,27 +13,27 @@ eth-types = { path = "../eth-types" }
 mpt-zktrie = { path = "../zktrie" }
 zkevm-circuits = { path = "../zkevm-circuits", default-features = false }
 
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+snark-verifier.workspace = true
+snark-verifier-sdk.workspace = true
 
-anyhow = "1.0"
+anyhow.workspace = true
 base64 = "0.13.0"
 blake2 = "0.10.3"
 chrono = "0.4.19"
 dotenvy = "0.15.7"
-ethers-core = { version = "2.0.7", features = ["scroll"] }
+ethers-core.workspace = true
 git-version = "0.3.5"
-hex = "0.4.3"
+hex.workspace = true
 itertools.workspace = true
 log.workspace = true
 log4rs = { version = "1.2.0", default_features = false, features = ["console_appender", "file_appender"] }
-num-bigint = "0.4.3"
-once_cell = "1.8.0"
-rand = "0.8"
-rand_xorshift = "0.3"
-serde = "1.0"
+num-bigint.workspace = true
+once_cell.workspace = true
+rand.workspace = true
+rand_xorshift.workspace = true
+serde.workspace = true
 serde_derive = "1.0"
-serde_json = { version = "1.0.66", features = ["unbounded_depth"] }
+serde_json = { workspace = true, features = ["unbounded_depth"] }
 serde_stacker = "0.1"
 sha2 ="0.10.2"
 

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -6,39 +6,39 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 bus-mapping = { path = "../bus-mapping" }
 clap = { version = "3.1", features = ["derive"] }
 env_logger.workspace = true
 eth-types = { path="../eth-types" }
-ethers-core = { version = "2.0.7", features = ["scroll"] }
-ethers-signers = "2.0.7"
+ethers-core.workspace = true
+ethers-signers.workspace = true
 external-tracer = { path="../external-tracer" }
 glob = "0.3"
 handlebars = "4.3"
-hex = "0.4.3"
+hex.workspace = true
 keccak256 = { path = "../keccak256" }
 log.workspace = true
 itertools.workspace = true
 mock = { path = "../mock" }
-once_cell = "1.10"
+once_cell.workspace = true
 prettytable-rs = "0.10"
 prover = { path = "../prover", optional = true }
-rayon = "1.5"
-regex = "1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-strum= "0.24"
-strum_macros = "0.24"
+rayon.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 thiserror = "1.0"
 toml = "0.5"
 yaml-rust = "0.4.5"
 zkevm-circuits = { path="../zkevm-circuits", features=["test"] }
-rand_chacha = "0.3"
-rand = "0.8"
+rand_chacha.workspace = true
+rand.workspace = true
 halo2_proofs.workspace = true
 urlencoding = "2.1.2"
-ctor = "0.1.22"
+ctor.workspace = true
 
 [features]
 default = ["ignore-test-docker", "skip-self-destruct", "shanghai"]

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -8,30 +8,30 @@ license.workspace = true
 
 [dependencies]
 halo2_proofs.workspace = true
-num = "0.4"
-sha3 = "0.10"
+num.workspace = true
+sha3.workspace = true
 array-init = "2.0.0"
 bus-mapping = { path = "../bus-mapping" }
 either = "1.9"
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
-ethers-core = { version = "2.0.7", features = ["scroll"] }
-ethers-signers = { version = "2.0.7", optional = true }
+ethers-core.workspace = true
+ethers-signers = { workspace = true, optional = true }
 mock = { path = "../mock", optional = true }
-strum = "0.24"
-strum_macros = "0.24"
-rand_xorshift = "0.3"
-rand = "0.8"
+strum.workspace = true
+strum_macros.workspace = true
+rand_xorshift.workspace = true
+rand.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 mpt-zktrie = { path = "../zktrie" }
 keccak256 = { path = "../keccak256"}
 log.workspace = true
 env_logger.workspace = true
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.78"
+serde.workspace = true
+serde_json.workspace = true
 
-hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
+hash-circuit.workspace = true
 misc-precompiled-circuit = { package = "misc-precompiled-circuit", git = "https://github.com/scroll-tech/misc-precompiled-circuit.git", tag = "v0.1.0" }
 
 halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", tag = "v0.1.5", default-features=false, features=["halo2-pse","display"] }
@@ -39,24 +39,22 @@ halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", tag = "v0.1.5", 
 
 maingate = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_02_02" }
 
-libsecp256k1 = "0.7"
-num-bigint = { version = "0.4" }
-subtle = "2.4"
-rand_chacha = "0.3"
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5", default-features=false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
-hex = "0.4.3"
-rayon = "1.5"
-once_cell = "1.17.0"
+libsecp256k1.workspace = true
+num-bigint.workspace = true
+subtle.workspace = true
+rand_chacha.workspace = true
+snark-verifier.workspace = true
+snark-verifier-sdk.workspace = true
+hex.workspace = true
+rayon.workspace = true
+once_cell.workspace = true
 
 [dev-dependencies]
 bus-mapping = { path = "../bus-mapping", features = ["test"] }
 criterion = "0.3"
-ctor = "0.1.22"
-ethers-signers = "2.0.7"
-hex = "0.4.3"
+ctor.workspace = true
 mock = { path = "../mock" }
-pretty_assertions = "1.0.0"
+pretty_assertions.workspace = true
 cli-table = "0.4"
 paste = "1.0"
 

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -10,17 +10,17 @@ license.workspace = true
 halo2_proofs.workspace = true
 mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", tag = "v0.7.0" }
 zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "v0.7"}
-hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
+hash-circuit.workspace = true
 eth-types = { path = "../eth-types" }
 lazy_static.workspace = true
-num-bigint = { version = "0.4" }
+num-bigint.workspace = true
 log.workspace = true
-hex = "0.4"
+hex.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
-serde = {version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
### Summary

- use [cargo-dependency-inheritor](https://github.com/TimonPost/cargo-dependency-inheritor) to find dependencies (at least `2` times in Cargo.toml). update cargo-dependency-inheritor's fmt, and revert fixes for local sub-crates (eth-types, bus-mapping, zkevm-circuits and so on).
```
cargo dependency-inheritor --workspace-path Cargo.toml -n 2
```
- upgrade `sha3` to `0.10.8` in `gadgets`.
