### PR TITLE
Fix little-endian to big-endian representation in tests

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
@@ -272,8 +272,8 @@ mod test {
         test_ok(OpcodeId::SDIV, 0xABC.into(), 0.into());
         // (1 << 255) + (7 << 128)
         let mut x = [0u8; 32];
-        x[31] = 128u8;
-        x[16] = 7u8;
+        x[0] = 128u8;
+        x[15] = 7u8;
         test_ok(OpcodeId::SDIV, Word::from_big_endian(&x), 0x1234.into());
         test_ok(
             OpcodeId::SDIV,
@@ -287,7 +287,7 @@ mod test {
         );
         // 1 << 255
         let mut x = [0u8; 32];
-        x[31] = 128u8;
+        x[0] = 128u8;
         test_ok(
             OpcodeId::SDIV,
             Word::from_big_endian(&x),
@@ -310,8 +310,8 @@ mod test {
         test_ok(OpcodeId::SMOD, 0xABC.into(), 0.into());
         // (1 << 255) + (7 << 128)
         let mut x = [0u8; 32];
-        x[31] = 128u8;
-        x[16] = 7u8;
+        x[0] = 128u8;
+        x[15] = 7u8;
         test_ok(OpcodeId::SMOD, Word::from_big_endian(&x), 0x1234.into());
         test_ok(
             OpcodeId::SMOD,
@@ -324,7 +324,7 @@ mod test {
             Word::from_big_endian(&[255u8; 32]),
         );
         let mut x = [0u8; 32];
-        x[31] = 128u8;
+        x[0] = 128u8;
         test_ok(
             OpcodeId::SMOD,
             Word::from_big_endian(&x),


### PR DESCRIPTION
### Description

Fix little-endian to big-endian representation in tests

### Issue Link

N/A

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

The title says it all.

### Rationale

N/A

### How Has This Been Tested?

N/A

<hr>

## How to fill a PR description 

The title says it all.