### PR TITLE
[OpenZeppelin audit N-07] replace `or_insert_with` with `or_default` for BTreeMap and HashMap

### DIFF
--- a/bus-mapping/src/circuit_input_builder/access.rs
+++ b/bus-mapping/src/circuit_input_builder/access.rs
@@ -70,7 +70,7 @@ pub struct AccessSet {
 impl AccessSet {
     #[inline(always)]
     pub(crate) fn add_account(&mut self, address: Address) {
-        self.state.entry(address).or_insert_with(HashSet::new);
+        self.state.entry(address).or_default();
     }
 
     #[inline(always)]
@@ -89,7 +89,7 @@ impl AccessSet {
 
     #[inline(always)]
     pub(crate) fn add_code(&mut self, address: Address) {
-        self.state.entry(address).or_insert_with(HashSet::new);
+        self.state.entry(address).or_default();
         self.code.insert(address);
     }
 

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -267,9 +267,9 @@ impl MptUpdates {
     ) -> Self {
         log::debug!("mpt update roots (mocking) {:?} {:?}", old_root, new_root);
         let rows_len = rows.len();
-        let mut updates = BTreeMap::new(); // TODO: preallocate
+        let mut updates: BTreeMap<_, Vec<_>> = BTreeMap::new(); // TODO: preallocate
         for (key, row) in rows.iter().filter_map(|row| key(row).map(|key| (key, row))) {
-            updates.entry(key).or_insert_with(Vec::new).push(*row); // TODO: preallocate
+            updates.entry(key).or_default().push(*row); // TODO: preallocate
         }
         let updates: BTreeMap<_, _> = updates
             .into_iter()


### PR DESCRIPTION
### Description

Reference [N-07](https://defender.openzeppelin.com/v2/#/audit/17fcde89-5506-43fb-98d0-3563a6557698/issues/N-07):

> The codebase contains some instances where the HashMap method or_insert_with is being used to construct default values. Some examples:
    [Line 73](https://github.com/scroll-tech/zkevm-circuits/blob/7fe99fe4e3de14801f4d66f75bd35307de39b0a8/bus-mapping/src/circuit_input_builder/access.rs#L73)
    [Line 92](https://github.com/scroll-tech/zkevm-circuits/blob/7fe99fe4e3de14801f4d66f75bd35307de39b0a8/bus-mapping/src/circuit_input_builder/access.rs#L92)
For cleaner and more efficient code, consider replacing instances of or_insert_with that are used for simple default value initialization with the more concise or_default() method.