### PR TITLE
[security-review] issue-1: fix to delete `keccak256` dependency from `bus-mapping`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,6 @@ dependencies = [
  "halo2_proofs",
  "hex",
  "itertools",
- "keccak256",
  "lazy_static",
  "log",
  "mock",

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 [dependencies]
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
-keccak256 = { path = "../keccak256" }
 mpt-zktrie = {path = "../zktrie"}
 mock = { path = "../mock", optional = true }
 


### PR DESCRIPTION
### Description

Reference [security review validated issue-1](https://gist.github.com/nicolasgarcia214/1d7522888f2ccc8336ec0edc5147723c#current-validated-issues):

> At present, the bus-mapping library crate includes the keccak256 internal crate in the cargo.toml. However, it is not utilized. All functionalities related to keccak256 are managed by the ethers_core external crate.

