### PR TITLE
[security-review] issue-13: fix wrong comment for opcodes in bus-mapping

### DIFF
--- a/bus-mapping/src/evm/opcodes/caller.rs
+++ b/bus-mapping/src/evm/opcodes/caller.rs
@@ -7,7 +7,7 @@ use crate::{
 use eth_types::GethExecStep;
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
-/// corresponding to the [`OpcodeId::PC`](crate::evm::OpcodeId::PC) `OpcodeId`.
+/// corresponding to the [`OpcodeId::CALLER`](crate::evm::OpcodeId::CALLER) `OpcodeId`.
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Caller;
 

--- a/bus-mapping/src/evm/opcodes/callvalue.rs
+++ b/bus-mapping/src/evm/opcodes/callvalue.rs
@@ -7,7 +7,7 @@ use crate::{
 use eth_types::GethExecStep;
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
-/// corresponding to the [`OpcodeId::PC`](crate::evm::OpcodeId::PC) `OpcodeId`.
+/// corresponding to the [`OpcodeId::CALLVALUE`](crate::evm::OpcodeId::CALLVALUE) `OpcodeId`.
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Callvalue;
 

--- a/bus-mapping/src/evm/opcodes/gasprice.rs
+++ b/bus-mapping/src/evm/opcodes/gasprice.rs
@@ -7,7 +7,7 @@ use crate::{
 use eth_types::GethExecStep;
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
-/// corresponding to the [`OpcodeId::PC`](crate::evm::OpcodeId::PC) `OpcodeId`.
+/// corresponding to the [`OpcodeId::GASPRICE`](crate::evm::OpcodeId::GASPRICE) `OpcodeId`.
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct GasPrice;
 


### PR DESCRIPTION
### Description

Reference [security review validated issue-13](https://gist.github.com/nicolasgarcia214/1d7522888f2ccc8336ec0edc5147723c#current-validated-issues):

> Wrong docstrings. [Gas price](https://github.com/scroll-tech/zkevm-circuits/blob/43817d3354394dddd400c848521f719c252b708e/bus-mapping/src/evm/opcodes/gasprice.rs#L9) description corresponds to pc opcode.
