### PR TITLE
[security-review] issue-6: upgrade dependency `itertools`, `strum` and `strum_macros`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "ethers-core",
  "halo2_proofs",
  "hex",
- "itertools",
+ "itertools 0.11.0",
  "log",
  "rand",
  "serde",
@@ -146,7 +146,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -492,7 +492,7 @@ dependencies = [
  "gadgets",
  "halo2_proofs",
  "hex",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "mock",
@@ -505,8 +505,8 @@ dependencies = [
  "revm-precompile",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "tokio",
  "url",
 ]
@@ -654,7 +654,7 @@ dependencies = [
  "ethers",
  "ethers-signers",
  "halo2_proofs",
- "itertools",
+ "itertools 0.11.0",
  "keccak256",
  "log",
  "mock",
@@ -928,7 +928,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -950,7 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ dependencies = [
  "ethers-signers",
  "halo2_proofs",
  "hex",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "num",
  "num-bigint",
@@ -1548,8 +1548,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3 0.10.8",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "subtle",
  "uint",
 ]
@@ -1710,7 +1710,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.24.1",
  "syn 2.0.32",
  "tempfile",
  "thiserror",
@@ -2197,7 +2197,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "sha3 0.10.8",
- "strum",
+ "strum 0.25.0",
 ]
 
 [[package]]
@@ -2358,7 +2358,7 @@ source = "git+https://github.com/scroll-tech/halo2-lib?tag=v0.1.5#70588177930400
 dependencies = [
  "ff 0.12.1",
  "halo2_proofs",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2374,7 +2374,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "halo2-base",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2396,8 +2396,8 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "subtle",
 ]
 
@@ -2409,7 +2409,7 @@ dependencies = [
  "ethers-core",
  "halo2_proofs",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "num-bigint",
@@ -2418,8 +2418,8 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "thiserror",
 ]
 
@@ -2809,7 +2809,7 @@ dependencies = [
  "rand_xorshift",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "tokio",
  "url",
  "zkevm-circuits",
@@ -2837,6 +2837,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -2914,7 +2923,7 @@ dependencies = [
  "env_logger 0.10.0",
  "eth-types",
  "halo2_proofs",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "num-bigint",
@@ -2935,7 +2944,7 @@ dependencies = [
  "diff",
  "ena",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "regex",
@@ -3114,8 +3123,8 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "subtle",
 ]
 
@@ -3127,7 +3136,7 @@ dependencies = [
  "ethers-core",
  "ethers-signers",
  "external-tracer",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "rand",
@@ -3869,7 +3878,7 @@ dependencies = [
  "git-version",
  "halo2_proofs",
  "hex",
- "itertools",
+ "itertools 0.11.0",
  "log",
  "log4rs",
  "mpt-zktrie",
@@ -4718,7 +4727,7 @@ dependencies = [
  "halo2-base",
  "halo2-ecc",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-bigint",
  "num-integer",
@@ -4742,7 +4751,7 @@ dependencies = [
  "ethereum-types",
  "halo2-base",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "num-bigint",
@@ -4781,7 +4790,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a94494913728908efa7a25a2dd2e4f037e714897985c24273c40596638ed909"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "lalrpop",
  "lalrpop-util",
  "phf",
@@ -4855,8 +4864,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
@@ -4869,6 +4884,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4999,7 +5027,7 @@ dependencies = [
  "halo2_proofs",
  "handlebars",
  "hex",
- "itertools",
+ "itertools 0.11.0",
  "keccak256",
  "log",
  "mock",
@@ -5012,8 +5040,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "thiserror",
  "toml 0.5.11",
  "urlencoding",
@@ -5803,7 +5831,7 @@ dependencies = [
  "halo2-ecc",
  "halo2_proofs",
  "hex",
- "itertools",
+ "itertools 0.11.0",
  "keccak256",
  "lazy_static",
  "log",
@@ -5826,8 +5854,8 @@ dependencies = [
  "sha3 0.10.8",
  "snark-verifier",
  "snark-verifier-sdk",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ethers-signers = "2.0.7"
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "develop" }
 hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "scroll-dev-0901"}
 hex = "0.4"
-itertools = "0.10"
+itertools = "0.11"
 lazy_static = "1.4"
 libsecp256k1 = "0.7"
 log = "0.4"
@@ -52,8 +52,8 @@ serde_json = "1.0"
 sha3 = "0.10"
 snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5" }
 snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", tag = "v0.1.5", default-features = false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.25"
+strum_macros = "0.25"
 subtle = "2.4"
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 url = "2.2"

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -2,7 +2,7 @@
 
 use eth_types::{evm_types::GasCost, Address, ToBigEndian, Word};
 use revm_precompile::{Precompile, PrecompileError, Precompiles};
-use strum::EnumIter;
+use strum_macros::EnumIter;
 
 use crate::circuit_input_builder::{EcMulOp, EcPairingOp, N_BYTES_PER_PAIR, N_PAIRING_PER_OP};
 

--- a/testool/src/main.rs
+++ b/testool/src/main.rs
@@ -22,7 +22,7 @@ use std::{
     path::PathBuf,
     time::SystemTime,
 };
-use strum::EnumString;
+use strum_macros::EnumString;
 
 const REPORT_FOLDER: &str = "report";
 const CODEHASH_FILE: &str = "./codehash.txt";


### PR DESCRIPTION
### Description

Reference [security review validated issue-6](https://gist.github.com/nicolasgarcia214/1d7522888f2ccc8336ec0edc5147723c#current-validated-issues):

> The `bus-mapping` module relies on several outdated external crates, including:
    - strum
    - itertools
    - strum_macros
    - env_logger
    Using outdated versions may contain bugs, hinder performance, and lack beneficial features found in more recent releases.

`env_logger` has already been upgraded to `0.10` before.

*_I upgrade `itertools`, `strum` and `strum_macros`, but old versions are also depdended by other crates. So this PR makes `Cargo.lock` has multiple versions of these 3 crates._*
