### PR TITLE
fix: only enable circuit for `BASEFEE` opcode (without opcode mapping)

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -283,11 +283,7 @@ impl<F: Field> EvmCircuit<F> {
     }
 }
 
-// the diff is from the num of valid opcodes: self-destruct?
-#[cfg(not(feature = "scroll"))]
 const FIXED_TABLE_ROWS_NO_BITWISE: usize = 3647;
-#[cfg(feature = "scroll")]
-const FIXED_TABLE_ROWS_NO_BITWISE: usize = 3646;
 const FIXED_TABLE_ROWS: usize = FIXED_TABLE_ROWS_NO_BITWISE + 3 * 65536;
 
 impl<F: Field> SubCircuit<F> for EvmCircuit<F> {

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1445,10 +1445,8 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::BLOCKCTXU64 => assign_exec_step!(self.block_ctx_u64_gadget),
             ExecutionState::BLOCKCTXU160 => assign_exec_step!(self.block_ctx_u160_gadget),
             ExecutionState::BLOCKCTXU256 => assign_exec_step!(self.block_ctx_u256_gadget),
-            ExecutionState::DIFFICULTY => {
-                #[cfg(feature = "scroll")]
-                assign_exec_step!(self.difficulty_gadget)
-            }
+            #[cfg(feature = "scroll")]
+            ExecutionState::DIFFICULTY => assign_exec_step!(self.difficulty_gadget),
             ExecutionState::BLOCKHASH => assign_exec_step!(self.blockhash_gadget),
             ExecutionState::SELFBALANCE => assign_exec_step!(self.selfbalance_gadget),
             ExecutionState::CREATE => assign_exec_step!(self.create_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -146,6 +146,8 @@ use address::AddressGadget;
 use balance::BalanceGadget;
 use begin_tx::BeginTxGadget;
 use bitwise::BitwiseGadget;
+#[cfg(feature = "scroll")]
+use block_ctx::DifficultyGadget;
 use block_ctx::{BlockCtxU160Gadget, BlockCtxU256Gadget, BlockCtxU64Gadget};
 use blockhash::BlockHashGadget;
 use byte::ByteGadget;
@@ -328,6 +330,8 @@ pub(crate) struct ExecutionConfig<F> {
     block_ctx_u64_gadget: Box<BlockCtxU64Gadget<F>>,
     block_ctx_u160_gadget: Box<BlockCtxU160Gadget<F>>,
     block_ctx_u256_gadget: Box<BlockCtxU256Gadget<F>>,
+    #[cfg(feature = "scroll")]
+    difficulty_gadget: Box<DifficultyGadget<F>>,
     // error gadgets
     error_oog_call: Box<ErrorOOGCallGadget<F>>,
     error_oog_precompile: Box<ErrorOOGPrecompileGadget<F>>,
@@ -606,6 +610,8 @@ impl<F: Field> ExecutionConfig<F> {
             block_ctx_u64_gadget: configure_gadget!(),
             block_ctx_u160_gadget: configure_gadget!(),
             block_ctx_u256_gadget: configure_gadget!(),
+            #[cfg(feature = "scroll")]
+            difficulty_gadget: configure_gadget!(),
             // error gadgets
             error_oog_constant: configure_gadget!(),
             error_oog_static_memory_gadget: configure_gadget!(),
@@ -1439,6 +1445,10 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::BLOCKCTXU64 => assign_exec_step!(self.block_ctx_u64_gadget),
             ExecutionState::BLOCKCTXU160 => assign_exec_step!(self.block_ctx_u160_gadget),
             ExecutionState::BLOCKCTXU256 => assign_exec_step!(self.block_ctx_u256_gadget),
+            ExecutionState::DIFFICULTY => {
+                #[cfg(feature = "scroll")]
+                assign_exec_step!(self.difficulty_gadget)
+            }
             ExecutionState::BLOCKHASH => assign_exec_step!(self.blockhash_gadget),
             ExecutionState::SELFBALANCE => assign_exec_step!(self.selfbalance_gadget),
             ExecutionState::CREATE => assign_exec_step!(self.create_gadget),

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -80,8 +80,9 @@ pub enum ExecutionState {
     BLOCKHASH,
     BLOCKCTXU64,  // TIMESTAMP, NUMBER, GASLIMIT
     BLOCKCTXU160, // COINBASE
-    BLOCKCTXU256, // BASEFEE
-    DIFFICULTY,   // DIFFICULTY
+    BLOCKCTXU256, // BASEFEE, DIFFICULTY (for non-scroll)
+    #[cfg(feature = "scroll")]
+    DIFFICULTY, // DIFFICULTY
     CHAINID,
     SELFBALANCE,
     POP,

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -80,7 +80,8 @@ pub enum ExecutionState {
     BLOCKHASH,
     BLOCKCTXU64,  // TIMESTAMP, NUMBER, GASLIMIT
     BLOCKCTXU160, // COINBASE
-    BLOCKCTXU256, // DIFFICULTY, BASEFEE
+    BLOCKCTXU256, // BASEFEE
+    DIFFICULTY,   // DIFFICULTY
     CHAINID,
     SELFBALANCE,
     POP,
@@ -270,11 +271,13 @@ impl ExecutionState {
             Self::BLOCKCTXU160 => vec![OpcodeId::COINBASE],
             Self::BLOCKCTXU256 => {
                 if cfg!(feature = "scroll") {
-                    vec![OpcodeId::DIFFICULTY]
+                    vec![OpcodeId::BASEFEE]
                 } else {
                     vec![OpcodeId::DIFFICULTY, OpcodeId::BASEFEE]
                 }
             }
+            #[cfg(feature = "scroll")]
+            Self::DIFFICULTY => vec![OpcodeId::DIFFICULTY],
             Self::CHAINID => vec![OpcodeId::CHAINID],
             Self::SELFBALANCE => vec![OpcodeId::SELFBALANCE],
             Self::POP => vec![OpcodeId::POP],

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -188,13 +188,10 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
                     }
                     OpcodeId::COINBASE => ExecutionState::BLOCKCTXU160,
                     OpcodeId::BASEFEE => ExecutionState::BLOCKCTXU256,
-                    OpcodeId::DIFFICULTY => {
-                        if cfg!(feature = "scroll") {
-                            ExecutionState::DIFFICULTY
-                        } else {
-                            ExecutionState::BLOCKCTXU256
-                        }
-                    }
+                    #[cfg(not(feature = "scroll"))]
+                    OpcodeId::DIFFICULTY => ExecutionState::BLOCKCTXU256,
+                    #[cfg(feature = "scroll")]
+                    OpcodeId::DIFFICULTY => ExecutionState::DIFFICULTY,
                     OpcodeId::GAS => ExecutionState::GAS,
                     OpcodeId::SAR => ExecutionState::SAR,
                     OpcodeId::SELFBALANCE => ExecutionState::SELFBALANCE,

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -187,7 +187,14 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
                         ExecutionState::BLOCKCTXU64
                     }
                     OpcodeId::COINBASE => ExecutionState::BLOCKCTXU160,
-                    OpcodeId::DIFFICULTY | OpcodeId::BASEFEE => ExecutionState::BLOCKCTXU256,
+                    OpcodeId::BASEFEE => ExecutionState::BLOCKCTXU256,
+                    OpcodeId::DIFFICULTY => {
+                        if cfg!(feature = "scroll") {
+                            ExecutionState::DIFFICULTY
+                        } else {
+                            ExecutionState::BLOCKCTXU256
+                        }
+                    }
                     OpcodeId::GAS => ExecutionState::GAS,
                     OpcodeId::SAR => ExecutionState::SAR,
                     OpcodeId::SELFBALANCE => ExecutionState::SELFBALANCE,


### PR DESCRIPTION
### Description

`BASEFEE` opcode is disabled by l2geth for now and converted to [an invalid opcode in eth-types](https://github.com/scroll-tech/zkevm-circuits/blob/develop/eth-types/src/evm_types/opcode_ids.rs#L1062), but it will be enabled soon (draft l2geth PR https://github.com/scroll-tech/go-ethereum/pull/573, after discussing with @NazariiDenha , he will send another PR).

This PR enables the `BlockCtxU256Gadget` for BASEFEE (separated with `DIFFICULTY` which always returns `0` for scroll), and tested with geth mainnet in integration-tests as described in PR https://github.com/scroll-tech/zkevm-circuits/pull/1034.