### PR TITLE
fix: add logs and verify inner snark if failed to check pairing

### DIFF
--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -81,7 +81,7 @@ pub(crate) fn extract_accumulators_and_proof(
             log::trace!("acc extraction {}-th acc check: right {:?}", i, right);
             if left != right {
                 return Err(snark_verifier::Error::AssertionFailure(format!(
-                    "accumulator check failed {left:?} {right:?}, index {i}",
+                    "old accumulator check failed {left:?} {right:?}, index {i}",
                 )));
             }
             //assert_eq!(left, right, "accumulator check failed");
@@ -134,7 +134,7 @@ pub fn extract_proof_and_instances_with_pairing_check(
 
         if left != right {
             return Err(snark_verifier::Error::AssertionFailure(format!(
-                "accumulator check failed {left:?} {right:?}",
+                "new accumulator check failed {left:?} {right:?}",
             )));
         }
     }

--- a/prover/src/common/prover/chunk.rs
+++ b/prover/src/common/prover/chunk.rs
@@ -70,12 +70,9 @@ impl Prover {
     }
 
     fn check_pairing_for_inner_snark(&self, inner_id: &str, inner_snark: &Snark) -> Result<()> {
-        // Params must exist.
-        let params = &self.params_map[&LayerId::Layer1.degree()];
-
         // Check pairing for snark.
         let pairing_result = extract_proof_and_instances_with_pairing_check(
-            params,
+            &self.params_map[&LayerId::Layer1.degree()],
             slice::from_ref(inner_snark),
             gen_rng(),
         );
@@ -87,7 +84,7 @@ impl Prover {
         let verified_result = if let Some(pk) = self.pk(inner_id) {
             // WARN: this may impact performance if failed to check pairing frequently.
             let verified = verify_snark_shplonk::<<SuperCircuit as TargetCircuit>::Inner>(
-                params.verifier_params(),
+                self.params_map[&LayerId::Inner.degree()].verifier_params(),
                 inner_snark.clone(),
                 pk.get_vk(),
             );

--- a/prover/src/common/prover/chunk.rs
+++ b/prover/src/common/prover/chunk.rs
@@ -1,9 +1,14 @@
 use super::Prover;
-use crate::{config::LayerId, utils::gen_rng};
+use crate::{
+    config::LayerId,
+    utils::gen_rng,
+    zkevm::circuit::{SuperCircuit, TargetCircuit},
+};
 use aggregator::extract_proof_and_instances_with_pairing_check;
 use anyhow::{anyhow, Result};
-use halo2_proofs::halo2curves::bn256::Fr;
-use snark_verifier_sdk::Snark;
+use halo2_proofs::{halo2curves::bn256::Fr, poly::commitment::ParamsProver};
+use snark_verifier_sdk::{verify_snark_shplonk, Snark};
+use std::slice;
 use zkevm_circuits::evm_circuit::witness::Block;
 
 impl Prover {
@@ -41,21 +46,14 @@ impl Prover {
         output_dir: Option<&str>,
     ) -> Result<Snark> {
         // Load or generate inner snark.
-        let inner_snark = self.load_or_gen_inner_snark(
-            name,
-            inner_id.unwrap_or(LayerId::Inner.id()),
-            witness_block,
-            output_dir,
-        )?;
+        let inner_id = inner_id.unwrap_or(LayerId::Inner.id());
+        let inner_snark =
+            self.load_or_gen_inner_snark(name, inner_id, witness_block, output_dir)?;
         log::info!("Got inner snark: {name}");
 
-        // Check pairing for super circuit.
-        extract_proof_and_instances_with_pairing_check(
-            self.params(LayerId::Layer1.degree()),
-            &[inner_snark.clone()],
-            gen_rng(),
-        )
-        .map_err(|err| anyhow!("Failed to check pairing for super circuit: {err:?}"))?;
+        // Check pairing for super circuit snark.
+        self.check_pairing_for_inner_snark(inner_id, &inner_snark)?;
+        log::info!("Check pairing for inner snark successfully: {name}");
 
         // Load or generate compression wide snark (layer-1).
         let layer1_snark = self.load_or_gen_comp_snark(
@@ -69,5 +67,35 @@ impl Prover {
         log::info!("Got compression wide snark (layer-1): {name}");
 
         Ok(layer1_snark)
+    }
+
+    fn check_pairing_for_inner_snark(&self, inner_id: &str, inner_snark: &Snark) -> Result<()> {
+        // Params must exist.
+        let params = &self.params_map[&LayerId::Layer1.degree()];
+
+        // Check pairing for snark.
+        let pairing_result = extract_proof_and_instances_with_pairing_check(
+            params,
+            slice::from_ref(inner_snark),
+            gen_rng(),
+        );
+        if pairing_result.is_ok() {
+            return Ok(());
+        }
+
+        // Verify snark if failed to check pairing.
+        let verified_result = if let Some(pk) = self.pk(inner_id) {
+            // WARN: this may impact performance if failed to check pairing frequently.
+            let verified = verify_snark_shplonk::<<SuperCircuit as TargetCircuit>::Inner>(
+                params.verifier_params(),
+                inner_snark.clone(),
+                pk.get_vk(),
+            );
+            format!("inner snark verified = {verified}")
+        } else {
+            "no inner pk".to_string()
+        };
+
+        Err(anyhow!("Failed to check pairing for super circuit: {pairing_result:?}, verified result: {verified_result}"))
     }
 }


### PR DESCRIPTION
### Description

- add and update logs for paring check.
- try to verify inner snark if failed to check pairing.
