### PR TITLE
[security-review] issue-14: replace `nth_last(0)` and `nth_last_filled(0)` with `last()` and `last_filled()`

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -627,7 +627,7 @@ impl<'a> CircuitInputBuilder {
                 } else if geth_step.op.is_call_without_value() {
                     format!(
                         "{:?} {:40x} {:?} {:?} {:?} {:?}",
-                        geth_step.stack.nth_last(0),
+                        geth_step.stack.last(),
                         geth_step.stack.nth_last(1).unwrap_or_default(),
                         geth_step.stack.nth_last(2),
                         geth_step.stack.nth_last(3),
@@ -637,7 +637,7 @@ impl<'a> CircuitInputBuilder {
                 } else if geth_step.op.is_call_with_value() {
                     format!(
                         "{:?} {:40x} {:?} {:?} {:?} {:?} {:?}",
-                        geth_step.stack.nth_last(0),
+                        geth_step.stack.last(),
                         geth_step.stack.nth_last(1).unwrap_or_default(),
                         geth_step.stack.nth_last(2),
                         geth_step.stack.nth_last(3),
@@ -648,7 +648,7 @@ impl<'a> CircuitInputBuilder {
                 } else if geth_step.op.is_create() {
                     format!(
                         "value {:?} offset {:?} size {:?} {}",
-                        geth_step.stack.nth_last(0),
+                        geth_step.stack.last(),
                         geth_step.stack.nth_last(1),
                         geth_step.stack.nth_last(2),
                         if geth_step.op == OpcodeId::CREATE2 {
@@ -661,7 +661,7 @@ impl<'a> CircuitInputBuilder {
                     format!(
                         "{:?} {:?} {:?}",
                         state_ref.call().map(|c| c.address),
-                        geth_step.stack.nth_last(0),
+                        geth_step.stack.last(),
                         geth_step.stack.nth_last(1),
                     )
                 } else {

--- a/bus-mapping/src/circuit_input_builder/access.rs
+++ b/bus-mapping/src/circuit_input_builder/access.rs
@@ -55,7 +55,7 @@ fn get_call_result(trace: &[GethExecStep]) -> Option<Word> {
     trace[1..]
         .iter()
         .find(|s| s.depth == depth)
-        .and_then(|s| s.stack.nth_last(0).ok())
+        .and_then(|s| s.stack.last().ok())
 }
 
 /// State and Code Access set.
@@ -184,12 +184,12 @@ pub fn gen_state_access_trace<TX>(
             match step.op {
                 OpcodeId::SSTORE => {
                     let address = contract_address;
-                    let key = step.stack.nth_last(0)?;
+                    let key = step.stack.last()?;
                     accs.push(Access::new(i, WRITE, Storage { address, key }));
                 }
                 OpcodeId::SLOAD => {
                     let address = contract_address;
-                    let key = step.stack.nth_last(0)?;
+                    let key = step.stack.last()?;
                     accs.push(Access::new(i, READ, Storage { address, key }));
                 }
                 OpcodeId::SELFBALANCE => {
@@ -207,25 +207,25 @@ pub fn gen_state_access_trace<TX>(
                     }
                 }
                 OpcodeId::BALANCE => {
-                    let address = step.stack.nth_last(0)?.to_address();
+                    let address = step.stack.last()?.to_address();
                     accs.push(Access::new(i, READ, Account { address }));
                 }
                 OpcodeId::EXTCODEHASH => {
-                    let address = step.stack.nth_last(0)?.to_address();
+                    let address = step.stack.last()?.to_address();
                     accs.push(Access::new(i, READ, Account { address }));
                 }
                 OpcodeId::EXTCODESIZE => {
-                    let address = step.stack.nth_last(0)?.to_address();
+                    let address = step.stack.last()?.to_address();
                     accs.push(Access::new(i, READ, Code { address }));
                 }
                 OpcodeId::EXTCODECOPY => {
-                    let address = step.stack.nth_last(0)?.to_address();
+                    let address = step.stack.last()?.to_address();
                     accs.push(Access::new(i, READ, Code { address }));
                 }
                 OpcodeId::SELFDESTRUCT => {
                     let address = contract_address;
                     accs.push(Access::new(i, WRITE, Account { address }));
-                    let address = step.stack.nth_last(0)?.to_address();
+                    let address = step.stack.last()?.to_address();
                     accs.push(Access::new(i, WRITE, Account { address }));
                 }
                 OpcodeId::CREATE => {

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1232,7 +1232,7 @@ impl<'a> CircuitInputStateRef<'a> {
 
         // Store deployed code if it's a successful create
         if call_success_create {
-            let offset = step.stack.nth_last(0)?;
+            let offset = step.stack.last()?;
             let length = step.stack.nth_last(1)?;
             let code = callee_memory.read_chunk(MemoryRange::new_with_length(
                 offset.low_u64(),
@@ -1272,7 +1272,7 @@ impl<'a> CircuitInputStateRef<'a> {
                 && step.error.is_none()
                 && !call_success_create
             {
-                step.stack.nth_last(0)?.low_u64()
+                step.stack.last()?.low_u64()
             } else {
                 // common err, call empty, call precompile
                 0
@@ -1318,7 +1318,7 @@ impl<'a> CircuitInputStateRef<'a> {
                     [Word::zero(), return_data_length]
                 }
                 OpcodeId::REVERT | OpcodeId::RETURN => {
-                    let offset = geth_step.stack.nth_last(0)?;
+                    let offset = geth_step.stack.last()?;
                     let length = geth_step.stack.nth_last(1)?;
                     // This is the convention we are using for memory addresses so that there is no
                     // memory expansion cost when the length is 0.
@@ -1546,7 +1546,7 @@ impl<'a> CircuitInputStateRef<'a> {
         // get value first if call/create
         let value = match step.op {
             OpcodeId::CALL | OpcodeId::CALLCODE => step.stack.nth_last(2)?,
-            OpcodeId::CREATE | OpcodeId::CREATE2 => step.stack.nth_last(0)?,
+            OpcodeId::CREATE | OpcodeId::CREATE2 => step.stack.last()?,
             _ => Word::zero(),
         };
 
@@ -1586,7 +1586,7 @@ impl<'a> CircuitInputStateRef<'a> {
             } else {
                 // Return from a {CREATE, CREATE2} with a failure, via RETURN
                 if call.is_create() {
-                    let offset = step.stack.nth_last(0)?;
+                    let offset = step.stack.last()?;
                     let length = step.stack.nth_last(1)?;
                     if length > Word::from(MAX_CODE_SIZE) {
                         return Ok(Some(ExecError::MaxCodeSizeExceeded));

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -770,7 +770,7 @@ fn tracer_err_code_store_out_of_gas_tx_deploy() {
 }
 
 fn check_err_invalid_code(step: &GethExecStep, next_step: Option<&GethExecStep>) -> bool {
-    let offset = step.stack.nth_last(0).unwrap();
+    let offset = step.stack.last().unwrap();
     let length = step.stack.nth_last(1).unwrap();
     step.op == OpcodeId::RETURN
         && step.error.is_none()

--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -64,7 +64,7 @@ impl Opcode for Balance {
         } else {
             H256::zero()
         };
-        debug_assert_eq!(balance, geth_steps[1].stack.nth_last(0)?);
+        debug_assert_eq!(balance, geth_steps[1].stack.last()?);
         state.account_read(
             &mut exec_step,
             address,
@@ -78,8 +78,8 @@ impl Opcode for Balance {
         // Write the BALANCE result to stack.
         state.stack_write(
             &mut exec_step,
-            geth_steps[1].stack.nth_last_filled(0),
-            geth_steps[1].stack.nth_last(0)?,
+            geth_steps[1].stack.last_filled(),
+            geth_steps[1].stack.last()?,
         )?;
 
         Ok(vec![exec_step])

--- a/bus-mapping/src/evm/opcodes/blockhash.rs
+++ b/bus-mapping/src/evm/opcodes/blockhash.rs
@@ -20,12 +20,8 @@ impl Opcode for Blockhash {
         let geth_step = &geth_steps[0];
         let mut exec_step = state.new_step(geth_step)?;
 
-        let block_number = geth_step.stack.nth_last(0)?;
-        state.stack_read(
-            &mut exec_step,
-            geth_step.stack.nth_last_filled(0),
-            block_number,
-        )?;
+        let block_number = geth_step.stack.last()?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), block_number)?;
 
         let block_hash = geth_steps[1].stack.last()?;
         state.stack_write(

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -29,15 +29,11 @@ fn gen_calldatacopy_step(
     geth_step: &GethExecStep,
 ) -> Result<ExecStep, Error> {
     let mut exec_step = state.new_step(geth_step)?;
-    let memory_offset = geth_step.stack.nth_last(0)?;
+    let memory_offset = geth_step.stack.last()?;
     let data_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?;
 
-    state.stack_read(
-        &mut exec_step,
-        geth_step.stack.nth_last_filled(0),
-        memory_offset,
-    )?;
+    state.stack_read(&mut exec_step, geth_step.stack.last_filled(), memory_offset)?;
     state.stack_read(
         &mut exec_step,
         geth_step.stack.nth_last_filled(1),
@@ -89,7 +85,7 @@ fn gen_copy_event(
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
 
-    let memory_offset = geth_step.stack.nth_last(0)?;
+    let memory_offset = geth_step.stack.last()?;
     let data_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?;
 

--- a/bus-mapping/src/evm/opcodes/calldataload.rs
+++ b/bus-mapping/src/evm/opcodes/calldataload.rs
@@ -20,8 +20,8 @@ impl Opcode for Calldataload {
 
         // fetch the top of the stack, i.e. offset in calldata to start reading 32-bytes
         // from.
-        let offset = geth_step.stack.nth_last(0)?;
-        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), offset)?;
+        let offset = geth_step.stack.last()?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), offset)?;
 
         // Check if offset is Uint64 overflow.
         let calldata_word = if let Ok(offset) = u64::try_from(offset) {

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -240,7 +240,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             // panic with full info
             let info1 = format!("callee_gas_left {callee_gas_left} gas_specified {gas_specified} gas_cost {gas_cost} is_warm {is_warm} has_value {has_value} current_memory_word_size {curr_memory_word_size} next_memory_word_size {next_memory_word_size}, memory_expansion_gas_cost {memory_expansion_gas_cost}");
             let info2 = format!("args gas:{:?} addr:{:?} value:{:?} cd_pos:{:?} cd_len:{:?} rd_pos:{:?} rd_len:{:?}",
-                        geth_step.stack.nth_last(0),
+                        geth_step.stack.last(),
                         geth_step.stack.nth_last(1),
                         geth_step.stack.nth_last(2),
                         geth_step.stack.nth_last(3),

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -31,16 +31,12 @@ fn gen_codecopy_step(
 ) -> Result<ExecStep, Error> {
     let mut exec_step = state.new_step(geth_step)?;
 
-    let dest_offset = geth_step.stack.nth_last(0)?;
+    let dest_offset = geth_step.stack.last()?;
     let code_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?;
 
     // stack reads
-    state.stack_read(
-        &mut exec_step,
-        geth_step.stack.nth_last_filled(0),
-        dest_offset,
-    )?;
+    state.stack_read(&mut exec_step, geth_step.stack.last_filled(), dest_offset)?;
     state.stack_read(
         &mut exec_step,
         geth_step.stack.nth_last_filled(1),
@@ -58,7 +54,7 @@ fn gen_copy_event(
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
 
-    let dst_offset = geth_step.stack.nth_last(0)?;
+    let dst_offset = geth_step.stack.last()?;
     let code_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?.as_u64();
 

--- a/bus-mapping/src/evm/opcodes/error_codestore.rs
+++ b/bus-mapping/src/evm/opcodes/error_codestore.rs
@@ -25,9 +25,9 @@ impl Opcode for ErrorCodeStore {
                 || exec_step.error == Some(ExecError::MaxCodeSizeExceeded)
         );
 
-        let offset = geth_step.stack.nth_last(0)?;
+        let offset = geth_step.stack.last()?;
         let length = geth_step.stack.nth_last(1)?;
-        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), offset)?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), offset)?;
         state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(1), length)?;
 
         // in internal call context

--- a/bus-mapping/src/evm/opcodes/error_invalid_creation_code.rs
+++ b/bus-mapping/src/evm/opcodes/error_invalid_creation_code.rs
@@ -19,9 +19,9 @@ impl Opcode for ErrorCreationCode {
 
         exec_step.error = Some(ExecError::InvalidCreationCode);
 
-        let offset = geth_step.stack.nth_last(0)?;
+        let offset = geth_step.stack.last()?;
         let length = geth_step.stack.nth_last(1)?;
-        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), offset)?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), offset)?;
         state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(1), length)?;
 
         // in create context

--- a/bus-mapping/src/evm/opcodes/error_oog_log.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_log.rs
@@ -31,10 +31,10 @@ impl Opcode for ErrorOOGLog {
             OpcodeId::LOG4
         ]
         .contains(&geth_step.op));
-        let mstart = geth_step.stack.nth_last(0)?;
+        let mstart = geth_step.stack.last()?;
         let msize = geth_step.stack.nth_last(1)?;
 
-        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), mstart)?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), mstart)?;
         state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(1), msize)?;
         // read static call property
         state.call_context_read(

--- a/bus-mapping/src/evm/opcodes/error_return_data_outofbound.rs
+++ b/bus-mapping/src/evm/opcodes/error_return_data_outofbound.rs
@@ -25,15 +25,11 @@ impl Opcode for ErrorReturnDataOutOfBound {
             Some(ExecError::ReturnDataOutOfBounds)
         );
 
-        let memory_offset = geth_step.stack.nth_last(0)?;
+        let memory_offset = geth_step.stack.last()?;
         let data_offset = geth_step.stack.nth_last(1)?;
         let length = geth_step.stack.nth_last(2)?;
 
-        state.stack_read(
-            &mut exec_step,
-            geth_step.stack.nth_last_filled(0),
-            memory_offset,
-        )?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), memory_offset)?;
         state.stack_read(
             &mut exec_step,
             geth_step.stack.nth_last_filled(1),

--- a/bus-mapping/src/evm/opcodes/exp.rs
+++ b/bus-mapping/src/evm/opcodes/exp.rs
@@ -41,8 +41,8 @@ impl Opcode for Exponentiation {
         let geth_step = &geth_steps[0];
         let mut exec_step = state.new_step(geth_step)?;
 
-        let base = geth_step.stack.nth_last(0)?;
-        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), base)?;
+        let base = geth_step.stack.last()?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), base)?;
         let exponent = geth_step.stack.nth_last(1)?;
         state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(1), exponent)?;
 

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -31,7 +31,7 @@ fn gen_extcodecopy_step(
 ) -> Result<ExecStep, Error> {
     let mut exec_step = state.new_step(geth_step)?;
 
-    let external_address_word = geth_step.stack.nth_last(0)?;
+    let external_address_word = geth_step.stack.last()?;
     let external_address = external_address_word.to_address();
     let dest_offset = geth_step.stack.nth_last(1)?;
     let offset = geth_step.stack.nth_last(2)?;
@@ -40,7 +40,7 @@ fn gen_extcodecopy_step(
     // stack reads
     state.stack_read(
         &mut exec_step,
-        geth_step.stack.nth_last_filled(0),
+        geth_step.stack.last_filled(),
         external_address_word,
     )?;
     state.stack_read(
@@ -100,7 +100,7 @@ fn gen_copy_event(
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
 
-    let external_address = geth_step.stack.nth_last(0)?.to_address();
+    let external_address = geth_step.stack.last()?.to_address();
     let dst_offset = geth_step.stack.nth_last(1)?;
     let code_offset = geth_step.stack.nth_last(2)?;
     let length = geth_step.stack.nth_last(3)?.as_u64();

--- a/bus-mapping/src/evm/opcodes/extcodesize.rs
+++ b/bus-mapping/src/evm/opcodes/extcodesize.rs
@@ -78,11 +78,7 @@ impl Opcode for Extcodesize {
 
         // Write the EXTCODESIZE result to stack.
         debug_assert_eq!(code_size, geth_steps[1].stack.last()?);
-        state.stack_write(
-            &mut exec_step,
-            geth_steps[1].stack.nth_last_filled(0),
-            code_size,
-        )?;
+        state.stack_write(&mut exec_step, geth_steps[1].stack.last_filled(), code_size)?;
 
         Ok(vec![exec_step])
     }

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -25,7 +25,7 @@ impl Opcode for Log {
         }
 
         // reconstruction
-        let offset = geth_step.stack.nth_last(0)?;
+        let offset = geth_step.stack.last()?;
         let length = geth_step.stack.nth_last(1)?.as_u64();
 
         if length != 0 {
@@ -49,11 +49,11 @@ fn gen_log_step(
 ) -> Result<ExecStep, Error> {
     let mut exec_step = state.new_step(geth_step)?;
 
-    let mstart = geth_step.stack.nth_last(0)?;
+    let mstart = geth_step.stack.last()?;
     let msize = geth_step.stack.nth_last(1)?;
 
     let call_id = state.call()?.call_id;
-    state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), mstart)?;
+    state.stack_read(&mut exec_step, geth_step.stack.last_filled(), mstart)?;
     state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(1), msize)?;
 
     state.call_context_read(
@@ -133,7 +133,7 @@ fn gen_copy_event(
     // Get low Uint64 for memory start as below reference. Memory size must be
     // within range of Uint64, otherwise returns ErrGasUintOverflow.
     // https://github.com/ethereum/go-ethereum/blob/b80f05bde2c4e93ae64bb3813b6d67266b5fc0e6/core/vm/instructions.go#L850
-    let memory_start = geth_step.stack.nth_last(0)?.low_u64();
+    let memory_start = geth_step.stack.last()?.low_u64();
     let msize = geth_step.stack.nth_last(1)?.as_u64();
 
     let (src_addr, src_addr_end) = (memory_start, memory_start.checked_add(msize).unwrap());

--- a/bus-mapping/src/evm/opcodes/mstore.rs
+++ b/bus-mapping/src/evm/opcodes/mstore.rs
@@ -19,8 +19,8 @@ impl<const IS_MSTORE8: bool> Opcode for Mstore<IS_MSTORE8> {
         let geth_step = &geth_steps[0];
         let mut exec_step = state.new_step(geth_step)?;
         // First stack read (offset)
-        let offset = geth_step.stack.nth_last(0)?;
-        let offset_pos = geth_step.stack.nth_last_filled(0);
+        let offset = geth_step.stack.last()?;
+        let offset_pos = geth_step.stack.last_filled();
         state.stack_read(&mut exec_step, offset_pos, offset)?;
 
         // Second stack read (value)

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -27,9 +27,9 @@ impl Opcode for ReturnRevert {
         let step = &steps[0];
         let mut exec_step = state.new_step(step)?;
 
-        let offset = step.stack.nth_last(0)?;
+        let offset = step.stack.last()?;
         let length = step.stack.nth_last(1)?;
-        state.stack_read(&mut exec_step, step.stack.nth_last_filled(0), offset)?;
+        state.stack_read(&mut exec_step, step.stack.last_filled(), offset)?;
         state.stack_read(&mut exec_step, step.stack.nth_last_filled(1), length)?;
 
         if !length.is_zero() {

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -30,15 +30,11 @@ fn gen_returndatacopy_step(
     geth_step: &GethExecStep,
 ) -> Result<ExecStep, Error> {
     let mut exec_step = state.new_step(geth_step)?;
-    let memory_offset = geth_step.stack.nth_last(0)?;
+    let memory_offset = geth_step.stack.last()?;
     let data_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?;
 
-    state.stack_read(
-        &mut exec_step,
-        geth_step.stack.nth_last_filled(0),
-        memory_offset,
-    )?;
+    state.stack_read(&mut exec_step, geth_step.stack.last_filled(), memory_offset)?;
     state.stack_read(
         &mut exec_step,
         geth_step.stack.nth_last_filled(1),
@@ -87,7 +83,7 @@ fn gen_copy_event(
     let rw_counter_start = state.block_ctx.rwc;
 
     // Get low Uint64 of offset.
-    let dst_addr = geth_step.stack.nth_last(0)?;
+    let dst_addr = geth_step.stack.last()?;
     let data_offset = geth_step.stack.nth_last(1)?;
     let length = geth_step.stack.nth_last(2)?;
 

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -27,8 +27,8 @@ impl Opcode for Sha3 {
         let expected_sha3 = geth_steps[1].stack.last()?;
 
         // byte offset in the memory.
-        let offset = geth_step.stack.nth_last(0)?;
-        state.stack_read(&mut exec_step, geth_step.stack.nth_last_filled(0), offset)?;
+        let offset = geth_step.stack.last()?;
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), offset)?;
 
         // byte size to read in the memory.
         let size = geth_step.stack.nth_last(1)?;

--- a/bus-mapping/src/evm/opcodes/sstore.rs
+++ b/bus-mapping/src/evm/opcodes/sstore.rs
@@ -58,8 +58,8 @@ impl Opcode for Sstore {
             state.call()?.address.to_word(),
         )?;
 
-        let key = geth_step.stack.nth_last(0)?;
-        let key_stack_position = geth_step.stack.nth_last_filled(0);
+        let key = geth_step.stack.last()?;
+        let key_stack_position = geth_step.stack.last_filled();
         let value = geth_step.stack.nth_last(1)?;
         let value_stack_position = geth_step.stack.nth_last_filled(1);
 

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -945,7 +945,7 @@ mod test {
                     .enumerate()
                     .filter(|(_, s)| s.op == OpcodeId::RETURN)
                     .flat_map(|(index, _)| block.geth_traces[0].struct_logs.get(index + 1))
-                    .flat_map(|s| s.stack.nth_last(0)) // contract addr on stack top
+                    .flat_map(|s| s.stack.last()) // contract addr on stack top
                     .collect_vec();
                 assert!(created_contract_addr.len() == 2); // both contract addr exist
                 created_contract_addr
@@ -959,7 +959,7 @@ mod test {
                     .enumerate()
                     .filter(|(_, s)| s.op == OpcodeId::RETURNDATASIZE)
                     .flat_map(|(index, _)| block.geth_traces[0].struct_logs.get(index + 1))
-                    .flat_map(|s| s.stack.nth_last(0)) // returndata size on stack top
+                    .flat_map(|s| s.stack.last()) // returndata size on stack top
                     .collect_vec();
                 assert!(return_data_size.len() == 2);
                 return_data_size


### PR DESCRIPTION
### Description

Reference [security review validated issue-14](https://gist.github.com/nicolasgarcia214/1d7522888f2ccc8336ec0edc5147723c#current-validated-issues):

> Replace `nth_last(0)` and `nth_last_filled(0)` for `last()` and `last_filled()` respectively.