### PR TITLE
Refactor: `PrecompileGadget` and precompile states

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -1251,6 +1251,10 @@ pub struct EcPairingOp {
     pub pairs: [EcPairingPair; N_PAIRING_PER_OP],
     /// Result from the pairing check.
     pub output: Word,
+    /// Input bytes to the ecPairing call.
+    pub input_bytes: Vec<u8>,
+    /// Bytes returned back to the caller.
+    pub return_bytes: Vec<u8>,
 }
 
 impl Default for EcPairingOp {
@@ -1283,6 +1287,12 @@ impl Default for EcPairingOp {
                 },
             ],
             output: Word::zero(),
+            // It does not matter what the input bytes and return bytes are in this case, as this
+            // operation is a filler op. It is not an op constructed from an EVM call to the
+            // ecPairing precompiled contract. Hence the input/return bytes will not be
+            // constrained.
+            input_bytes: vec![],
+            return_bytes: vec![],
         }
     }
 }
@@ -1321,6 +1331,7 @@ impl EcPairingOp {
                 EcPairingPair::new(G1Affine::identity(), G2Affine::generator()),
             ],
             output: 1.into(),
+            ..Default::default()
         }
     }
 }

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -976,13 +976,17 @@ impl EcAddOp {
             })
         };
 
-        assert_eq!(input.len(), 128);
-        assert_eq!(output.len(), 64);
+        let mut resized_input = input.to_vec();
+        resized_input.resize(128, 0u8);
+        let mut resized_output = output.to_vec();
+        resized_output.resize(64, 0u8);
 
         let mut buf = [0u8; 32];
-        let opt_point_p: Option<G1Affine> = g1_from_slice(&mut buf, &input[0x00..0x40]).into();
-        let opt_point_q: Option<G1Affine> = g1_from_slice(&mut buf, &input[0x40..0x80]).into();
-        let point_r_evm = g1_from_slice(&mut buf, &output[0x00..0x40]).unwrap();
+        let opt_point_p: Option<G1Affine> =
+            g1_from_slice(&mut buf, &resized_input[0x00..0x40]).into();
+        let opt_point_q: Option<G1Affine> =
+            g1_from_slice(&mut buf, &resized_input[0x40..0x80]).into();
+        let point_r_evm = g1_from_slice(&mut buf, &resized_output[0x00..0x40]).unwrap();
         let point_r_cal = opt_point_p.zip(opt_point_q).map(|(point_p, point_q)| {
             let point_r: G1Affine = point_p.add(&point_q).into();
             debug_assert_eq!(
@@ -994,12 +998,12 @@ impl EcAddOp {
 
         Self {
             p: (
-                U256::from_big_endian(&input[0x00..0x20]),
-                U256::from_big_endian(&input[0x20..0x40]),
+                U256::from_big_endian(&resized_input[0x00..0x20]),
+                U256::from_big_endian(&resized_input[0x20..0x40]),
             ),
             q: (
-                U256::from_big_endian(&input[0x40..0x60]),
-                U256::from_big_endian(&input[0x60..0x80]),
+                U256::from_big_endian(&resized_input[0x40..0x60]),
+                U256::from_big_endian(&resized_input[0x60..0x80]),
             ),
             r: point_r_cal,
         }
@@ -1078,14 +1082,17 @@ impl EcMulOp {
             })
         };
 
-        assert_eq!(input.len(), 96);
-        assert_eq!(output.len(), 64);
+        let mut resized_input = input.to_vec();
+        resized_input.resize(96, 0u8);
+        let mut resized_output = output.to_vec();
+        resized_output.resize(64, 0u8);
 
         let mut buf = [0u8; 32];
 
-        let opt_point_p: Option<G1Affine> = g1_from_slice(&mut buf, &input[0x00..0x40]).into();
-        let s = Fr::from_raw(Word::from_big_endian(&input[0x40..0x60]).0);
-        let point_r_evm = g1_from_slice(&mut buf, &output[0x00..0x40]).unwrap();
+        let opt_point_p: Option<G1Affine> =
+            g1_from_slice(&mut buf, &resized_input[0x00..0x40]).into();
+        let s = Fr::from_raw(Word::from_big_endian(&resized_input[0x40..0x60]).0);
+        let point_r_evm = g1_from_slice(&mut buf, &resized_output[0x00..0x40]).unwrap();
         let point_r_cal = opt_point_p.map(|point_p| {
             let point_r: G1Affine = point_p.mul(s).into();
             debug_assert_eq!(
@@ -1097,8 +1104,8 @@ impl EcMulOp {
 
         Self {
             p: (
-                U256::from_big_endian(&input[0x00..0x20]),
-                U256::from_big_endian(&input[0x20..0x40]),
+                U256::from_big_endian(&resized_input[0x00..0x20]),
+                U256::from_big_endian(&resized_input[0x20..0x40]),
             ),
             s,
             r: point_r_cal,
@@ -1253,6 +1260,8 @@ pub struct EcPairingOp {
     pub output: Word,
     /// Input bytes to the ecPairing call.
     pub input_bytes: Vec<u8>,
+    /// Output bytes from the ecPairing call.
+    pub output_bytes: Vec<u8>,
     /// Bytes returned back to the caller.
     pub return_bytes: Vec<u8>,
 }
@@ -1292,6 +1301,7 @@ impl Default for EcPairingOp {
             // ecPairing precompiled contract. Hence the input/return bytes will not be
             // constrained.
             input_bytes: vec![],
+            output_bytes: vec![],
             return_bytes: vec![],
         }
     }

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -368,7 +368,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         .iter()
                         .filter(|(_, _, is_mask)| !*is_mask)
                         .map(|t| t.0)
-                        .collect();
+                        .collect::<Vec<u8>>();
                     state.push_copy(
                         &mut exec_step,
                         CopyEvent {
@@ -398,7 +398,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         .iter()
                         .filter(|(_, _, is_mask)| !*is_mask)
                         .map(|t| t.0)
-                        .collect();
+                        .collect::<Vec<u8>>();
                     state.push_copy(
                         &mut exec_step,
                         CopyEvent {
@@ -433,7 +433,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         .iter()
                         .filter(|(_, _, is_mask)| !*is_mask)
                         .map(|t| t.0)
-                        .collect();
+                        .collect::<Vec<u8>>();
                     state.push_copy(
                         &mut exec_step,
                         CopyEvent {
@@ -484,7 +484,9 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         geth_steps[1].clone(),
                         callee_call.clone(),
                         precompile_call,
-                        (input_bytes, output_bytes, returned_bytes),
+                        &input_bytes.unwrap_or_default(),
+                        &output_bytes.unwrap_or_default(),
+                        &returned_bytes.unwrap_or_default(),
                     )?;
 
                     // Set gas left and gas cost for precompile step.

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
@@ -4,25 +4,12 @@ use crate::{
 };
 
 pub(crate) fn opt_data(
-    input_bytes: Option<Vec<u8>>,
-    output_bytes: Option<Vec<u8>>,
-    return_bytes: Option<Vec<u8>>,
+    input_bytes: &[u8],
+    output_bytes: &[u8],
+    return_bytes: &[u8],
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
-    let input_bytes = input_bytes.map_or(vec![0u8; 128], |mut bytes| {
-        bytes.resize(128, 0u8);
-        bytes
-    });
-    let output_bytes = output_bytes.map_or(vec![0u8; 64], |mut bytes| {
-        bytes.resize(64, 0u8);
-        bytes
-    });
-
-    let aux_data = EcAddAuxData::new(
-        &input_bytes,
-        &output_bytes,
-        &return_bytes.unwrap_or_default(),
-    );
-    let ec_add_op = EcAddOp::new_from_bytes(&input_bytes, &output_bytes);
+    let aux_data = EcAddAuxData::new(input_bytes, output_bytes, return_bytes);
+    let ec_add_op = EcAddOp::new_from_bytes(input_bytes, output_bytes);
 
     (
         Some(PrecompileEvent::EcAdd(ec_add_op)),

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_add.rs
@@ -6,6 +6,7 @@ use crate::{
 pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
+    return_bytes: Option<Vec<u8>>,
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 128], |mut bytes| {
         bytes.resize(128, 0u8);
@@ -16,7 +17,11 @@ pub(crate) fn opt_data(
         bytes
     });
 
-    let aux_data = EcAddAuxData::new(&input_bytes, &output_bytes);
+    let aux_data = EcAddAuxData::new(
+        &input_bytes,
+        &output_bytes,
+        &return_bytes.unwrap_or_default(),
+    );
     let ec_add_op = EcAddOp::new_from_bytes(&input_bytes, &output_bytes);
 
     (

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
@@ -6,6 +6,7 @@ use crate::{
 pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
+    return_bytes: Option<Vec<u8>>,
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 96], |mut bytes| {
         bytes.resize(96, 0u8);
@@ -16,7 +17,11 @@ pub(crate) fn opt_data(
         bytes
     });
 
-    let aux_data = EcMulAuxData::new(&input_bytes, &output_bytes);
+    let aux_data = EcMulAuxData::new(
+        &input_bytes,
+        &output_bytes,
+        &return_bytes.unwrap_or_default(),
+    );
     let ec_mul_op = EcMulOp::new_from_bytes(&input_bytes, &output_bytes);
 
     (

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_mul.rs
@@ -4,25 +4,12 @@ use crate::{
 };
 
 pub(crate) fn opt_data(
-    input_bytes: Option<Vec<u8>>,
-    output_bytes: Option<Vec<u8>>,
-    return_bytes: Option<Vec<u8>>,
+    input_bytes: &[u8],
+    output_bytes: &[u8],
+    return_bytes: &[u8],
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
-    let input_bytes = input_bytes.map_or(vec![0u8; 96], |mut bytes| {
-        bytes.resize(96, 0u8);
-        bytes
-    });
-    let output_bytes = output_bytes.map_or(vec![0u8; 64], |mut bytes| {
-        bytes.resize(64, 0u8);
-        bytes
-    });
-
-    let aux_data = EcMulAuxData::new(
-        &input_bytes,
-        &output_bytes,
-        &return_bytes.unwrap_or_default(),
-    );
-    let ec_mul_op = EcMulOp::new_from_bytes(&input_bytes, &output_bytes);
+    let aux_data = EcMulAuxData::new(input_bytes, output_bytes, return_bytes);
+    let ec_mul_op = EcMulOp::new_from_bytes(input_bytes, output_bytes);
 
     (
         Some(PrecompileEvent::EcMul(ec_mul_op)),

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
@@ -11,6 +11,7 @@ use crate::{
 pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
+    return_bytes: Option<Vec<u8>>,
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     // assertions.
     let pairing_check = output_bytes.map_or(U256::zero(), |output| {
@@ -73,12 +74,16 @@ pub(crate) fn opt_data(
         EcPairingOp {
             pairs: <[_; N_PAIRING_PER_OP]>::try_from(pairs).unwrap(),
             output: pairing_check,
+            input_bytes: input,
+            return_bytes: return_bytes.unwrap_or_default(),
         }
     } else {
         let pairs = [EcPairingPair::padding_pair(); N_PAIRING_PER_OP];
         EcPairingOp {
             pairs,
             output: pairing_check,
+            input_bytes: vec![],
+            return_bytes: return_bytes.unwrap_or_default(),
         }
     };
 

--- a/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ec_pairing.rs
@@ -9,49 +9,51 @@ use crate::{
 };
 
 pub(crate) fn opt_data(
-    input_bytes: Option<Vec<u8>>,
-    output_bytes: Option<Vec<u8>>,
-    return_bytes: Option<Vec<u8>>,
+    input_bytes: &[u8],
+    output_bytes: &[u8],
+    return_bytes: &[u8],
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     // assertions.
-    let pairing_check = output_bytes.map_or(U256::zero(), |output| {
+    let pairing_check = if output_bytes.is_empty() {
+        U256::zero()
+    } else {
         debug_assert_eq!(
-            output.len(),
+            output_bytes.len(),
             32,
             "len(output)={:?}, expected={:?}",
-            output.len(),
+            output_bytes.len(),
             32
         );
-        U256::from(output[31])
-    });
+        U256::from_big_endian(output_bytes)
+    };
     debug_assert!(
         pairing_check.eq(&U256::one()) || pairing_check.is_zero(),
         "ecPairing returns 1 or 0"
     );
-    if input_bytes.is_none() {
+    if input_bytes.is_empty() {
         debug_assert!(
             pairing_check.eq(&U256::one()),
             "for zero inputs, pairing check == 1"
         );
     }
 
-    let op = if let Some(input) = input_bytes {
-        if (input.len() > N_PAIRING_PER_OP * N_BYTES_PER_PAIR)
-            || (input.len() % N_BYTES_PER_PAIR != 0)
+    let op = if !input_bytes.is_empty() {
+        if (input_bytes.len() > N_PAIRING_PER_OP * N_BYTES_PER_PAIR)
+            || (input_bytes.len() % N_BYTES_PER_PAIR != 0)
         {
             return (
                 None,
                 Some(PrecompileAuxData::EcPairing(Box::new(Err(
-                    EcPairingError::InvalidInputLen(input),
+                    EcPairingError::InvalidInputLen(input_bytes.to_vec()),
                 )))),
             );
         }
         debug_assert!(
-            input.len() % N_BYTES_PER_PAIR == 0
-                && input.len() <= N_PAIRING_PER_OP * N_BYTES_PER_PAIR
+            input_bytes.len() % N_BYTES_PER_PAIR == 0
+                && input_bytes.len() <= N_PAIRING_PER_OP * N_BYTES_PER_PAIR
         );
         // process input bytes.
-        let mut pairs = input
+        let mut pairs = input_bytes
             .chunks_exact(N_BYTES_PER_PAIR)
             .map(|chunk| {
                 // process <= 192 bytes chunk at a time.
@@ -74,8 +76,9 @@ pub(crate) fn opt_data(
         EcPairingOp {
             pairs: <[_; N_PAIRING_PER_OP]>::try_from(pairs).unwrap(),
             output: pairing_check,
-            input_bytes: input,
-            return_bytes: return_bytes.unwrap_or_default(),
+            input_bytes: input_bytes.to_vec(),
+            output_bytes: output_bytes.to_vec(),
+            return_bytes: return_bytes.to_vec(),
         }
     } else {
         let pairs = [EcPairingPair::padding_pair(); N_PAIRING_PER_OP];
@@ -83,7 +86,8 @@ pub(crate) fn opt_data(
             pairs,
             output: pairing_check,
             input_bytes: vec![],
-            return_bytes: return_bytes.unwrap_or_default(),
+            output_bytes: output_bytes.to_vec(),
+            return_bytes: return_bytes.to_vec(),
         }
     };
 

--- a/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
@@ -14,23 +14,11 @@ use crate::{
 };
 
 pub(crate) fn opt_data(
-    input_bytes: Option<Vec<u8>>,
-    output_bytes: Option<Vec<u8>>,
-    return_bytes: Option<Vec<u8>>,
+    input_bytes: &[u8],
+    output_bytes: &[u8],
+    return_bytes: &[u8],
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
-    let input_bytes = input_bytes.map_or(vec![0u8; 128], |mut bytes| {
-        bytes.resize(128, 0u8);
-        bytes
-    });
-    let output_bytes = output_bytes.map_or(vec![0u8; 32], |mut bytes| {
-        bytes.resize(32, 0u8);
-        bytes
-    });
-    let aux_data = EcrecoverAuxData::new(
-        &input_bytes,
-        &output_bytes,
-        &return_bytes.unwrap_or_default(),
-    );
+    let aux_data = EcrecoverAuxData::new(input_bytes, output_bytes, return_bytes);
 
     // We skip the validation through sig circuit if r or s was not in canonical form.
     let opt_sig_r: Option<Fq> = Fq::from_bytes(&aux_data.sig_r.to_le_bytes()).into();

--- a/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/ecrecover.rs
@@ -16,6 +16,7 @@ use crate::{
 pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
+    return_bytes: Option<Vec<u8>>,
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let input_bytes = input_bytes.map_or(vec![0u8; 128], |mut bytes| {
         bytes.resize(128, 0u8);
@@ -25,7 +26,11 @@ pub(crate) fn opt_data(
         bytes.resize(32, 0u8);
         bytes
     });
-    let aux_data = EcrecoverAuxData::new(input_bytes, output_bytes);
+    let aux_data = EcrecoverAuxData::new(
+        &input_bytes,
+        &output_bytes,
+        &return_bytes.unwrap_or_default(),
+    );
 
     // We skip the validation through sig circuit if r or s was not in canonical form.
     let opt_sig_r: Option<Fq> = Fq::from_bytes(&aux_data.sig_r.to_le_bytes()).into();

--- a/bus-mapping/src/evm/opcodes/precompiles/mod.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/mod.rs
@@ -3,7 +3,7 @@ use eth_types::{GethExecStep, ToWord, Word};
 use crate::{
     circuit_input_builder::{Call, CircuitInputStateRef, ExecState, ExecStep},
     operation::CallContextField,
-    precompile::PrecompileCalls,
+    precompile::{PrecompileAuxData, PrecompileCalls},
     Error,
 };
 
@@ -26,7 +26,7 @@ pub fn gen_associated_ops(
     geth_step: GethExecStep,
     call: Call,
     precompile: PrecompileCalls,
-    (input_bytes, output_bytes, _returned_bytes): InOutRetData,
+    (input_bytes, output_bytes, return_bytes): InOutRetData,
 ) -> Result<ExecStep, Error> {
     assert_eq!(call.code_address(), Some(precompile.into()));
     let mut exec_step = state.new_step(&geth_step)?;
@@ -35,12 +35,20 @@ pub fn gen_associated_ops(
     common_call_ctx_reads(state, &mut exec_step, &call)?;
 
     let (opt_event, aux_data) = match precompile {
-        PrecompileCalls::Ecrecover => opt_data_ecrecover(input_bytes, output_bytes),
-        PrecompileCalls::Bn128Add => opt_data_ec_add(input_bytes, output_bytes),
-        PrecompileCalls::Bn128Mul => opt_data_ec_mul(input_bytes, output_bytes),
-        PrecompileCalls::Bn128Pairing => opt_data_ec_pairing(input_bytes, output_bytes),
-        PrecompileCalls::Modexp => opt_data_modexp(input_bytes, output_bytes),
-        PrecompileCalls::Identity => (None, None),
+        PrecompileCalls::Ecrecover => opt_data_ecrecover(input_bytes, output_bytes, return_bytes),
+        PrecompileCalls::Bn128Add => opt_data_ec_add(input_bytes, output_bytes, return_bytes),
+        PrecompileCalls::Bn128Mul => opt_data_ec_mul(input_bytes, output_bytes, return_bytes),
+        PrecompileCalls::Bn128Pairing => {
+            opt_data_ec_pairing(input_bytes, output_bytes, return_bytes)
+        }
+        PrecompileCalls::Modexp => opt_data_modexp(input_bytes, output_bytes, return_bytes),
+        PrecompileCalls::Identity => (
+            None,
+            Some(PrecompileAuxData::Identity {
+                input_bytes: input_bytes.unwrap_or_default(),
+                return_bytes: return_bytes.unwrap_or_default(),
+            }),
+        ),
         _ => {
             log::warn!("precompile {:?} unsupported in circuits", precompile);
             (None, None)

--- a/bus-mapping/src/evm/opcodes/precompiles/mod.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/mod.rs
@@ -52,7 +52,14 @@ pub fn gen_associated_ops(
         ),
         _ => {
             log::warn!("precompile {:?} unsupported in circuits", precompile);
-            (None, None)
+            (
+                None,
+                Some(PrecompileAuxData::Base {
+                    input_bytes: input_bytes.to_vec(),
+                    output_bytes: output_bytes.to_vec(),
+                    return_bytes: return_bytes.to_vec(),
+                }),
+            )
         }
     };
     log::trace!("precompile event {opt_event:?}, aux data {aux_data:?}");

--- a/bus-mapping/src/evm/opcodes/precompiles/mod.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/mod.rs
@@ -19,14 +19,14 @@ use ec_pairing::opt_data as opt_data_ec_pairing;
 use ecrecover::opt_data as opt_data_ecrecover;
 use modexp::opt_data as opt_data_modexp;
 
-type InOutRetData = (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>);
-
 pub fn gen_associated_ops(
     state: &mut CircuitInputStateRef,
     geth_step: GethExecStep,
     call: Call,
     precompile: PrecompileCalls,
-    (input_bytes, output_bytes, return_bytes): InOutRetData,
+    input_bytes: &[u8],
+    output_bytes: &[u8],
+    return_bytes: &[u8],
 ) -> Result<ExecStep, Error> {
     assert_eq!(call.code_address(), Some(precompile.into()));
     let mut exec_step = state.new_step(&geth_step)?;
@@ -45,8 +45,9 @@ pub fn gen_associated_ops(
         PrecompileCalls::Identity => (
             None,
             Some(PrecompileAuxData::Identity {
-                input_bytes: input_bytes.unwrap_or_default(),
-                return_bytes: return_bytes.unwrap_or_default(),
+                input_bytes: input_bytes.to_vec(),
+                output_bytes: output_bytes.to_vec(),
+                return_bytes: return_bytes.to_vec(),
             }),
         ),
         _ => {

--- a/bus-mapping/src/evm/opcodes/precompiles/modexp.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/modexp.rs
@@ -6,15 +6,11 @@ use crate::{
 use eth_types::Word;
 
 pub(crate) fn opt_data(
-    input_bytes: Option<Vec<u8>>,
-    output_bytes: Option<Vec<u8>>,
-    return_bytes: Option<Vec<u8>>,
+    input_bytes: &[u8],
+    output_bytes: &[u8],
+    return_bytes: &[u8],
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
-    let aux_data = ModExpAuxData::new(
-        &input_bytes.unwrap_or_default(),
-        &output_bytes.unwrap_or_default(),
-        &return_bytes.unwrap_or_default(),
-    );
+    let aux_data = ModExpAuxData::new(input_bytes, output_bytes, return_bytes);
     if aux_data.valid {
         let event = BigModExp {
             base: Word::from_big_endian(&aux_data.inputs[0]),

--- a/bus-mapping/src/evm/opcodes/precompiles/modexp.rs
+++ b/bus-mapping/src/evm/opcodes/precompiles/modexp.rs
@@ -8,10 +8,12 @@ use eth_types::Word;
 pub(crate) fn opt_data(
     input_bytes: Option<Vec<u8>>,
     output_bytes: Option<Vec<u8>>,
+    return_bytes: Option<Vec<u8>>,
 ) -> (Option<PrecompileEvent>, Option<PrecompileAuxData>) {
     let aux_data = ModExpAuxData::new(
-        input_bytes.unwrap_or_default(),
-        output_bytes.unwrap_or_default(),
+        &input_bytes.unwrap_or_default(),
+        &output_bytes.unwrap_or_default(),
+        &return_bytes.unwrap_or_default(),
     );
     if aux_data.valid {
         let event = BigModExp {

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -437,6 +437,15 @@ pub enum EcPairingError {
 /// Auxiliary data attached to an internal state for precompile verification.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PrecompileAuxData {
+    /// Base precompile (used for SHA256, RIPEMD-160 and BLAKE2F).
+    Base {
+        /// input bytes to the identity call.
+        input_bytes: Vec<u8>,
+        /// output bytes from the identity call.
+        output_bytes: Vec<u8>,
+        /// bytes returned back to the caller from the identity call.
+        return_bytes: Vec<u8>,
+    },
     /// Identity.
     Identity {
         /// input bytes to the identity call.

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -184,6 +184,8 @@ pub struct EcrecoverAuxData {
     pub recovered_addr: Address,
     /// Input bytes to the ecrecover call.
     pub input_bytes: Vec<u8>,
+    /// Output bytes from the ecrecover call.
+    pub output_bytes: Vec<u8>,
     /// Bytes returned to the caller from the ecrecover call.
     pub return_bytes: Vec<u8>,
 }
@@ -191,20 +193,23 @@ pub struct EcrecoverAuxData {
 impl EcrecoverAuxData {
     /// Create a new instance of ecrecover auxiliary data.
     pub fn new(input: &[u8], output: &[u8], return_bytes: &[u8]) -> Self {
-        assert_eq!(input.len(), 128);
-        assert_eq!(output.len(), 32);
+        let mut resized_input = input.to_vec();
+        resized_input.resize(128, 0u8);
+        let mut resized_output = output.to_vec();
+        resized_output.resize(32, 0u8);
 
         // assert that recovered address is 20 bytes.
-        assert!(output[0x00..0x0c].iter().all(|&b| b == 0));
-        let recovered_addr = Address::from_slice(&output[0x0c..0x20]);
+        assert!(resized_output[0x00..0x0c].iter().all(|&b| b == 0));
+        let recovered_addr = Address::from_slice(&resized_output[0x0c..0x20]);
 
         Self {
-            msg_hash: Word::from_big_endian(&input[0x00..0x20]),
-            sig_v: Word::from_big_endian(&input[0x20..0x40]),
-            sig_r: Word::from_big_endian(&input[0x40..0x60]),
-            sig_s: Word::from_big_endian(&input[0x60..0x80]),
+            msg_hash: Word::from_big_endian(&resized_input[0x00..0x20]),
+            sig_v: Word::from_big_endian(&resized_input[0x20..0x40]),
+            sig_r: Word::from_big_endian(&resized_input[0x40..0x60]),
+            sig_s: Word::from_big_endian(&resized_input[0x60..0x80]),
             recovered_addr,
             input_bytes: input.to_vec(),
+            output_bytes: output.to_vec(),
             return_bytes: return_bytes.to_vec(),
         }
     }
@@ -239,10 +244,10 @@ pub struct ModExpAuxData {
     pub output_len: usize,
     /// output of modexp.
     pub output: [u8; MODEXP_SIZE_LIMIT],
-    /// backup of input memory
-    pub input_memory: Vec<u8>,
-    /// backup of output memory
-    pub output_memory: Vec<u8>,
+    /// Input to the modexp call.
+    pub input_bytes: Vec<u8>,
+    /// Output bytes from the modexp call.
+    pub output_bytes: Vec<u8>,
     /// Bytes returned back to the caller from the modexp call.
     pub return_bytes: Vec<u8>,
 }
@@ -279,11 +284,10 @@ impl ModExpAuxData {
     }
 
     /// Create a new instance of modexp auxiliary data.
-    pub fn new(mem_input: &[u8], output: &[u8], return_bytes: &[u8]) -> Self {
-        let mut input_memory = mem_input.to_vec();
-        let output_memory = output.to_vec();
+    pub fn new(input: &[u8], output: &[u8], return_bytes: &[u8]) -> Self {
+        let mut resized_input = input.to_vec();
 
-        let (input_valid, [base_len, exp_len, modulus_len]) = Self::check_input(mem_input);
+        let (input_valid, [base_len, exp_len, modulus_len]) = Self::check_input(input);
 
         let base_mem_len = if input_valid { base_len.as_usize() } else { 0 };
         let exp_mem_len = if input_valid { exp_len.as_usize() } else { 0 };
@@ -299,8 +303,8 @@ impl ModExpAuxData {
         } else {
             // In non scroll mode, this can be dangerous.
             // If base and mod are all 0, exp can be very huge.
-            input_memory.resize(96 + base_mem_len + exp_mem_len + modulus_mem_len, 0);
-            let mut cur_input_begin = &mem_input[96..];
+            resized_input.resize(96 + base_mem_len + exp_mem_len + modulus_mem_len, 0);
+            let mut cur_input_begin = &resized_input[96..];
 
             let base = Self::parse_memory_to_value(&cur_input_begin[..base_mem_len]);
             cur_input_begin = &cur_input_begin[base_mem_len..];
@@ -318,8 +322,8 @@ impl ModExpAuxData {
             inputs: [base, exp, modulus],
             output,
             output_len,
-            input_memory,
-            output_memory,
+            input_bytes: input.to_vec(),
+            output_bytes: output.to_vec(),
             return_bytes: return_bytes.to_vec(),
         }
     }
@@ -342,6 +346,8 @@ pub struct EcAddAuxData {
     pub r_y: Word,
     /// Input bytes to the ecAdd call.
     pub input_bytes: Vec<u8>,
+    /// Output bytes from the ecAdd call.
+    pub output_bytes: Vec<u8>,
     /// Bytes returned back to the caller.
     pub return_bytes: Vec<u8>,
 }
@@ -349,16 +355,20 @@ pub struct EcAddAuxData {
 impl EcAddAuxData {
     /// Create a new instance of ecrecover auxiliary data.
     pub fn new(input: &[u8], output: &[u8], return_bytes: &[u8]) -> Self {
-        assert_eq!(input.len(), 128);
-        assert_eq!(output.len(), 64);
+        let mut resized_input = input.to_vec();
+        resized_input.resize(128, 0u8);
+        let mut resized_output = output.to_vec();
+        resized_output.resize(64, 0u8);
+
         Self {
-            p_x: Word::from_big_endian(&input[0x00..0x20]),
-            p_y: Word::from_big_endian(&input[0x20..0x40]),
-            q_x: Word::from_big_endian(&input[0x40..0x60]),
-            q_y: Word::from_big_endian(&input[0x60..0x80]),
-            r_x: Word::from_big_endian(&output[0x00..0x20]),
-            r_y: Word::from_big_endian(&output[0x20..0x40]),
+            p_x: Word::from_big_endian(&resized_input[0x00..0x20]),
+            p_y: Word::from_big_endian(&resized_input[0x20..0x40]),
+            q_x: Word::from_big_endian(&resized_input[0x40..0x60]),
+            q_y: Word::from_big_endian(&resized_input[0x60..0x80]),
+            r_x: Word::from_big_endian(&resized_output[0x00..0x20]),
+            r_y: Word::from_big_endian(&resized_output[0x20..0x40]),
             input_bytes: input.to_vec(),
+            output_bytes: output.to_vec(),
             return_bytes: return_bytes.to_vec(),
         }
     }
@@ -381,6 +391,8 @@ pub struct EcMulAuxData {
     pub r_y: Word,
     /// Input bytes to the ecMul call.
     pub input_bytes: Vec<u8>,
+    /// Output bytes from the ecMul call.
+    pub output_bytes: Vec<u8>,
     /// Bytes returned back to the caller from the ecMul call.
     pub return_bytes: Vec<u8>,
 }
@@ -388,18 +400,22 @@ pub struct EcMulAuxData {
 impl EcMulAuxData {
     /// Create a new instance of EcMul auxiliary data.
     pub fn new(input: &[u8], output: &[u8], return_bytes: &[u8]) -> Self {
-        assert_eq!(input.len(), 96);
-        assert_eq!(output.len(), 64);
+        let mut resized_input = input.to_vec();
+        resized_input.resize(96, 0u8);
+        let mut resized_output = output.to_vec();
+        resized_output.resize(64, 0u8);
+
         let ec_mul_op = EcMulOp::new_from_bytes(input, output);
 
         Self {
-            p_x: Word::from_big_endian(&input[0x00..0x20]),
-            p_y: Word::from_big_endian(&input[0x20..0x40]),
+            p_x: Word::from_big_endian(&resized_input[0x00..0x20]),
+            p_y: Word::from_big_endian(&resized_input[0x20..0x40]),
             s: Word::from_little_endian(&ec_mul_op.s.to_bytes()),
-            s_raw: Word::from_big_endian(&input[0x40..0x60]),
-            r_x: Word::from_big_endian(&output[0x00..0x20]),
-            r_y: Word::from_big_endian(&output[0x20..0x40]),
+            s_raw: Word::from_big_endian(&resized_input[0x40..0x60]),
+            r_x: Word::from_big_endian(&resized_output[0x00..0x20]),
+            r_y: Word::from_big_endian(&resized_output[0x20..0x40]),
             input_bytes: input.to_vec(),
+            output_bytes: output.to_vec(),
             return_bytes: return_bytes.to_vec(),
         }
     }
@@ -425,6 +441,8 @@ pub enum PrecompileAuxData {
     Identity {
         /// input bytes to the identity call.
         input_bytes: Vec<u8>,
+        /// output bytes from the identity call.
+        output_bytes: Vec<u8>,
         /// bytes returned back to the caller from the identity call.
         return_bytes: Vec<u8>,
     },

--- a/zkevm-circuits/src/ecc_circuit/test.rs
+++ b/zkevm-circuits/src/ecc_circuit/test.rs
@@ -129,17 +129,26 @@ impl GenRand for EcPairingOp {
                 true => Self {
                     pairs,
                     output: eth_types::U256::one() - output,
+                    ..Default::default()
                 },
                 // change a point in one of the pairs.
                 false => {
                     let altered: G1Affine = point_p_negated.add(&G1Affine::generator()).into();
                     pairs[0].g1_point.0 = U256::from_little_endian(&altered.x.to_bytes());
                     pairs[0].g1_point.1 = U256::from_little_endian(&altered.y.to_bytes());
-                    Self { pairs, output }
+                    Self {
+                        pairs,
+                        output,
+                        ..Default::default()
+                    }
                 }
             }
         } else {
-            Self { pairs, output }
+            Self {
+                pairs,
+                output,
+                ..Default::default()
+            }
         }
     }
 }
@@ -249,6 +258,7 @@ mod valid_invalid_cases {
                     EcPairingOp {
                         pairs,
                         output: U256::one(),
+                        ..Default::default()
                     }
                 },
                 // 2. invalid: field element > Fq::MODULUS, mod p is OK
@@ -279,6 +289,7 @@ mod valid_invalid_cases {
                     EcPairingOp {
                         pairs,
                         output: U256::zero(),
+                        ..Default::default()
                     }
                 },
             ]
@@ -304,6 +315,7 @@ mod valid_invalid_cases {
                     EcPairingOp {
                         pairs,
                         output: U256::zero(),
+                        ..Default::default()
                     }
                 },
                 // 4. invalid: not on curve G1.
@@ -318,6 +330,7 @@ mod valid_invalid_cases {
                         EcPairingPair::padding_pair(),
                     ],
                     output: 0.into(),
+                    ..Default::default()
                 },
             ]
         };
@@ -335,6 +348,7 @@ mod valid_invalid_cases {
                         EcPairingPair::padding_pair(),
                     ],
                     output: 0.into(),
+                    ..Default::default()
                 },
                 // 6. valid: all zero.
                 EcPairingOp {
@@ -345,6 +359,7 @@ mod valid_invalid_cases {
                         EcPairingPair::padding_pair(),
                     ],
                     output: 1.into(),
+                    ..Default::default()
                 },
             ]
         };
@@ -359,6 +374,7 @@ mod valid_invalid_cases {
                         EcPairingPair::padding_pair(),
                     ],
                     output: 1.into(),
+                    ..Default::default()
                 },
                 // 8. valid: [(G1::gen, G2::gen), (-G1::gen, G2::gen); 2]
                 EcPairingOp {
@@ -369,6 +385,7 @@ mod valid_invalid_cases {
                         EcPairingPair::new(G1Affine::generator().neg(), G2Affine::generator()),
                     ],
                     output: 1.into(),
+                    ..Default::default()
                 },
             ]
         };

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_add.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_add.rs
@@ -6,10 +6,13 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
+        param::N_BYTES_MEMORY_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::RestoreContextGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+            math_gadget::LtGadget,
+            padding_gadget::PaddingGadget,
             rlc, CachedRegion, Cell,
         },
     },
@@ -21,8 +24,14 @@ use crate::{
 pub struct EcAddGadget<F> {
     // input bytes RLC.
     input_bytes_rlc: Cell<F>,
+    // output bytes RLC.
+    output_bytes_rlc: Cell<F>,
     // return bytes RLC.
     return_bytes_rlc: Cell<F>,
+
+    // utility gadgets for right-padding the input bytes.
+    pad_right: LtGadget<F, N_BYTES_MEMORY_ADDRESS>,
+    padding: PaddingGadget<F>,
 
     // EC points: P, Q, R
     point_p_x_rlc: Cell<F>,
@@ -50,6 +59,7 @@ impl<F: Field> ExecutionGadget<F> for EcAddGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let (
             input_bytes_rlc,
+            output_bytes_rlc,
             return_bytes_rlc,
             point_p_x_rlc,
             point_p_y_rlc,
@@ -58,6 +68,7 @@ impl<F: Field> ExecutionGadget<F> for EcAddGadget<F> {
             point_r_x_rlc,
             point_r_y_rlc,
         ) = (
+            cb.query_cell_phase2(),
             cb.query_cell_phase2(),
             cb.query_cell_phase2(),
             cb.query_cell_phase2(),
@@ -109,6 +120,46 @@ impl<F: Field> ExecutionGadget<F> for EcAddGadget<F> {
             cb.require_zero("R_y == 0", point_r_y_rlc.expr());
         });
 
+        let required_input_len = 128.expr();
+        let pad_right = LtGadget::construct(cb, call_data_length.expr(), required_input_len.expr());
+        let padding = cb.condition(pad_right.expr(), |cb| {
+            PaddingGadget::construct(
+                cb,
+                input_bytes_rlc.expr(),
+                call_data_length.expr(),
+                required_input_len,
+            )
+        });
+        cb.condition(not::expr(pad_right.expr()), |cb| {
+            cb.require_equal(
+                "no padding implies padded bytes == input bytes",
+                padding.padded_rlc(),
+                input_bytes_rlc.expr(),
+            );
+        });
+        let (r_pow_32, r_pow_64, r_pow_96) = {
+            let challenges = cb.challenges().keccak_powers_of_randomness::<16>();
+            let r_pow_16 = challenges[15].clone();
+            let r_pow_32 = r_pow_16.square();
+            let r_pow_64 = r_pow_32.expr().square();
+            let r_pow_96 = r_pow_64.expr() * r_pow_32.expr();
+            (r_pow_32, r_pow_64, r_pow_96)
+        };
+        cb.require_equal(
+            "input bytes (RLC) = [ p_x | p_y | q_x | q_y ]",
+            padding.padded_rlc(),
+            (point_p_x_rlc.expr() * r_pow_96)
+                + (point_p_y_rlc.expr() * r_pow_64)
+                + (point_q_x_rlc.expr() * r_pow_32.expr())
+                + point_q_y_rlc.expr(),
+        );
+        // RLC of output bytes always equals RLC of result elliptic curve point R.
+        cb.require_equal(
+            "output bytes (RLC) = [ r_x | r_y ]",
+            output_bytes_rlc.expr(),
+            point_r_x_rlc.expr() * r_pow_32 + point_r_y_rlc.expr(),
+        );
+
         let restore_context = RestoreContextGadget::construct2(
             cb,
             is_success.expr(),
@@ -122,7 +173,11 @@ impl<F: Field> ExecutionGadget<F> for EcAddGadget<F> {
 
         Self {
             input_bytes_rlc,
+            output_bytes_rlc,
             return_bytes_rlc,
+
+            pad_right,
+            padding,
 
             point_p_x_rlc,
             point_p_y_rlc,
@@ -155,6 +210,7 @@ impl<F: Field> ExecutionGadget<F> for EcAddGadget<F> {
             let keccak_rand = region.challenges().keccak_input();
             for (col, bytes) in [
                 (&self.input_bytes_rlc, &aux_data.input_bytes),
+                (&self.output_bytes_rlc, &aux_data.output_bytes),
                 (&self.return_bytes_rlc, &aux_data.return_bytes),
             ] {
                 col.assign(
@@ -177,6 +233,19 @@ impl<F: Field> ExecutionGadget<F> for EcAddGadget<F> {
                     keccak_rand.map(|r| rlc::value(&word_value.to_le_bytes(), r)),
                 )?;
             }
+            self.pad_right
+                .assign(region, offset, call.call_data_length.into(), 128.into())?;
+            self.padding.assign(
+                region,
+                offset,
+                PrecompileCalls::Bn128Add,
+                region
+                    .challenges()
+                    .keccak_input()
+                    .map(|r| rlc::value(aux_data.input_bytes.iter().rev(), r)),
+                call.call_data_length,
+                region.challenges().keccak_input(),
+            )?;
         } else {
             log::error!("unexpected aux_data {:?} for ecAdd", step.aux_data);
             return Err(Error::Synthesis);
@@ -505,7 +574,6 @@ mod test {
                     address: PrecompileCalls::Bn128Add.address().to_word(),
                     ..Default::default()
                 },
-
             ]
         };
 
@@ -557,9 +625,10 @@ mod test {
         TEST_VECTOR
             .iter()
             .cartesian_product(&call_kinds)
-            .par_bridge()
+            //.par_bridge()
             .for_each(|(test_vector, &call_kind)| {
                 let bytecode = test_vector.with_call_op(call_kind);
+                log::info!("TESTING {}", test_vector.name);
 
                 CircuitTestBuilder::new_from_test_ctx(
                     TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_mul.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_mul.rs
@@ -11,11 +11,13 @@ use halo2_proofs::{
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
+        param::N_BYTES_MEMORY_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::RestoreContextGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            math_gadget::{AddWordsGadget, IsEqualGadget, IsZeroGadget, ModGadget},
+            math_gadget::{AddWordsGadget, IsEqualGadget, IsZeroGadget, LtGadget, ModGadget},
+            padding_gadget::PaddingGadget,
             rlc, CachedRegion, Cell, Word,
         },
     },
@@ -39,7 +41,11 @@ lazy_static::lazy_static! {
 #[derive(Clone, Debug)]
 pub struct EcMulGadget<F> {
     input_bytes_rlc: Cell<F>,
+    output_bytes_rlc: Cell<F>,
     return_bytes_rlc: Cell<F>,
+
+    pad_right: LtGadget<F, N_BYTES_MEMORY_ADDRESS>,
+    padding: PaddingGadget<F>,
 
     point_p_x_rlc: Cell<F>,
     point_p_y_rlc: Cell<F>,
@@ -81,6 +87,7 @@ impl<F: Field> ExecutionGadget<F> for EcMulGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let (
             input_bytes_rlc,
+            output_bytes_rlc,
             return_bytes_rlc,
             point_p_x_rlc,
             point_p_y_rlc,
@@ -88,6 +95,7 @@ impl<F: Field> ExecutionGadget<F> for EcMulGadget<F> {
             point_r_x_rlc,
             point_r_y_rlc,
         ) = (
+            cb.query_cell_phase2(),
             cb.query_cell_phase2(),
             cb.query_cell_phase2(),
             cb.query_cell_phase2(),
@@ -256,6 +264,44 @@ impl<F: Field> ExecutionGadget<F> for EcMulGadget<F> {
             cb.execution_state().precompile_base_gas_cost().expr(),
         );
 
+        let required_input_len = 96.expr();
+        let pad_right = LtGadget::construct(cb, call_data_length.expr(), required_input_len.expr());
+        let padding = cb.condition(pad_right.expr(), |cb| {
+            PaddingGadget::construct(
+                cb,
+                input_bytes_rlc.expr(),
+                call_data_length.expr(),
+                required_input_len,
+            )
+        });
+        cb.condition(not::expr(pad_right.expr()), |cb| {
+            cb.require_equal(
+                "no padding implies padded bytes == input bytes",
+                padding.padded_rlc(),
+                input_bytes_rlc.expr(),
+            );
+        });
+        let (r_pow_32, r_pow_64) = {
+            let challenges = cb.challenges().keccak_powers_of_randomness::<16>();
+            let r_pow_16 = challenges[15].clone();
+            let r_pow_32 = r_pow_16.square();
+            let r_pow_64 = r_pow_32.expr().square();
+            (r_pow_32, r_pow_64)
+        };
+        cb.require_equal(
+            "input bytes (RLC) = [ p_x | p_y | s ]",
+            padding.padded_rlc(),
+            (point_p_x_rlc.expr() * r_pow_64)
+                + (point_p_y_rlc.expr() * r_pow_32.expr())
+                + scalar_s_raw_rlc.expr(),
+        );
+        // RLC of output bytes always equals RLC of result elliptic curve point R.
+        cb.require_equal(
+            "output bytes (RLC) = [ r_x | r_y ]",
+            output_bytes_rlc.expr(),
+            point_r_x_rlc.expr() * r_pow_32 + point_r_y_rlc.expr(),
+        );
+
         let restore_context = RestoreContextGadget::construct2(
             cb,
             is_success.expr(),
@@ -269,7 +315,11 @@ impl<F: Field> ExecutionGadget<F> for EcMulGadget<F> {
 
         Self {
             input_bytes_rlc,
+            output_bytes_rlc,
             return_bytes_rlc,
+
+            pad_right,
+            padding,
 
             point_p_x_rlc,
             point_p_y_rlc,
@@ -314,6 +364,7 @@ impl<F: Field> ExecutionGadget<F> for EcMulGadget<F> {
         if let Some(PrecompileAuxData::EcMul(aux_data)) = &step.aux_data {
             for (col, bytes) in [
                 (&self.input_bytes_rlc, &aux_data.input_bytes),
+                (&self.output_bytes_rlc, &aux_data.output_bytes),
                 (&self.return_bytes_rlc, &aux_data.return_bytes),
             ] {
                 col.assign(
@@ -384,6 +435,19 @@ impl<F: Field> ExecutionGadget<F> for EcMulGadget<F> {
             let (k, _) = aux_data.s_raw.div_mod(*FR_MODULUS);
             self.modword
                 .assign(region, offset, aux_data.s_raw, *FR_MODULUS, aux_data.s, k)?;
+            self.pad_right
+                .assign(region, offset, call.call_data_length.into(), 96.into())?;
+            self.padding.assign(
+                region,
+                offset,
+                PrecompileCalls::Bn128Mul,
+                region
+                    .challenges()
+                    .keccak_input()
+                    .map(|r| rlc::value(aux_data.input_bytes.iter().rev(), r)),
+                call.call_data_length,
+                region.challenges().keccak_input(),
+            )?;
         } else {
             log::error!("unexpected aux_data {:?} for ecMul", step.aux_data);
             return Err(Error::Synthesis);

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ec_pairing.rs
@@ -28,7 +28,10 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct EcPairingGadget<F> {
     // Random linear combination of input bytes to the precompile ecPairing call.
-    evm_input_rlc: Cell<F>,
+    input_bytes_rlc: Cell<F>,
+    // return bytes
+    return_bytes_rlc: Cell<F>,
+
     // Boolean output from the ecPairing call, denoting whether or not the pairing check was
     // successful.
     output: Cell<F>,
@@ -67,7 +70,11 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::PrecompileBn256Pairing;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let (evm_input_rlc, output) = (cb.query_cell_phase2(), cb.query_bool());
+        let (input_bytes_rlc, return_bytes_rlc, output) = (
+            cb.query_cell_phase2(),
+            cb.query_cell_phase2(),
+            cb.query_bool(),
+        );
 
         let n_pairs = cb.query_cell();
         let n_pairs_cmp = BinaryNumberGadget::construct(cb, n_pairs.expr());
@@ -179,14 +186,14 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                     0.expr(),
                     select::expr(
                         n_pairs_cmp.value_equals(1usize),
-                        evm_input_rlc.expr() * rand_pow_576.expr(), /* 576 bytes padded */
+                        input_bytes_rlc.expr() * rand_pow_576.expr(), /* 576 bytes padded */
                         select::expr(
                             n_pairs_cmp.value_equals(2usize),
-                            evm_input_rlc.expr() * rand_pow_384.expr(), /* 384 bytes padded */
+                            input_bytes_rlc.expr() * rand_pow_384.expr(), /* 384 bytes padded */
                             select::expr(
                                 n_pairs_cmp.value_equals(3usize),
-                                evm_input_rlc.expr() * rand_pow_192.expr(), /* 192 bytes padded */
-                                evm_input_rlc.expr(),                       /* 0 bytes padded */
+                                input_bytes_rlc.expr() * rand_pow_192.expr(), /* 192 bytes padded */
+                                input_bytes_rlc.expr(),                       /* 0 bytes padded */
                             ),
                         ),
                     ),
@@ -194,7 +201,7 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                 cb.condition(n_pairs_cmp.value_equals(0usize), |cb| {
                     cb.require_zero(
                         "ecPairing: n_pairs == 0 => evm input == 0",
-                        evm_input_rlc.expr(),
+                        input_bytes_rlc.expr(),
                     );
                 });
 
@@ -256,7 +263,8 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
         );
 
         Self {
-            evm_input_rlc,
+            input_bytes_rlc,
+            return_bytes_rlc,
             output,
 
             input_is_zero,
@@ -330,7 +338,7 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                         "len(input) % 192 != 0"
                     );
                     // Consider only call_data_length bytes for EVM input.
-                    self.evm_input_rlc.assign(
+                    self.input_bytes_rlc.assign(
                         region,
                         offset,
                         keccak_rand.map(|r| {
@@ -344,6 +352,11 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                                 r,
                             )
                         }),
+                    )?;
+                    self.return_bytes_rlc.assign(
+                        region,
+                        offset,
+                        keccak_rand.map(|r| rlc::value(aux_data.0.return_bytes.iter().rev(), r)),
                     )?;
                     // Pairing check output from ecPairing call.
                     self.output.assign(
@@ -380,11 +393,13 @@ impl<F: Field> ExecutionGadget<F> for EcPairingGadget<F> {
                         "len(input) is expected to be invalid",
                     );
                     // Consider only call_data_length bytes for EVM input.
-                    self.evm_input_rlc.assign(
+                    self.input_bytes_rlc.assign(
                         region,
                         offset,
                         keccak_rand.map(|r| rlc::value(input_bytes.iter().rev(), r)),
                     )?;
+                    self.return_bytes_rlc
+                        .assign(region, offset, Value::known(F::zero()))?;
                     // Pairing check output from ecPairing call.
                     self.output
                         .assign(region, offset, Value::known(F::zero()))?;

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/ecrecover.rs
@@ -1,4 +1,4 @@
-use bus_mapping::precompile::PrecompileAuxData;
+use bus_mapping::precompile::{PrecompileAuxData, PrecompileCalls};
 use eth_types::{evm_types::GasCost, word, Field, ToLittleEndian, ToScalar, U256};
 use gadgets::util::{and, not, or, select, sum, Expr};
 use halo2_proofs::{
@@ -9,13 +9,14 @@ use halo2_proofs::{
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_WORD},
+        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_MEMORY_ADDRESS, N_BYTES_WORD},
         step::ExecutionState,
         util::{
             common_gadget::RestoreContextGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
             from_bytes,
-            math_gadget::{IsEqualGadget, IsZeroGadget, LtWordGadget, ModGadget},
+            math_gadget::{IsEqualGadget, IsZeroGadget, LtGadget, LtWordGadget, ModGadget},
+            padding_gadget::PaddingGadget,
             rlc, CachedRegion, Cell, RandomLinearCombination, Word,
         },
     },
@@ -32,7 +33,11 @@ lazy_static::lazy_static! {
 #[derive(Clone, Debug)]
 pub struct EcrecoverGadget<F> {
     input_bytes_rlc: Cell<F>,
+    output_bytes_rlc: Cell<F>,
     return_bytes_rlc: Cell<F>,
+
+    pad_right: LtGadget<F, N_BYTES_MEMORY_ADDRESS>,
+    padding: PaddingGadget<F>,
 
     recovered: Cell<F>,
     msg_hash_keccak_rlc: Cell<F>,
@@ -72,7 +77,11 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
     const NAME: &'static str = "ECRECOVER";
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let (input_bytes_rlc, return_bytes_rlc) = (cb.query_cell_phase2(), cb.query_cell_phase2());
+        let (input_bytes_rlc, output_bytes_rlc, return_bytes_rlc) = (
+            cb.query_cell_phase2(),
+            cb.query_cell_phase2(),
+            cb.query_cell_phase2(),
+        );
         let (
             recovered,
             msg_hash_keccak_rlc,
@@ -229,6 +238,50 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
             cb.execution_state().precompile_base_gas_cost().expr(),
         );
 
+        let required_input_len = 128.expr();
+        let pad_right = LtGadget::construct(cb, call_data_length.expr(), required_input_len.expr());
+        let padding = cb.condition(pad_right.expr(), |cb| {
+            PaddingGadget::construct(
+                cb,
+                input_bytes_rlc.expr(),
+                call_data_length.expr(),
+                required_input_len,
+            )
+        });
+        cb.condition(not::expr(pad_right.expr()), |cb| {
+            cb.require_equal(
+                "no padding implies padded bytes == input bytes",
+                padding.padded_rlc(),
+                input_bytes_rlc.expr(),
+            );
+        });
+        let (r_pow_32, r_pow_64, r_pow_96) = {
+            let challenges = cb.challenges().keccak_powers_of_randomness::<16>();
+            let r_pow_16 = challenges[15].clone();
+            let r_pow_32 = r_pow_16.square();
+            let r_pow_64 = r_pow_32.expr().square();
+            let r_pow_96 = r_pow_64.expr() * r_pow_32.expr();
+            (r_pow_32, r_pow_64, r_pow_96)
+        };
+        cb.require_equal(
+            "input bytes (RLC) = [msg_hash | sig_v_rlc | sig_r | sig_s]",
+            padding.padded_rlc(),
+            (msg_hash_keccak_rlc.expr() * r_pow_96)
+                + (sig_v_keccak_rlc.expr() * r_pow_64)
+                + (sig_r_keccak_rlc.expr() * r_pow_32)
+                + sig_s_keccak_rlc.expr(),
+        );
+        // RLC of output bytes always equals RLC of the recovered address.
+        cb.require_equal(
+            "output bytes (RLC) = recovered address",
+            output_bytes_rlc.expr(),
+            recovered_addr_keccak_rlc.expr(),
+        );
+        // If the address was not recovered, RLC(address) == RLC(output) == 0.
+        cb.condition(not::expr(recovered.expr()), |cb| {
+            cb.require_zero("output bytes == 0", output_bytes_rlc.expr());
+        });
+
         let restore_context = RestoreContextGadget::construct2(
             cb,
             is_success.expr(),
@@ -242,7 +295,11 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
 
         Self {
             input_bytes_rlc,
+            output_bytes_rlc,
             return_bytes_rlc,
+
+            pad_right,
+            padding,
 
             recovered,
             msg_hash_keccak_rlc,
@@ -294,6 +351,14 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
                     .challenges()
                     .keccak_input()
                     .map(|r| rlc::value(aux_data.input_bytes.iter().rev(), r)),
+            )?;
+            self.output_bytes_rlc.assign(
+                region,
+                offset,
+                region
+                    .challenges()
+                    .keccak_input()
+                    .map(|r| rlc::value(aux_data.output_bytes.iter().rev(), r)),
             )?;
             self.return_bytes_rlc.assign(
                 region,
@@ -396,6 +461,19 @@ impl<F: Field> ExecutionGadget<F> for EcrecoverGadget<F> {
                     recovered_addr.reverse();
                     recovered_addr
                 }),
+            )?;
+            self.pad_right
+                .assign(region, offset, call.call_data_length.into(), 128.into())?;
+            self.padding.assign(
+                region,
+                offset,
+                PrecompileCalls::Ecrecover,
+                region
+                    .challenges()
+                    .keccak_input()
+                    .map(|r| rlc::value(aux_data.input_bytes.iter().rev(), r)),
+                call.call_data_length,
+                region.challenges().keccak_input(),
             )?;
         } else {
             log::error!("unexpected aux_data {:?} for ecrecover", step.aux_data);

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/identity.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/identity.rs
@@ -1,3 +1,4 @@
+use bus_mapping::precompile::PrecompileAuxData;
 use eth_types::{evm_types::GasCost, Field, ToScalar};
 use gadgets::util::{select, Expr};
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -9,7 +10,7 @@ use crate::{
         step::ExecutionState,
         util::{
             common_gadget::RestoreContextGadget, constraint_builder::EVMConstraintBuilder,
-            math_gadget::ConstantDivisionGadget, CachedRegion, Cell,
+            math_gadget::ConstantDivisionGadget, rlc, CachedRegion, Cell,
         },
     },
     table::CallContextFieldTag,
@@ -18,6 +19,9 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct IdentityGadget<F> {
+    input_bytes_rlc: Cell<F>,
+    return_bytes_rlc: Cell<F>,
+
     input_word_size: ConstantDivisionGadget<F, N_BYTES_MEMORY_WORD_SIZE>,
     is_success: Cell<F>,
     callee_address: Cell<F>,
@@ -35,6 +39,7 @@ impl<F: Field> ExecutionGadget<F> for IdentityGadget<F> {
     const NAME: &'static str = "IDENTITY";
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
+        let (input_bytes_rlc, return_bytes_rlc) = (cb.query_cell_phase2(), cb.query_cell_phase2());
         let [is_success, callee_address, caller_id, call_data_offset, call_data_length, return_data_offset, return_data_length] =
             [
                 CallContextFieldTag::IsSuccess,
@@ -78,8 +83,10 @@ impl<F: Field> ExecutionGadget<F> for IdentityGadget<F> {
         );
 
         Self {
-            input_word_size,
+            input_bytes_rlc,
+            return_bytes_rlc,
 
+            input_word_size,
             is_success,
             callee_address,
             caller_id,
@@ -100,6 +107,31 @@ impl<F: Field> ExecutionGadget<F> for IdentityGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
+        if let Some(PrecompileAuxData::Identity {
+            input_bytes,
+            return_bytes,
+        }) = &step.aux_data
+        {
+            self.input_bytes_rlc.assign(
+                region,
+                offset,
+                region
+                    .challenges()
+                    .keccak_input()
+                    .map(|r| rlc::value(input_bytes.iter().rev(), r)),
+            )?;
+            self.return_bytes_rlc.assign(
+                region,
+                offset,
+                region
+                    .challenges()
+                    .keccak_input()
+                    .map(|r| rlc::value(return_bytes.iter().rev(), r)),
+            )?;
+        } else {
+            log::error!("unexpected aux_data {:?} for identity", step.aux_data);
+            return Err(Error::Synthesis);
+        }
         self.input_word_size.assign(
             region,
             offset,

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/mod.rs
@@ -1,5 +1,6 @@
+use bus_mapping::precompile::PrecompileAuxData;
 use eth_types::{Field, ToScalar};
-use gadgets::util::Expr;
+use gadgets::util::{select, Expr};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 use crate::{
@@ -7,7 +8,7 @@ use crate::{
         execution::ExecutionGadget,
         step::ExecutionState,
         util::{
-            common_gadget::RestoreContextGadget, constraint_builder::EVMConstraintBuilder,
+            common_gadget::RestoreContextGadget, constraint_builder::EVMConstraintBuilder, rlc,
             CachedRegion, Cell,
         },
     },
@@ -34,6 +35,10 @@ pub use identity::IdentityGadget;
 
 #[derive(Clone, Debug)]
 pub struct BasePrecompileGadget<F, const S: ExecutionState> {
+    input_bytes_rlc: Cell<F>,
+    output_bytes_rlc: Cell<F>,
+    return_bytes_rlc: Cell<F>,
+
     is_success: Cell<F>,
     callee_address: Cell<F>,
     caller_id: Cell<F>,
@@ -51,6 +56,11 @@ impl<F: Field, const S: ExecutionState> ExecutionGadget<F> for BasePrecompileGad
     const NAME: &'static str = "BASE_PRECOMPILE";
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
+        let (input_bytes_rlc, output_bytes_rlc, return_bytes_rlc) = (
+            cb.query_cell_phase2(),
+            cb.query_cell_phase2(),
+            cb.query_cell_phase2(),
+        );
         let gas_cost = cb.query_cell();
         let [is_success, callee_address, caller_id, call_data_offset, call_data_length, return_data_offset, return_data_length] =
             [
@@ -80,13 +90,21 @@ impl<F: Field, const S: ExecutionState> ExecutionGadget<F> for BasePrecompileGad
             is_success.expr(),
             gas_cost.expr(),
             0.expr(),
-            0.expr(),                              // ReturnDataOffset
-            last_callee_return_data_length.expr(), // ReturnDataLength
+            0.expr(), // ReturnDataOffset
+            select::expr(
+                is_success.expr(),
+                last_callee_return_data_length.expr(),
+                0x00.expr(),
+            ), // ReturnDataLength
             0.expr(),
             0.expr(),
         );
 
         Self {
+            input_bytes_rlc,
+            output_bytes_rlc,
+            return_bytes_rlc,
+
             is_success,
             callee_address,
             caller_id,
@@ -108,6 +126,31 @@ impl<F: Field, const S: ExecutionState> ExecutionGadget<F> for BasePrecompileGad
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
+        if let Some(PrecompileAuxData::Base {
+            input_bytes,
+            output_bytes,
+            return_bytes,
+        }) = &step.aux_data
+        {
+            for (col, bytes) in [
+                (&self.input_bytes_rlc, input_bytes),
+                (&self.output_bytes_rlc, output_bytes),
+                (&self.return_bytes_rlc, return_bytes),
+            ] {
+                col.assign(
+                    region,
+                    offset,
+                    region
+                        .challenges()
+                        .keccak_input()
+                        .map(|r| rlc::value(bytes.iter().rev(), r)),
+                )?;
+            }
+        } else {
+            log::error!("unexpected aux_data {:?} for basePrecompile", step.aux_data);
+            return Err(Error::Synthesis);
+        }
+
         self.gas_cost
             .assign(region, offset, Value::known(F::from(step.gas_cost)))?;
         self.is_success.assign(

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
@@ -1,4 +1,6 @@
-use bus_mapping::precompile::{PrecompileAuxData, MODEXP_INPUT_LIMIT, MODEXP_SIZE_LIMIT};
+use bus_mapping::precompile::{
+    PrecompileAuxData, PrecompileCalls, MODEXP_INPUT_LIMIT, MODEXP_SIZE_LIMIT,
+};
 use eth_types::{evm_types::GasCost, Field, ToBigEndian, ToScalar, U256};
 use gadgets::util::{self, not, select, Expr};
 use halo2_proofs::{
@@ -9,7 +11,7 @@ use halo2_proofs::{
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{N_BITS_U8, N_BYTES_U64, N_BYTES_WORD},
+        param::{N_BITS_U8, N_BYTES_MEMORY_ADDRESS, N_BYTES_U64, N_BYTES_WORD},
         step::ExecutionState,
         util::{
             common_gadget::RestoreContextGadget,
@@ -18,6 +20,7 @@ use crate::{
                 BinaryNumberGadget, BitLengthGadget, ByteOrWord, ByteSizeGadget,
                 ConstantDivisionGadget, IsZeroGadget, LtGadget, MinMaxGadget,
             },
+            padding_gadget::PaddingGadget,
             rlc, CachedRegion, Cell,
         },
     },
@@ -702,7 +705,11 @@ impl<F: Field> ModExpGasCost<F> {
 #[derive(Clone, Debug)]
 pub struct ModExpGadget<F> {
     input_bytes_rlc: Cell<F>,
+    output_bytes_rlc: Cell<F>,
     return_bytes_rlc: Cell<F>,
+
+    pad_right: LtGadget<F, N_BYTES_MEMORY_ADDRESS>,
+    padding: PaddingGadget<F>,
 
     is_success: Cell<F>,
     callee_address: Cell<F>,
@@ -718,7 +725,6 @@ pub struct ModExpGadget<F> {
     output: ModExpOutputs<F>,
 
     input_bytes_acc: Cell<F>,
-    output_bytes_acc: Cell<F>,
     is_gas_insufficient: LtGadget<F, N_BYTES_U64>,
     gas_cost_gadget: ModExpGasCost<F>,
     garbage_bytes_holder: [Cell<F>; INPUT_LIMIT - 96],
@@ -730,10 +736,13 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
     const NAME: &'static str = "MODEXP";
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let (input_bytes_rlc, return_bytes_rlc) = (cb.query_cell_phase2(), cb.query_cell_phase2());
+        let (input_bytes_rlc, output_bytes_rlc, return_bytes_rlc) = (
+            cb.query_cell_phase2(),
+            cb.query_cell_phase2(),
+            cb.query_cell_phase2(),
+        );
         // we 'copy' the acc_bytes cell inside call_op step, so it must be the first query cells
         let input_bytes_acc = cb.query_cell_phase2();
-        let output_bytes_acc = cb.query_cell_phase2();
 
         let [is_success, callee_address, caller_id, call_data_offset, call_data_length, return_data_offset, return_data_length] =
             [
@@ -806,7 +815,7 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
 
         cb.require_equal(
             "output acc bytes must equal",
-            output_bytes_acc.expr(),
+            output_bytes_rlc.expr(),
             output.bytes_rlc(),
         );
 
@@ -816,7 +825,28 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             cb.curr.state.gas_left.expr(),
         );
 
-        let rd_length = select::expr(is_success.expr(), input.modulus_len(), 0.expr());
+        let required_input_len = 192.expr();
+        let pad_right = LtGadget::construct(cb, call_data_length.expr(), required_input_len.expr());
+        let padding = cb.condition(pad_right.expr(), |cb| {
+            PaddingGadget::construct(
+                cb,
+                input_bytes_rlc.expr(),
+                call_data_length.expr(),
+                required_input_len,
+            )
+        });
+        cb.condition(not::expr(pad_right.expr()), |cb| {
+            cb.require_equal(
+                "no padding implies padded bytes == input bytes",
+                padding.padded_rlc(),
+                input_bytes_rlc.expr(),
+            );
+        });
+        cb.require_equal(
+            "copy padded input bytes",
+            padding.padded_rlc(),
+            input_bytes_acc.expr(),
+        );
 
         let restore_context_gadget = RestoreContextGadget::construct2(
             cb,
@@ -824,14 +854,19 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             gas_cost.expr(),
             0.expr(),
             0.expr(),
-            rd_length,
+            select::expr(is_success.expr(), input.modulus_len(), 0.expr()),
             0.expr(),
             0.expr(),
         );
 
         Self {
             input_bytes_rlc,
+            output_bytes_rlc,
             return_bytes_rlc,
+
+            pad_right,
+            padding,
+
             is_success,
             callee_address,
             caller_id,
@@ -844,7 +879,6 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             padding_zero,
             output,
             input_bytes_acc,
-            output_bytes_acc,
             is_gas_insufficient,
             gas_cost_gadget,
             garbage_bytes_holder,
@@ -874,7 +908,7 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             let garbage_bytes = if call.call_data_length as usize > input_expected_len {
                 let mut bts = Vec::new();
                 bts.resize(input_expected_len - 96, 0); //front prefix zero
-                bts.append(&mut Vec::from(&data.input_memory[input_expected_len..]));
+                bts.append(&mut Vec::from(&data.input_bytes[input_expected_len..]));
                 bts.resize(96, 0); //padding zero
                 bts
             } else {
@@ -894,7 +928,8 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             let input_rlc = region
                 .challenges()
                 .keccak_input()
-                .map(|randomness| rlc::value(data.input_memory.iter().rev(), randomness));
+                .map(|randomness| rlc::value(data.input_bytes.iter().rev(), randomness));
+
             self.input_bytes_rlc.assign(region, offset, input_rlc)?;
             self.return_bytes_rlc.assign(
                 region,
@@ -921,11 +956,11 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             let output_rlc = region
                 .challenges()
                 .keccak_input()
-                .map(|randomness| rlc::value(data.output_memory.iter().rev(), randomness));
+                .map(|randomness| rlc::value(data.output_bytes.iter().rev(), randomness));
 
             self.input_bytes_acc
                 .assign(region, offset, n_padded_zeroes_pow * input_rlc)?;
-            self.output_bytes_acc.assign(region, offset, output_rlc)?;
+            self.output_bytes_rlc.assign(region, offset, output_rlc)?;
 
             let required_gas_cost = self.gas_cost_gadget.assign(
                 region,
@@ -939,6 +974,19 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
                 offset,
                 F::from(step.gas_left),
                 F::from(required_gas_cost),
+            )?;
+            self.pad_right
+                .assign(region, offset, call.call_data_length.into(), 192.into())?;
+            self.padding.assign(
+                region,
+                offset,
+                PrecompileCalls::Modexp,
+                region
+                    .challenges()
+                    .keccak_input()
+                    .map(|r| rlc::value(data.input_bytes.iter().rev(), r)),
+                call.call_data_length,
+                region.challenges().keccak_input(),
             )?;
         } else {
             log::error!("unexpected aux_data {:?} for modexp", step.aux_data);

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -30,6 +30,7 @@ pub(crate) mod constraint_builder;
 pub(crate) mod instrumentation;
 pub(crate) mod math_gadget;
 pub(crate) mod memory_gadget;
+pub(crate) mod padding_gadget;
 pub(crate) mod precompile_gadget;
 
 pub use gadgets::util::{and, not, or, select, sum};

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -418,12 +418,6 @@ impl<F: FieldExt> CellManager<F> {
         }
     }
 
-    pub(crate) fn reset_heights_to(&mut self, heights: &[usize]) {
-        for (column, &height) in self.columns.iter_mut().zip_eq(heights.iter()) {
-            column.height = height;
-        }
-    }
-
     pub(crate) fn query_cells(&mut self, cell_type: CellType, count: usize) -> Vec<Cell<F>> {
         let mut cells = Vec::with_capacity(count);
         while cells.len() < count {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -16,7 +16,7 @@ use bus_mapping::{
     util::{KECCAK_CODE_HASH_EMPTY, POSEIDON_CODE_HASH_EMPTY},
 };
 use eth_types::{Field, ToLittleEndian, ToScalar, ToWord};
-use gadgets::util::{and, not, sum};
+use gadgets::util::{and, not};
 use halo2_proofs::{
     circuit::Value,
     plonk::{
@@ -332,8 +332,6 @@ impl<'a, F: Field> ConstrainBuilderCommon<F> for EVMConstraintBuilder<'a, F> {
         self.push_constraint(name, constraint);
     }
 }
-
-pub(crate) type BoxedClosure<'a, F> = Box<dyn FnOnce(&mut EVMConstraintBuilder<F>) + 'a>;
 
 impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     pub(crate) fn new(
@@ -1543,60 +1541,13 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         ret
     }
 
-    /// Constraints the next step, given mutually exclusive conditions to determine the next state
-    /// and constrain it using the provided respective constraint. This mechanism is specifically
-    /// used for constraining the internal states for precompile calls. Each precompile call
-    /// expects a different cell layout, but since the next state can be at the most one precompile
-    /// state, we can re-use cells assigned across all those conditions.
-    pub(crate) fn constrain_mutually_exclusive_next_step(
-        &mut self,
-        conditions: Vec<Expression<F>>,
-        next_states: Vec<ExecutionState>,
-        constraints: Vec<BoxedClosure<F>>,
-    ) {
-        assert_eq!(conditions.len(), constraints.len());
-        assert_eq!(conditions.len(), next_states.len());
-        self.require_boolean(
-            "at the most one condition is true from mutually exclusive conditions",
-            sum::expr(&conditions),
-        );
-
-        // record the heights of all columns (for the next step) as we begin cell assignment.
-        let start_heights = self.next.cell_manager.get_heights();
-
-        let mut max_end_heights: Vec<usize> = vec![0usize; start_heights.len()];
-        for ((&next_state, condition), constraint) in next_states
-            .iter()
-            .zip(conditions.into_iter())
-            .zip(constraints.into_iter())
-        {
-            // constraint the next step.
-            self.constrain_next_step(next_state, Some(condition), constraint);
-
-            // get the column heights at the end of querying cells in the above constraints.
-            let end_heights = self.next.cell_manager.get_heights();
-            for (max_end_height, end_height) in max_end_heights.iter_mut().zip(end_heights.iter()) {
-                if end_height > max_end_height {
-                    *max_end_height = *end_height;
-                }
-            }
-
-            // reset the column heights of the next step before proceeding to the next mutually
-            // exclusive condition/constraint/next_state.
-            self.next.cell_manager.reset_heights_to(&start_heights);
-        }
-
-        // reset height of next step to the maximum heights of each column.
-        self.next.cell_manager.reset_heights_to(&max_end_heights);
-    }
-
     /// This function needs to be used with extra precaution. You need to make
     /// sure the layout is the same as the gadget for `next_step_state`.
     /// `query_cell` will return cells in the next step in the `constraint`
     /// function.
     pub(crate) fn constrain_next_step<R>(
         &mut self,
-        next_step_state: ExecutionState,
+        opt_next_step_state: Option<ExecutionState>,
         condition: Option<Expression<F>>,
         constraint: impl FnOnce(&mut Self) -> R,
     ) -> R {
@@ -1604,11 +1555,15 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         self.in_next_step = true;
         let ret = match condition {
             None => {
-                self.require_next_state(next_step_state);
+                if let Some(next_step_state) = opt_next_step_state {
+                    self.require_next_state(next_step_state);
+                }
                 constraint(self)
             }
             Some(cond) => self.condition(cond, |cb| {
-                cb.require_next_state(next_step_state);
+                if let Some(next_step_state) = opt_next_step_state {
+                    cb.require_next_state(next_step_state);
+                }
                 constraint(cb)
             }),
         };

--- a/zkevm-circuits/src/evm_circuit/util/padding_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/padding_gadget.rs
@@ -1,0 +1,111 @@
+use bus_mapping::precompile::PrecompileCalls;
+use eth_types::Field;
+use gadgets::util::{not, Expr};
+use halo2_proofs::{circuit::Value, plonk::Expression};
+
+use super::{
+    constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+    math_gadget::IsZeroGadget,
+    CachedRegion, Cell,
+};
+
+#[derive(Clone, Debug)]
+pub struct PaddingGadget<F> {
+    is_cd_len_zero: IsZeroGadget<F>,
+    padded_rlc: Cell<F>,
+    power_of_rand: Cell<F>,
+}
+
+impl<F: Field> PaddingGadget<F> {
+    pub(crate) fn construct(
+        cb: &mut EVMConstraintBuilder<F>,
+        input_rlc: Expression<F>,
+        cd_len: Expression<F>,
+        input_len: Expression<F>,
+    ) -> Self {
+        let is_cd_len_zero = IsZeroGadget::construct(cb, cd_len.expr());
+        let padded_rlc = cb.query_cell_phase2();
+        let power_of_rand = cb.query_cell_phase2();
+
+        // for calldata length == 0, we expect the input RLC and padded RLC to be the same, i.e. 0.
+        cb.condition(is_cd_len_zero.expr(), |cb| {
+            cb.require_equal(
+                "padded RLC == input RLC",
+                padded_rlc.expr(),
+                input_rlc.expr(),
+            );
+            cb.require_zero("input RLC == 0", input_rlc.expr());
+        });
+
+        // for calldata length > 0 && calldata length < required input length.
+        cb.condition(not::expr(is_cd_len_zero.expr()), |cb| {
+            // No. of right padded zeroes is the difference between the required input length and
+            // the length of the provided input bytes. We only support right-padding by
+            // up to 191 bytes, as that's the maximum we ever require considering all
+            // cases (modexp, ecrecover, ecAdd, ecMul).
+            let n_padded_zeroes = input_len.expr() - cd_len.expr();
+            cb.range_lookup(n_padded_zeroes.expr(), 192);
+
+            // Power of randomness we are interested in, i.e. r ^ n_padded_zeroes.
+            cb.pow_of_rand_lookup(n_padded_zeroes.expr(), power_of_rand.expr());
+
+            // Validate value of padded RLC.
+            cb.require_equal(
+                "padded RLC == input RLC * pow_of_r",
+                padded_rlc.expr(),
+                input_rlc * power_of_rand.expr(),
+            );
+        });
+
+        Self {
+            is_cd_len_zero,
+            padded_rlc,
+            power_of_rand,
+        }
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        precompile: PrecompileCalls,
+        input_rlc: Value<F>,
+        cd_len: u64,
+        keccak_rand: Value<F>,
+    ) -> Result<u64, halo2_proofs::plonk::Error> {
+        let (input_len, padded_rlc, power_of_rand) =
+            if let Some(required_input_len) = precompile.input_len() {
+                // skip padding if calldata length == 0.
+                if cd_len == 0 {
+                    (required_input_len as u64, input_rlc, Value::known(F::one()))
+                } else {
+                    // pad only if calldata length is less than the required input length.
+                    let n_padded_zeroes = if cd_len < required_input_len as u64 {
+                        (required_input_len as u64) - cd_len
+                    } else {
+                        0
+                    };
+                    assert!(required_input_len <= 192);
+                    assert!(n_padded_zeroes < 192);
+                    let power_of_rand = keccak_rand.map(|r| r.pow(&[n_padded_zeroes, 0, 0, 0]));
+                    (
+                        required_input_len as u64,
+                        input_rlc * power_of_rand,
+                        power_of_rand,
+                    )
+                }
+            } else {
+                (cd_len, input_rlc, Value::known(F::one()))
+            };
+
+        self.is_cd_len_zero.assign(region, offset, cd_len.into())?;
+        self.padded_rlc.assign(region, offset, padded_rlc)?;
+        self.power_of_rand.assign(region, offset, power_of_rand)?;
+
+        Ok(input_len)
+    }
+
+    pub(crate) fn padded_rlc(&self) -> Expression<F> {
+        self.padded_rlc.expr()
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
@@ -51,7 +51,11 @@ impl<F: Field> PrecompileGadget<F> {
 
         // Without constraining the next step's state, only constrain the first two Phase2 cells,
         // i.e. RLC(input_bytes) and RLC(return_bytes)
-        cb.constrain_next_step(None, None, |cb| {
+        // We only check these constraints if there was no OOG error in the precompile call.
+        let is_oog_err = cb
+            .next
+            .execution_state_selector([ExecutionState::ErrorOutOfGasPrecompile]);
+        cb.constrain_next_step(None, Some(not::expr(is_oog_err)), |cb| {
             let (next_input_bytes_rlc, next_output_bytes_rlc, next_return_bytes_rlc) = (
                 cb.query_cell_phase2(),
                 cb.query_cell_phase2(),

--- a/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
@@ -1,271 +1,80 @@
 use bus_mapping::precompile::PrecompileCalls;
 use eth_types::Field;
-use gadgets::util::{not, or, select, Expr};
-use halo2_proofs::{circuit::Value, plonk::Expression};
+use gadgets::util::{and, not, Expr};
+use halo2_proofs::plonk::Expression;
 
-use crate::evm_circuit::{
-    param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_U64},
-    step::{ExecutionState, ExecutionState::ErrorOutOfGasPrecompile},
-};
+use crate::evm_circuit::step::{ExecutionState, ExecutionState::ErrorOutOfGasPrecompile};
 
 use super::{
-    constraint_builder::{BoxedClosure, ConstrainBuilderCommon, EVMConstraintBuilder},
-    math_gadget::{BinaryNumberGadget, LtGadget},
-    padding_gadget::PaddingGadget,
+    constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+    math_gadget::BinaryNumberGadget,
     CachedRegion,
 };
 
 #[derive(Clone, Debug)]
 pub struct PrecompileGadget<F> {
     address: BinaryNumberGadget<F, 4>,
-    pad_right: LtGadget<F, N_BYTES_U64>,
-    padding_gadget: PaddingGadget<F>,
 }
 
 impl<F: Field> PrecompileGadget<F> {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        _is_success: Expression<F>,
         callee_address: Expression<F>,
-        _caller_id: Expression<F>,
-        _cd_offset: Expression<F>,
-        cd_length: Expression<F>,
-        _rd_offset: Expression<F>,
-        _rd_length: Expression<F>,
-        precompile_return_length: Expression<F>,
-        // input bytes to precompile call.
         input_bytes_rlc: Expression<F>,
-        // output result from precompile call.
         output_bytes_rlc: Expression<F>,
-        // returned bytes back to caller.
         return_bytes_rlc: Expression<F>,
     ) -> Self {
         let address = BinaryNumberGadget::construct(cb, callee_address.expr());
 
-        // input length represents:
-        // - 128 bytes for ecrecover/ecAdd
-        // - 96 bytes for ecMul
-        // - calldata length for all other cases
-        let input_len = {
-            let len_128 = or::expr([
-                address.value_equals(PrecompileCalls::Ecrecover),
-                address.value_equals(PrecompileCalls::Bn128Add),
-            ]);
-            let len_96 = address.value_equals(PrecompileCalls::Bn128Mul);
-            let len_192 = address.value_equals(PrecompileCalls::Modexp);
-            select::expr(
-                len_128,
-                128.expr(),
-                select::expr(
-                    len_96,
-                    96.expr(),
-                    select::expr(len_192, 192.expr(), cd_length.expr()),
-                ),
-            )
-        };
-        let pad_right = LtGadget::construct(cb, cd_length.expr(), input_len.expr());
+        macro_rules! constrain_next_state {
+            ($cb:ident, $precompile_call_type:ident, $precompile_exec_state:ident) => {
+                $cb.condition(
+                    and::expr([
+                        address.value_equals(PrecompileCalls::$precompile_call_type),
+                        not::expr($cb.next.execution_state_selector([ErrorOutOfGasPrecompile])),
+                    ]),
+                    |cb| {
+                        cb.require_next_state(ExecutionState::$precompile_exec_state);
+                    },
+                );
+            };
+        }
+        constrain_next_state!(cb, Ecrecover, PrecompileEcrecover);
+        constrain_next_state!(cb, Sha256, PrecompileSha256);
+        constrain_next_state!(cb, Ripemd160, PrecompileRipemd160);
+        constrain_next_state!(cb, Identity, PrecompileIdentity);
+        constrain_next_state!(cb, Modexp, PrecompileBigModExp);
+        constrain_next_state!(cb, Bn128Add, PrecompileBn256Add);
+        constrain_next_state!(cb, Bn128Mul, PrecompileBn256ScalarMul);
+        constrain_next_state!(cb, Bn128Pairing, PrecompileBn256Pairing);
+        constrain_next_state!(cb, Blake2F, PrecompileBlake2f);
 
-        // we right-pad zeroes only if calldata length provided was less than the expected/required
-        // input length for that precompile call.
-        let padding_gadget = cb.condition(pad_right.expr(), |cb| {
-            PaddingGadget::construct(
-                cb,
-                input_bytes_rlc.expr(),
-                cd_length.expr(),
-                input_len.expr(),
-            )
-        });
-        cb.condition(not::expr(pad_right.expr()), |cb| {
+        // Without constraining the next step's state, only constrain the first two Phase2 cells,
+        // i.e. RLC(input_bytes) and RLC(return_bytes)
+        cb.constrain_next_step(None, None, |cb| {
+            let (next_input_bytes_rlc, next_output_bytes_rlc, next_return_bytes_rlc) = (
+                cb.query_cell_phase2(),
+                cb.query_cell_phase2(),
+                cb.query_cell_phase2(),
+            );
             cb.require_equal(
-                "no padding implies both equal",
-                padding_gadget.padded_rlc(),
+                "equality: RLC(input_bytes)",
+                next_input_bytes_rlc.expr(),
                 input_bytes_rlc.expr(),
+            );
+            cb.require_equal(
+                "equality: RLC(output_bytes)",
+                next_output_bytes_rlc.expr(),
+                output_bytes_rlc.expr(),
+            );
+            cb.require_equal(
+                "equality: RLC(return_bytes)",
+                next_return_bytes_rlc.expr(),
+                return_bytes_rlc.expr(),
             );
         });
 
-        let conditions = vec![
-            address.value_equals(PrecompileCalls::Ecrecover),
-            address.value_equals(PrecompileCalls::Sha256),
-            address.value_equals(PrecompileCalls::Ripemd160),
-            address.value_equals(PrecompileCalls::Identity),
-            address.value_equals(PrecompileCalls::Modexp),
-            address.value_equals(PrecompileCalls::Bn128Add),
-            address.value_equals(PrecompileCalls::Bn128Mul),
-            address.value_equals(PrecompileCalls::Bn128Pairing),
-            address.value_equals(PrecompileCalls::Blake2F),
-        ]
-        .into_iter()
-        .map(|cond| {
-            cond.expr() * not::expr(cb.next.execution_state_selector([ErrorOutOfGasPrecompile]))
-        })
-        .collect::<Vec<_>>();
-        let next_states = vec![
-            ExecutionState::PrecompileEcrecover,
-            ExecutionState::PrecompileSha256,
-            ExecutionState::PrecompileRipemd160,
-            ExecutionState::PrecompileIdentity,
-            ExecutionState::PrecompileBigModExp,
-            ExecutionState::PrecompileBn256Add,
-            ExecutionState::PrecompileBn256ScalarMul,
-            ExecutionState::PrecompileBn256Pairing,
-            ExecutionState::PrecompileBlake2f,
-        ];
-        let constraints: Vec<BoxedClosure<F>> = vec![
-            Box::new(|cb| {
-                /* Ecrecover */
-                let (recovered, msg_hash_rlc, sig_v_rlc, sig_r_rlc, sig_s_rlc, recovered_addr_rlc) = (
-                    cb.query_bool(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_keccak_rlc::<N_BYTES_ACCOUNT_ADDRESS>(),
-                );
-                let (r_pow_32, r_pow_64, r_pow_96) = {
-                    let challenges = cb.challenges().keccak_powers_of_randomness::<16>();
-                    let r_pow_16 = challenges[15].clone();
-                    let r_pow_32 = r_pow_16.square();
-                    let r_pow_64 = r_pow_32.expr().square();
-                    let r_pow_96 = r_pow_64.expr() * r_pow_32.expr();
-                    (r_pow_32, r_pow_64, r_pow_96)
-                };
-                cb.require_equal(
-                    "input bytes (RLC) = [msg_hash | sig_v_rlc | sig_r | sig_s]",
-                    padding_gadget.padded_rlc(),
-                    (msg_hash_rlc.expr() * r_pow_96)
-                        + (sig_v_rlc.expr() * r_pow_64)
-                        + (sig_r_rlc.expr() * r_pow_32)
-                        + sig_s_rlc.expr(),
-                );
-                // RLC of output bytes always equals RLC of the recovered address.
-                cb.require_equal(
-                    "output bytes (RLC) = recovered address",
-                    output_bytes_rlc.expr(),
-                    recovered_addr_rlc.expr(),
-                );
-                // If the address was not recovered, RLC(address) == RLC(output) == 0.
-                cb.condition(not::expr(recovered.expr()), |cb| {
-                    cb.require_zero("output bytes == 0", output_bytes_rlc.expr());
-                });
-            }),
-            Box::new(|_cb| { /* Sha256 */ }),
-            Box::new(|_cb| { /* Ripemd160 */ }),
-            Box::new(|cb| {
-                /* Identity */
-                cb.require_equal(
-                    "input and output bytes are the same",
-                    input_bytes_rlc.expr(),
-                    output_bytes_rlc.expr(),
-                );
-                cb.require_equal(
-                    "input length and precompile return length are the same",
-                    cd_length,
-                    precompile_return_length,
-                );
-            }),
-            Box::new(|cb| {
-                /* Modexp */
-                let (input_bytes_acc_copied, output_bytes_acc_copied) =
-                    (cb.query_cell_phase2(), cb.query_cell_phase2());
-                cb.require_equal(
-                    "copy padded input bytes",
-                    padding_gadget.padded_rlc(),
-                    input_bytes_acc_copied.expr(),
-                );
-                cb.require_equal(
-                    "copy output bytes",
-                    output_bytes_rlc.clone(),
-                    output_bytes_acc_copied.expr(),
-                );
-            }),
-            Box::new(|cb| {
-                /* EcAdd */
-                let (p_x_rlc, p_y_rlc, q_x_rlc, q_y_rlc, r_x_rlc, r_y_rlc) = (
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                );
-                let (r_pow_32, r_pow_64, r_pow_96) = {
-                    let challenges = cb.challenges().keccak_powers_of_randomness::<16>();
-                    let r_pow_16 = challenges[15].clone();
-                    let r_pow_32 = r_pow_16.square();
-                    let r_pow_64 = r_pow_32.expr().square();
-                    let r_pow_96 = r_pow_64.expr() * r_pow_32.expr();
-                    (r_pow_32, r_pow_64, r_pow_96)
-                };
-                cb.require_equal(
-                    "input bytes (RLC) = [ p_x | p_y | q_x | q_y ]",
-                    padding_gadget.padded_rlc(),
-                    (p_x_rlc.expr() * r_pow_96)
-                        + (p_y_rlc.expr() * r_pow_64)
-                        + (q_x_rlc.expr() * r_pow_32.expr())
-                        + q_y_rlc.expr(),
-                );
-                // RLC of output bytes always equals RLC of result elliptic curve point R.
-                cb.require_equal(
-                    "output bytes (RLC) = [ r_x | r_y ]",
-                    output_bytes_rlc.expr(),
-                    r_x_rlc.expr() * r_pow_32 + r_y_rlc.expr(),
-                );
-            }),
-            Box::new(|cb| {
-                /* EcMul */
-                let (p_x_rlc, p_y_rlc, scalar_s_raw_rlc, r_x_rlc, r_y_rlc) = (
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                    cb.query_cell_phase2(),
-                );
-                let (r_pow_32, r_pow_64) = {
-                    let challenges = cb.challenges().keccak_powers_of_randomness::<16>();
-                    let r_pow_16 = challenges[15].clone();
-                    let r_pow_32 = r_pow_16.square();
-                    let r_pow_64 = r_pow_32.expr().square();
-                    (r_pow_32, r_pow_64)
-                };
-                cb.require_equal(
-                    "input bytes (RLC) = [ p_x | p_y | s ]",
-                    padding_gadget.padded_rlc(),
-                    (p_x_rlc.expr() * r_pow_64)
-                        + (p_y_rlc.expr() * r_pow_32.expr())
-                        + scalar_s_raw_rlc.expr(),
-                );
-                // RLC of output bytes always equals RLC of result elliptic curve point R.
-                cb.require_equal(
-                    "output bytes (RLC) = [ r_x | r_y ]",
-                    output_bytes_rlc.expr(),
-                    r_x_rlc.expr() * r_pow_32 + r_y_rlc.expr(),
-                );
-            }),
-            Box::new(|cb| {
-                /* EcPairing */
-                let (evm_input_rlc, output) = (cb.query_cell_phase2(), cb.query_bool());
-                cb.require_equal(
-                    "input bytes (RLC) equality",
-                    padding_gadget.padded_rlc(),
-                    evm_input_rlc.expr(),
-                );
-                // RLC of output bytes always equals boolean result of pairing check.
-                cb.require_equal(
-                    "output bytes (RLC) equality",
-                    output_bytes_rlc.expr(),
-                    output.expr(),
-                );
-            }),
-            Box::new(|_cb| { /* Blake2F */ }),
-        ];
-        cb.constrain_mutually_exclusive_next_step(conditions, next_states, constraints);
-
-        Self {
-            address,
-            pad_right,
-            padding_gadget,
-        }
+        Self { address }
     }
 
     pub(crate) fn assign(
@@ -273,17 +82,7 @@ impl<F: Field> PrecompileGadget<F> {
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         address: PrecompileCalls,
-        input_rlc: Value<F>,
-        cd_len: u64,
-        keccak_rand: Value<F>,
     ) -> Result<(), halo2_proofs::plonk::Error> {
-        self.address.assign(region, offset, address)?;
-        let input_len =
-            self.padding_gadget
-                .assign(region, offset, address, input_rlc, cd_len, keccak_rand)?;
-        self.pad_right
-            .assign(region, offset, F::from(cd_len), F::from(input_len))?;
-
-        Ok(())
+        self.address.assign(region, offset, address)
     }
 }

--- a/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/precompile_gadget.rs
@@ -10,8 +10,9 @@ use crate::evm_circuit::{
 
 use super::{
     constraint_builder::{BoxedClosure, ConstrainBuilderCommon, EVMConstraintBuilder},
-    math_gadget::{BinaryNumberGadget, IsZeroGadget, LtGadget},
-    CachedRegion, Cell,
+    math_gadget::{BinaryNumberGadget, LtGadget},
+    padding_gadget::PaddingGadget,
+    CachedRegion,
 };
 
 #[derive(Clone, Debug)]
@@ -38,7 +39,7 @@ impl<F: Field> PrecompileGadget<F> {
         // output result from precompile call.
         output_bytes_rlc: Expression<F>,
         // returned bytes back to caller.
-        _return_bytes_rlc: Expression<F>,
+        return_bytes_rlc: Expression<F>,
     ) -> Self {
         let address = BinaryNumberGadget::construct(cb, callee_address.expr());
 
@@ -284,106 +285,5 @@ impl<F: Field> PrecompileGadget<F> {
             .assign(region, offset, F::from(cd_len), F::from(input_len))?;
 
         Ok(())
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct PaddingGadget<F> {
-    is_cd_len_zero: IsZeroGadget<F>,
-    padded_rlc: Cell<F>,
-    power_of_rand: Cell<F>,
-}
-
-impl<F: Field> PaddingGadget<F> {
-    pub(crate) fn construct(
-        cb: &mut EVMConstraintBuilder<F>,
-        input_rlc: Expression<F>,
-        cd_len: Expression<F>,
-        input_len: Expression<F>,
-    ) -> Self {
-        let is_cd_len_zero = IsZeroGadget::construct(cb, cd_len.expr());
-        let padded_rlc = cb.query_cell_phase2();
-        let power_of_rand = cb.query_cell_phase2();
-
-        // for calldata length == 0, we expect the input RLC and padded RLC to be the same, i.e. 0.
-        cb.condition(is_cd_len_zero.expr(), |cb| {
-            cb.require_equal(
-                "padded RLC == input RLC",
-                padded_rlc.expr(),
-                input_rlc.expr(),
-            );
-            cb.require_zero("input RLC == 0", input_rlc.expr());
-        });
-
-        // for calldata length > 0 && calldata length < required input length.
-        cb.condition(not::expr(is_cd_len_zero.expr()), |cb| {
-            // No. of right padded zeroes is the difference between the required input length and
-            // the length of the provided input bytes. We only support right-padding by
-            // up to 191 bytes, as that's the maximum we ever require considering all
-            // cases (modexp, ecrecover, ecAdd, ecMul).
-            let n_padded_zeroes = input_len.expr() - cd_len.expr();
-            cb.range_lookup(n_padded_zeroes.expr(), 192);
-
-            // Power of randomness we are interested in, i.e. r ^ n_padded_zeroes.
-            cb.pow_of_rand_lookup(n_padded_zeroes.expr(), power_of_rand.expr());
-
-            // Validate value of padded RLC.
-            cb.require_equal(
-                "padded RLC == input RLC * pow_of_r",
-                padded_rlc.expr(),
-                input_rlc * power_of_rand.expr(),
-            );
-        });
-
-        Self {
-            is_cd_len_zero,
-            padded_rlc,
-            power_of_rand,
-        }
-    }
-
-    pub(crate) fn assign(
-        &self,
-        region: &mut CachedRegion<'_, '_, F>,
-        offset: usize,
-        precompile: PrecompileCalls,
-        input_rlc: Value<F>,
-        cd_len: u64,
-        keccak_rand: Value<F>,
-    ) -> Result<u64, halo2_proofs::plonk::Error> {
-        let (input_len, padded_rlc, power_of_rand) =
-            if let Some(required_input_len) = precompile.input_len() {
-                // skip padding if calldata length == 0.
-                if cd_len == 0 {
-                    (required_input_len as u64, input_rlc, Value::known(F::one()))
-                } else {
-                    // pad only if calldata length is less than the required input length.
-                    let n_padded_zeroes = if cd_len < required_input_len as u64 {
-                        (required_input_len as u64) - cd_len
-                    } else {
-                        0
-                    };
-                    assert!(required_input_len <= 192);
-                    assert!(n_padded_zeroes < 192);
-                    let power_of_rand = keccak_rand.map(|r| r.pow(&[n_padded_zeroes, 0, 0, 0]));
-                    (
-                        required_input_len as u64,
-                        input_rlc * power_of_rand,
-                        power_of_rand,
-                    )
-                }
-            } else {
-                (cd_len, input_rlc, Value::known(F::one()))
-            };
-
-        self.is_cd_len_zero.assign(region, offset, cd_len.into())?;
-        self.padded_rlc.assign(region, offset, padded_rlc)?;
-        self.power_of_rand.assign(region, offset, power_of_rand)?;
-
-        Ok(input_len)
-    }
-
-    pub(crate) fn padded_rlc(&self) -> Expression<F> {
-        self.padded_rlc.expr()
     }
 }


### PR DESCRIPTION
### Description

Refactor codebase related to precompile ops, to effectively remove the `constrain_mutually_exclusive_next_step` from our codebase. Furthermore, we also don't need the functionality to `reset` the `CellManager`.