### PR TITLE
[security-review] issue-4: add explicit dependency `resolver` to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "aggregator",
     "prover"
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
### Description

Reference [security review validated issue-4](https://gist.github.com/nicolasgarcia214/1d7522888f2ccc8336ec0edc5147723c#current-validated-issues):

> All packages in the workspace are set to the 2021 edition, which optimally aligns with the v2 dependency resolver. However, the workspace currently defaults to the v1 resolver. This could lead to potential inconsistencies and inconsistent behaviors.

And rust-doc links to explicitly set `resolver` to workspace:

https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details

https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
