### PR TITLE
fix: disable applying MPT for non-scroll to fix panic in integration-tests

### DIFF
--- a/integration-tests/tests/mainnet.rs
+++ b/integration-tests/tests/mainnet.rs
@@ -81,11 +81,12 @@ async fn test_mock_prove_tx() {
     }
 
     let mut block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
+    #[cfg(feature = "scroll")]
     witness::block_mocking_apply_mpt(&mut block);
     let mut updated_state_root = H256::default();
     block
         .state_root
-        .unwrap()
+        .unwrap_or_default()
         .to_big_endian(&mut updated_state_root.0);
 
     builder.block.prev_state_root = block.prev_state_root;
@@ -190,11 +191,12 @@ async fn test_circuit_all_block() {
         }
 
         let mut block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
+        #[cfg(feature = "scroll")]
         witness::block_mocking_apply_mpt(&mut block);
         let mut updated_state_root = H256::default();
         block
             .state_root
-            .unwrap()
+            .unwrap_or_default()
             .to_big_endian(&mut updated_state_root.0);
 
         builder.block.prev_state_root = block.prev_state_root;


### PR DESCRIPTION
### Description

Fix to disable `witness::block_mocking_apply_mpt` for non-scroll.

integration-tests failed with below backtrace (when testing geth mainnet without this fix):
```
  18:     0x563da8d18136 - mpt_zktrie::state::witness::WitnessGenerator::handle_new_state::h27b6c80bd6924970
  19:     0x563da92a85f4 - zkevm_circuits::witness::mpt::MptUpdates::mock_fill_state_roots::h553bdbb32ff29c30
```

### Test

Run below block and tx tests with this fix, it could work.

Block number `18509878` contains `BASEFEE` opcode (and returns circuit error of gas-left in BeginTx):
```
GETH0_URL=http://* \
    RUST_BACKTRACE=full \
    RUST_LOG=debug \
    CIRCUIT=evm \
    START_BLOCK=18509878 \
    END_BLOCK=18509878 \
    cargo test --release test_circuit_all_block

[2023-11-16T07:23:54Z INFO  halo2_proofs::dev] MockProver synthesize took 132.965810814s
[2023-11-16T07:32:06Z INFO  mainnet] test evm circuit, block number: 18509878 err num 3
[2023-11-16T07:32:06Z ERROR mainnet] circuit err: Constraint 234 ('BeginTx: State transition (to) constraint of gas_left') in gate 13 ('BeginTx') is not satisfied in Region 14 ('Execution step') at offset 21407
    - Column('Advice', 64 - EVM_q_step)@0 = 1
    
[2023-11-16T07:32:06Z ERROR mainnet] circuit err: Constraint 234 ('BeginTx: State transition (to) constraint of gas_left') in gate 13 ('BeginTx') is not satisfied in Region 14 ('Execution step') at offset 69866
    - Column('Advice', 64 - EVM_q_step)@0 = 1
    
[2023-11-16T07:32:06Z ERROR mainnet] circuit err: Constraint 234 ('BeginTx: State transition (to) constraint of gas_left') in gate 13 ('BeginTx') is not satisfied in Region 14 ('Execution step') at offset 89113
    - Column('Advice', 64 - EVM_q_step)@0 = 1
    
test test_circuit_all_block ... ok
```

TX hash `0bc527d39e95e6e25fcc95898aeb9057ca88bc61f6a402de1a2a6463bc414974` contains `BASEFEE` opcode (block number `18509901` different with above):
```
GETH0_URL=http://* \
    RUST_BACKTRACE=full \
    RUST_LOG=debug \
    CIRCUIT=evm \
    TX_ID=0bc527d39e95e6e25fcc95898aeb9057ca88bc61f6a402de1a2a6463bc414974 \
    cargo test --release test_mock_prove_tx

[2023-11-16T07:23:01Z INFO  halo2_proofs::dev] MockProver synthesize took 3.368390473s
test test_mock_prove_tx has been running for over 60 seconds
[2023-11-16T07:31:32Z INFO  mainnet] prove done
test test_mock_prove_tx ... ok
```