### PR TITLE
[OpenZeppelin audit N-05] fix typos in bus-mapping

### DIFF
--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -74,7 +74,7 @@ pub struct BlockHead {
     /// chain id
     pub chain_id: u64,
     /// history hashes contains most recent 256 block hashes in history, where
-    /// the lastest one is at history_hashes[history_hashes.len() - 1].
+    /// the latest one is at history_hashes[history_hashes.len() - 1].
     pub history_hashes: Vec<Word>,
     /// coinbase
     pub coinbase: Address,
@@ -204,7 +204,7 @@ pub struct Block {
     pub block_steps: BlockSteps,
     /// Exponentiation events in the block.
     pub exp_events: Vec<ExpEvent>,
-    /// Circuits Setup Paramteres
+    /// Circuits Setup Parameters
     pub circuits_params: CircuitsParams,
     /// chain id
     pub chain_id: u64,

--- a/bus-mapping/src/circuit_input_builder/call.rs
+++ b/bus-mapping/src/circuit_input_builder/call.rs
@@ -61,7 +61,7 @@ pub struct Call {
     pub kind: CallKind,
     /// This call is being executed without write access (STATIC)
     pub is_static: bool,
-    /// This call generated implicity by a Transaction.
+    /// This call is generated implicitly by a Transaction
     pub is_root: bool,
     /// This call is persistent or call stack reverts at some point
     pub is_persistent: bool,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -2173,7 +2173,7 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
-    // write all chunks to memroy word and add prev bytes
+    // write all chunks to memory word and add prev bytes
     pub(crate) fn write_chunks(
         &mut self,
         exec_step: &mut ExecStep,

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -25,7 +25,7 @@ use mock::{
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
 
-// Helper struct that contains a CircuitInputBuilder, a particuar tx and a
+// Helper struct that contains a CircuitInputBuilder, a particular tx and a
 // particular execution step so that we can easily get a
 // CircuitInputStateRef to have a context in order to get the error at a
 // given step.


### PR DESCRIPTION
### Description

Reference [N-05](https://defender.openzeppelin.com/v2/#/audit/17fcde89-5506-43fb-98d0-3563a6557698/issues/N-05):

> Throughout the codebase, there are some instances of typographical errors in comments and docstrings:
    In [line 77](https://github.com/scroll-tech/zkevm-circuits/blob/7fe99fe4e3de14801f4d66f75bd35307de39b0a8/bus-mapping/src/circuit_input_builder/block.rs#L77) of the block module: "lastest" should be "latest".
    In [line 207](https://github.com/scroll-tech/zkevm-circuits/blob/7fe99fe4e3de14801f4d66f75bd35307de39b0a8/bus-mapping/src/circuit_input_builder/block.rs#L207) of the block module: "Paramteres" should be "Parameters".
    In [line 64](https://github.com/scroll-tech/zkevm-circuits/blob/7fe99fe4e3de14801f4d66f75bd35307de39b0a8/bus-mapping/src/circuit_input_builder/call.rs#L64) of the call module: "This call generated implicity by a Transaction" should be "This call is generated implicitly by a Transaction".
    In [line 2157](https://github.com/scroll-tech/zkevm-circuits/blob/7fe99fe4e3de14801f4d66f75bd35307de39b0a8/bus-mapping/src/circuit_input_builder/input_state_ref.rs#L2157) of the input_state_ref module: "memroy" should be "memory".
    In [line 28](https://github.com/scroll-tech/zkevm-circuits/blob/7fe99fe4e3de14801f4d66f75bd35307de39b0a8/bus-mapping/src/circuit_input_builder/tracer_tests.rs#L28) of the tracer_tests module: "particuar" should be "particular".
Consider updating the lines identified above. Furthermore, consider applying an automated spelling and grammar checker to your codebase to identify any other instances.
