### PR TITLE
feat: add `AccessListGasCost` to fix begin-tx gas cost (EIP 2930 optional-access-list)

### DIFF
--- a/eth-types/src/evm_types.rs
+++ b/eth-types/src/evm_types.rs
@@ -205,6 +205,10 @@ impl GasCost {
     pub const PRECOMPILE_MODEXP_MIN: Self = Self(200);
     /// Base gas cost for precompile call: BLAKE2F
     pub const PRECOMPILE_BLAKE2F: Self = Self(0);
+    /// Gas cost per address in tx access list (EIP 2930)
+    pub const ACCESS_LIST_PER_ADDRESS: Self = Self(2400);
+    /// Gas cost per storage key in tx access list (EIP 2930)
+    pub const ACCESS_LIST_PER_STORAGE_KEY: Self = Self(1900);
 }
 
 impl GasCost {

--- a/eth-types/src/evm_types/gas_utils.rs
+++ b/eth-types/src/evm_types/gas_utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions to help calculate gas
 
 use super::GasCost;
-use crate::Word;
+use crate::{AccessList, Word};
 
 /// Calculate memory expansion gas cost by current and next memory word size.
 pub fn memory_expansion_gas_cost(curr_memory_word_size: u64, next_memory_word_size: u64) -> u64 {
@@ -47,6 +47,18 @@ pub fn eip150_gas(gas_left: u64, gas_specified: Word) -> u64 {
     }
 
     capped_gas
+}
+
+/// Calculate gas cost for access list (EIP 2930).
+pub fn tx_access_list_gas_cost(access_list: &Option<AccessList>) -> u64 {
+    access_list.as_ref().map_or(0, |access_list| {
+        access_list.0.len() as u64 * GasCost::ACCESS_LIST_PER_ADDRESS.as_u64()
+            + access_list
+                .0
+                .iter()
+                .fold(0, |acc, item| acc + item.storage_keys.len() as u64)
+                * GasCost::ACCESS_LIST_PER_STORAGE_KEY.as_u64()
+    })
 }
 
 /// Calculate gas cost for transaction data.

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -146,6 +146,8 @@ pub enum TxFieldTag {
     CallDataLength,
     /// Gas cost for transaction call data (4 for byte == 0, 16 otherwise)
     CallDataGasCost,
+    /// Gas cost for access list (EIP 2930)
+    AccessListGasCost,
     /// Gas cost of the transaction data charged in L1
     TxDataGasCost,
     /// Chain ID

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -19,9 +19,9 @@ use crate::{
         BlockContextFieldTag::{CumNumTxs, NumAllTxs, NumTxs},
         BlockTable, KeccakTable, LookupTable, RlpFsmRlpTable as RlpTable, SigTable, TxFieldTag,
         TxFieldTag::{
-            BlockNumber, CallData, CallDataGasCost, CallDataLength, CallDataRLC, CalleeAddress,
-            CallerAddress, ChainID, Gas, GasPrice, IsCreate, Nonce, SigR, SigS, SigV,
-            TxDataGasCost, TxHashLength, TxHashRLC, TxSignHash, TxSignLength, TxSignRLC,
+            AccessListGasCost, BlockNumber, CallData, CallDataGasCost, CallDataLength, CallDataRLC,
+            CalleeAddress, CallerAddress, ChainID, Gas, GasPrice, IsCreate, Nonce, SigR, SigS,
+            SigV, TxDataGasCost, TxHashLength, TxHashRLC, TxSignHash, TxSignLength, TxSignRLC,
         },
         TxTable, U16Table, U8Table,
     },
@@ -79,11 +79,11 @@ use halo2_proofs::plonk::SecondPhase;
 use itertools::Itertools;
 
 /// Number of rows of one tx occupies in the fixed part of tx table
-pub const TX_LEN: usize = 23;
+pub const TX_LEN: usize = 24;
 /// Offset of TxHash tag in the tx table
-pub const TX_HASH_OFFSET: usize = 21;
+pub const TX_HASH_OFFSET: usize = 22;
 /// Offset of ChainID tag in the tx table
-pub const CHAIN_ID_OFFSET: usize = 12;
+pub const CHAIN_ID_OFFSET: usize = 13;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 enum LookupCondition {
@@ -331,6 +331,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         is_tx_tag!(is_data, CallData);
         is_tx_tag!(is_data_length, CallDataLength);
         is_tx_tag!(is_data_gas_cost, CallDataGasCost);
+        is_tx_tag!(is_access_list_gas_cost, AccessListGasCost);
         is_tx_tag!(is_tx_gas_cost, TxDataGasCost);
         is_tx_tag!(is_data_rlc, CallDataRLC);
         is_tx_tag!(is_chain_id_expr, ChainID);
@@ -466,6 +467,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                 (is_create(meta), Null),
                 (is_data_length(meta), Null),
                 (is_data_gas_cost(meta), Null),
+                (is_access_list_gas_cost(meta), Null),
                 (is_sign_hash(meta), Null),
                 (is_hash(meta), Null),
                 (is_data(meta), Null),
@@ -556,6 +558,8 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
 
             cb.gate(meta.query_fixed(q_enable, Rotation::cur()))
         });
+
+        // TODO: add constraints for AccessListGasCost.
 
         //////////////////////////////////////////////////////////
         ///// Constraints for booleans that reducing degree  /////
@@ -1834,6 +1838,11 @@ impl<F: Field> TxCircuitConfig<F> {
                 CallDataGasCost,
                 None,
                 Value::known(F::from(tx.call_data_gas_cost)),
+            ),
+            (
+                AccessListGasCost,
+                None,
+                Value::known(F::from(tx.access_list_gas_cost)),
             ),
             (
                 TxDataGasCost,


### PR DESCRIPTION
### Summary

Reference [zkevm-specs definition](https://github.com/search?q=repo%3Aprivacy-scaling-explorations%2Fzkevm-specs%20AccessListGasCost&type=code) to calculate and add `AccessListGasCost` value to tx-table.
And add access-list-gas-cost to intrinsic-gas-cost in begin-tx.

After dicussing with @kunxian-xia, the tx-circuit constraints will be added in another PR by @kunxian-xia or @darth-cy (I added a TODO to tx-circuit).

### Test

Tested with integration-tests by below command:
```
GETH0_URL=* \
    RUST_BACKTRACE=full \
    RUST_LOG=debug \
    CIRCUIT=evm \
    TX_ID=0x8f031bc81fbbcba343a5082e17404b5d878ef7cf56eee0a010b536fefdde6d13 \
    cargo test --release test_mock_prove_tx
```

There is a circuit error before this PR:

<img width="800" alt="failure" src="https://github.com/scroll-tech/zkevm-circuits/assets/31645658/2812d507-c746-4dde-890c-51fb466a149c">

It could be fixed with this PR:

<img width="800" alt="success" src="https://github.com/scroll-tech/zkevm-circuits/assets/31645658/2403c1db-d85e-494c-bfbe-d7241bf5b0ed">

I tested this PR with `3` txs (including access-list), they are all successful without the circuit error.
```
0xe581e62eae89509c0ea7b35b6c45c6a5352d4fa4b84adeb089d643d58020835b
0xc18c137021bfa1aa0f25bd2942d409d254e9f1f94df7bb33689ae49a508ac085
0x8f031bc81fbbcba343a5082e17404b5d878ef7cf56eee0a010b536fefdde6d13
```