### PR TITLE
parallel assignment of evm circuit

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -260,6 +260,7 @@ impl<F: Field> EvmCircuit<F> {
         num_rows
     }
 
+    #[deprecated]
     pub fn get_num_rows_required(block: &Block<F>) -> usize {
         let evm_rows = block.circuits_params.max_evm_rows;
         if evm_rows == 0 {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -260,7 +260,6 @@ impl<F: Field> EvmCircuit<F> {
         num_rows
     }
 
-    #[deprecated]
     pub fn get_num_rows_required(block: &Block<F>) -> usize {
         let evm_rows = block.circuits_params.max_evm_rows;
         if evm_rows == 0 {

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -966,6 +966,15 @@ impl<F: Field> ExecutionConfig<F> {
         }
     }
 
+    pub fn get_num_rows_required_no_padding(&self, block: &Block<F>) -> usize {
+        let mut num_rows = 0;
+        for transaction in &block.txs {
+            for step in &transaction.steps {
+                num_rows += step.execution_state.get_step_height();
+            }
+        }
+        num_rows
+    }
     pub fn get_num_rows_required(&self, block: &Block<F>) -> usize {
         // Start at 1 so we can be sure there is an unused `next` row available
         let mut num_rows = 1;
@@ -1027,96 +1036,155 @@ impl<F: Field> ExecutionConfig<F> {
         block: &Block<F>,
         challenges: &Challenges<Value<F>>,
     ) -> Result<EvmCircuitExports<Assigned<F>>, Error> {
-        let mut is_first_time = true;
+        debug_assert_eq!(ExecutionState::EndBlock.get_step_height(), 1);
 
+        let inverter = Inverter::new(MAX_STEP_HEIGHT as u64);
+        let evm_rows = block.circuits_params.max_evm_rows;
+        let no_padding = evm_rows == 0;
+
+        // There should be 3 group of regions
+        // 1. real steps
+        // 2. padding EndBlocks. Even for `no_padding`, we will still pad 1 end_block_not_last
+        // 3. final EndBlock
+        let region1_height = self.get_num_rows_required_no_padding(block);
+        let region3_height = 2; // EndBlock, plus a dummy "next" row
+        let region2_height = if no_padding {
+            1
+        } else {
+            evm_rows - region3_height - region1_height
+        };
+        let total_height = region1_height + region2_height + region3_height;
+        if evm_rows != 0 {
+            if total_height > evm_rows {
+                log::error!(
+                    "evm circuit row not enough, offset: {}+{}+{}, max_evm_rows: {}",
+                    region1_height,
+                    region2_height,
+                    region3_height,
+                    evm_rows
+                );
+                return Err(Error::Synthesis);
+            }
+            debug_assert_eq!(total_height, evm_rows);
+        }
+
+        let mut region1_is_first_time = true;
+        let mut region2_is_first_time = true;
+        let mut region3_is_first_time = true;
+
+        let assign_shape = |region: &mut Region<'_, F>, height| {
+            region.assign_advice(
+                || "step selector",
+                self.q_step,
+                height - 1,
+                || Value::known(F::zero()),
+            )?;
+            return Ok(());
+        };
+
+        let dummy_tx = Transaction::default();
+        let last_call = block
+            .txs
+            .last()
+            .map(|tx| tx.calls[0].clone())
+            .unwrap_or_else(Call::default);
+        let end_block_not_last = &block.end_block_not_last;
+        let end_block_last = &block.end_block_last;
+
+        struct StepAssignment {
+            tx_idx: usize,
+            step_idx: usize,
+            offset: usize,
+        }
+        let mut step_assignments: Vec<StepAssignment> = Vec::new();
+        let total_step_num = block.txs.iter().map(|t| t.steps.len()).sum::<usize>();
+        let mut offset = 0;
+        step_assignments.reserve(total_step_num);
+        for (tx_idx, tx) in block.txs.iter().enumerate() {
+            for (step_idx, step) in tx.steps.iter().enumerate() {
+                let height = step.execution_state.get_step_height();
+                step_assignments.push(StepAssignment {
+                    tx_idx,
+                    step_idx,
+                    offset,
+                });
+                offset += height;
+            }
+        }
+        assert_eq!(offset, region1_height);
+        offset = 0;
+
+        let log_step_fn = |transaction: &Transaction, step: &ExecStep, offset| {
+            if step.execution_state == ExecutionState::EndTx {
+                let mut tx = transaction.clone();
+                tx.call_data.clear();
+                tx.calls.clear();
+                tx.steps.clear();
+                tx.rlp_signed.clear();
+                tx.rlp_unsigned.clear();
+                let total_gas = {
+                    let gas_used = tx.gas - step.gas_left;
+                    let current_cumulative_gas_used: u64 = if tx.id == 1 {
+                        0
+                    } else {
+                        // first transaction needs TxReceiptFieldTag::COUNT(3) lookups
+                        // to tx receipt,
+                        // while later transactions need 4 (with one extra cumulative
+                        // gas read) lookups
+                        let rw = &block.rws[(
+                            RwTableTag::TxReceipt,
+                            (tx.id - 2) * (TxReceiptFieldTag::COUNT + 1) + 2,
+                        )];
+                        rw.receipt_value()
+                    };
+                    current_cumulative_gas_used + gas_used
+                };
+                log::info!(
+                    "offset {} tx_num {} total_gas {} assign last step {:?} of tx {:?}",
+                    offset,
+                    tx.id,
+                    total_gas,
+                    step,
+                    tx
+                );
+            }
+        };
+
+        // Step1: assign real steps
         layouter.assign_region(
-            || "Execution step",
+            || "Execution step region1",
             |mut region| {
-                if is_first_time {
-                    is_first_time = false;
-                    region.assign_advice(
-                        || "step selector",
-                        self.q_step,
-                        self.get_num_rows_required(block) - 1,
-                        || Value::known(F::zero()),
-                    )?;
-                    return Ok(());
+                if region1_is_first_time {
+                    region1_is_first_time = false;
+                    return assign_shape(&mut region, region1_height);
                 }
                 let mut offset = 0;
-
-                let inverter = Inverter::new(MAX_STEP_HEIGHT as u64);
 
                 // Annotate the EVMCircuit columns within it's single region.
                 self.annotate_circuit(&mut region);
 
                 self.q_step_first.enable(&mut region, offset)?;
 
-                let dummy_tx = Transaction::default();
-                let last_call = block
-                    .txs
-                    .last()
-                    .map(|tx| tx.calls[0].clone())
-                    .unwrap_or_else(Call::default);
-                let end_block_not_last = &block.end_block_not_last;
-                let end_block_last = &block.end_block_last;
-                // Collect all steps
-                let mut steps = block
-                    .txs
-                    .iter()
-                    .flat_map(|tx| {
-                        tx.steps
-                            .iter()
-                            .map(move |step| (tx, &tx.calls[step.call_index], step))
-                    })
-                    .chain(std::iter::once((&dummy_tx, &last_call, end_block_not_last)))
-                    .peekable();
+                for (idx, step_assignment) in step_assignments.iter().enumerate() {
+                    let transaction = &block.txs[step_assignment.tx_idx];
+                    let step = &transaction.steps[step_assignment.step_idx];
+                    let call = &transaction.calls[step.call_index];
 
-                let evm_rows = block.circuits_params.max_evm_rows;
-                let no_padding = evm_rows == 0;
-
-                // part1: assign real steps
-                loop {
-                    let (transaction, call, step) = steps.next().expect("should not be empty");
-                    let next = steps.peek();
-                    if next.is_none() {
-                        break;
-                    }
                     let height = step.execution_state.get_step_height();
 
-                    // Assign the step witness
-                    if step.execution_state == ExecutionState::EndTx {
-                        let mut tx = transaction.clone();
-                        tx.call_data.clear();
-                        tx.calls.clear();
-                        tx.steps.clear();
-                        tx.rlp_signed.clear();
-                        tx.rlp_unsigned.clear();
-                        let total_gas = {
-                            let gas_used = tx.gas - step.gas_left;
-                            let current_cumulative_gas_used: u64 = if tx.id == 1 {
-                                0
-                            } else {
-                                // first transaction needs TxReceiptFieldTag::COUNT(3) lookups
-                                // to tx receipt,
-                                // while later transactions need 4 (with one extra cumulative
-                                // gas read) lookups
-                                let rw = &block.rws[(
-                                    RwTableTag::TxReceipt,
-                                    (tx.id - 2) * (TxReceiptFieldTag::COUNT + 1) + 2,
-                                )];
-                                rw.receipt_value()
-                            };
-                            current_cumulative_gas_used + gas_used
-                        };
-                        log::info!(
-                            "offset {} tx_num {} total_gas {} assign last step {:?} of tx {:?}",
-                            offset,
-                            tx.id,
-                            total_gas,
-                            step,
-                            tx
-                        );
-                    }
+                    log_step_fn(&transaction, &step, offset);
+
+                    let next = match step_assignments.get(idx + 1) {
+                        None => (&dummy_tx, &last_call, end_block_not_last),
+                        Some(step_assignment) => {
+                            // refactor here
+                            let transaction = &block.txs[step_assignment.tx_idx];
+                            let step = &transaction.steps[step_assignment.step_idx];
+                            let call = &transaction.calls[step.call_index];
+                            (transaction, call, step)
+                        }
+                    };
+
                     self.assign_exec_step(
                         &mut region,
                         offset,
@@ -1125,57 +1193,63 @@ impl<F: Field> ExecutionConfig<F> {
                         call,
                         step,
                         height,
-                        next.copied(),
+                        Some(next),
                         challenges,
                     )?;
 
-                    // q_step logic
                     self.assign_q_step(&mut region, &inverter, offset, height)?;
 
                     offset += height;
                 }
 
-                // part2: assign non-last EndBlock steps when padding needed
-                if !no_padding {
-                    let height = ExecutionState::EndBlock.get_step_height();
-                    debug_assert_eq!(height, 1);
-                    // 1 for EndBlock(last), 1 for "part 4" cells
-                    let last_row = evm_rows - 2;
-                    log::trace!(
-                        "assign non-last EndBlock in range [{},{})",
-                        offset,
-                        last_row
-                    );
-                    if offset > last_row {
-                        log::error!(
-                            "evm circuit row not enough, offset: {}, max_evm_rows: {}",
-                            offset,
-                            evm_rows
-                        );
-                        return Err(Error::Synthesis);
-                    }
-                    self.assign_same_exec_step_in_range(
-                        &mut region,
-                        offset,
-                        last_row,
-                        block,
-                        &dummy_tx,
-                        &last_call,
-                        end_block_not_last,
-                        height,
-                        challenges,
-                    )?;
+                Ok(())
+            },
+        )?;
 
-                    for row_idx in offset..last_row {
-                        self.assign_q_step(&mut region, &inverter, row_idx, height)?;
-                    }
-                    offset = last_row;
+        // part2: assign non-last EndBlock steps when padding needed
+        layouter.assign_region(
+            || "Execution step region2",
+            |mut region| {
+                if region2_is_first_time {
+                    region2_is_first_time = false;
+                    return assign_shape(&mut region, region2_height);
                 }
+                log::trace!(
+                    "assign non-last EndBlock in range [{},{})",
+                    region1_height,
+                    region1_height + region2_height
+                );
+                self.assign_same_exec_step_in_range(
+                    &mut region,
+                    0,
+                    region2_height,
+                    block,
+                    &dummy_tx,
+                    &last_call,
+                    end_block_not_last,
+                    1,
+                    challenges,
+                )?;
+                for row_idx in 0..region2_height {
+                    self.assign_q_step(&mut region, &inverter, row_idx, 1)?;
+                }
+                Ok(())
+            },
+        )?;
 
-                // part3: assign the last EndBlock at offset `evm_rows - 1`
-                let height = ExecutionState::EndBlock.get_step_height();
-                debug_assert_eq!(height, 1);
-                log::trace!("assign last EndBlock at offset {}", offset);
+        // part3: assign the last EndBlock at offset `evm_rows - 1`
+        // This region don't need to be parallelized
+        log::trace!(
+            "assign last EndBlock at offset {}",
+            region1_height + region2_height
+        );
+        layouter.assign_region(
+            || "Execution step region3",
+            |mut region| {
+                if region3_is_first_time {
+                    region3_is_first_time = false;
+                    return assign_shape(&mut region, region3_height);
+                }
                 self.assign_exec_step(
                     &mut region,
                     offset,
@@ -1183,31 +1257,26 @@ impl<F: Field> ExecutionConfig<F> {
                     &dummy_tx,
                     &last_call,
                     end_block_last,
-                    height,
+                    1,
                     None,
                     challenges,
                 )?;
-                self.assign_q_step(&mut region, &inverter, offset, height)?;
-                // enable q_step_last
+                self.assign_q_step(&mut region, &inverter, offset, 1)?;
                 self.q_step_last.enable(&mut region, offset)?;
-                offset += height;
-
                 // part4:
                 // These are still referenced (but not used) in next rows
                 region.assign_advice(
                     || "step height",
                     self.num_rows_until_next_step,
-                    offset,
+                    1,
                     || Value::known(F::zero()),
                 )?;
                 region.assign_advice(
                     || "step height inv",
                     self.q_step,
-                    offset,
+                    1,
                     || Value::known(F::zero()),
                 )?;
-
-                log::debug!("assign for region done at offset {}", offset);
                 Ok(())
             },
         )?;

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1153,6 +1153,9 @@ impl<F: Field> ExecutionConfig<F> {
         };
 
         let chunking_fn = |name: &str, rows_len: usize| -> (usize, usize) {
+            if rows_len == 0 {
+                return (0, 0);
+            }
             let num_threads = std::thread::available_parallelism()
                 .map(|e| e.get())
                 .unwrap_or(1);
@@ -1379,12 +1382,6 @@ impl<F: Field> ExecutionConfig<F> {
             .lock()
             .unwrap()
             .expect("withdraw_root cell should has been assigned");
-
-        // sanity check
-        let evm_rows = block.circuits_params.max_evm_rows;
-        if evm_rows >= 2 {
-            assert_eq!(final_withdraw_root_cell.row_offset, evm_rows - 2);
-        }
 
         let withdraw_root_rlc = challenges
             .evm_word()

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -453,7 +453,7 @@ impl<F: Field> ExecutionConfig<F> {
             let q_step_last = meta.query_selector(q_step_last);
             let q_step = meta.query_advice(q_step, Rotation::cur());
             let num_rows_left_cur = meta.query_advice(num_rows_until_next_step, Rotation::cur());
-            let num_rows_left_next = meta.query_advice(num_rows_until_next_step, Rotation::next());
+            //let num_rows_left_next = meta.query_advice(num_rows_until_next_step, Rotation::next());
             let num_rows_left_inverse = meta.query_advice(num_rows_inv, Rotation::cur());
 
             let mut cb = BaseConstraintBuilder::default();
@@ -480,6 +480,7 @@ impl<F: Field> ExecutionConfig<F> {
                 cb.require_equal("q_step == 1", q_step.clone(), 1.expr());
             });
             // Except when step is enabled, the step counter needs to decrease by 1
+            /* 
             cb.condition(1.expr() - q_step.clone(), |cb| {
                 cb.require_equal(
                     "num_rows_left_cur := num_rows_left_next + 1",
@@ -487,6 +488,7 @@ impl<F: Field> ExecutionConfig<F> {
                     num_rows_left_next + 1.expr(),
                 );
             });
+            */
             // Enforce that q_step := num_rows_until_next_step == 0
             let is_zero = 1.expr() - (num_rows_left_cur.clone() * num_rows_left_inverse.clone());
             cb.require_zero(

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
@@ -23,7 +25,7 @@ use halo2_proofs::{
     plonk::{Error, Expression},
 };
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct EndBlockGadget<F> {
     total_txs: Cell<F>,
     total_txs_is_max_txs: IsEqualGadget<F>,
@@ -32,7 +34,23 @@ pub(crate) struct EndBlockGadget<F> {
     max_txs: Cell<F>,
     phase2_withdraw_root: Cell<F>,
     phase2_withdraw_root_prev: Cell<F>,
-    pub withdraw_root_assigned: std::cell::RefCell<Option<AssignedCell>>,
+    pub withdraw_root_assigned: Mutex<Option<AssignedCell>>,
+}
+
+impl<F: Clone> Clone for EndBlockGadget<F> {
+    fn clone(&self) -> Self {
+        let withdraw_root_assigned = self.withdraw_root_assigned.lock().unwrap().clone();
+        Self {
+            withdraw_root_assigned: Mutex::new(withdraw_root_assigned),
+            total_txs: self.total_txs.clone(),
+            total_txs_is_max_txs: self.total_txs_is_max_txs.clone(),
+            is_empty_block: self.is_empty_block.clone(),
+            max_rws: self.max_rws.clone(),
+            max_txs: self.max_txs.clone(),
+            phase2_withdraw_root: self.phase2_withdraw_root.clone(),
+            phase2_withdraw_root_prev: self.phase2_withdraw_root_prev.clone(),
+        }
+    }
 }
 
 const EMPTY_BLOCK_N_RWS: u64 = 0;
@@ -172,10 +190,9 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
             offset,
             region.word_rlc(block.prev_withdraw_root),
         )?;
-
-        self.withdraw_root_assigned
-            .borrow_mut()
-            .replace(withdraw_root.cell());
+        if let Some(cell) = withdraw_root {
+            *self.withdraw_root_assigned.lock().unwrap() = Some(cell.cell());
+        }
         // TODO: now we do not export withdraw_root_prev for we have only one
         // phase2 cell which is enabled for copy constraint
         // self.withdraw_root_prev_assigned
@@ -185,8 +202,8 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
         // When rw_indices is not empty, we're at the last row (at a fixed offset),
         // where we need to access the max_rws and max_txs constant.
         if !step.rw_indices.is_empty() {
-            region.constrain_constant(max_rws_assigned, max_rws)?;
-            region.constrain_constant(max_txs_assigned, max_txs)?;
+            region.constrain_constant(max_rws_assigned.unwrap(), max_rws)?;
+            region.constrain_constant(max_txs_assigned.unwrap(), max_txs)?;
         }
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -39,7 +39,8 @@ pub(crate) struct EndBlockGadget<F> {
 
 impl<F: Clone> Clone for EndBlockGadget<F> {
     fn clone(&self) -> Self {
-        let withdraw_root_assigned = self.withdraw_root_assigned.lock().unwrap().clone();
+        let withdraw_root_assigned: Option<AssignedCell> =
+            *self.withdraw_root_assigned.lock().unwrap();
         Self {
             withdraw_root_assigned: Mutex::new(withdraw_root_assigned),
             total_txs: self.total_txs.clone(),

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -169,7 +169,7 @@ impl<'r, 'b, F: FieldExt> CachedRegion<'r, 'b, F> {
         AR: Into<String>,
     {
         // Actually set the value
-        log::info!("Cached assign at {offset}");
+        // log::info!("Cached assign at {offset}");
         if offset - self.height_start < self.height_limit {
             let res = self.region.assign_advice(annotation, column, offset, &to);
             // Cache the value

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
@@ -203,6 +203,7 @@ impl<F: Field, G: MathGadgetContainer<F>> Circuit<F> for UnitTestMathGadgetBaseC
                     &challenge_values,
                     config.advices.to_vec(),
                     MAX_STEP_HEIGHT * 3,
+                    MAX_STEP_HEIGHT * 3,
                     offset,
                 );
                 config.step.state.execution_state.assign(


### PR DESCRIPTION
in this PR, assignment of evm circuit is split into 3 groups of regions:

1. real steps
2. padding EndBlock 
3. real final EndBlock and remaining assignments

only the (1)(2) need to be parallelized.

btw, the halo2 parallel assignment API is already very stable, so this time i am not going to use a env var to control whether to enable parallel assignment