### PR TITLE
feat: implement access list address and storage key lookups in copy circuit (EIP-2930)

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -490,7 +490,8 @@ impl CopyEvent {
             || self.dst_type == CopyDataType::AccessListStorageKeys
         {
             // For access list, the placeholder is used for copy bytes which
-            // value will be replaced by address and storage key.
+            // value will be replaced by address and storage key, and no word
+            // operations.
             return self.full_length();
         }
 

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -366,12 +366,6 @@ pub enum NumberOrHash {
     Hash(H256),
 }
 
-impl Default for NumberOrHash {
-    fn default() -> Self {
-        Self::Number(0)
-    }
-}
-
 /// Represents all bytes related in one copy event.
 ///
 /// - When the source is memory, `bytes` is the memory content, including masked areas. The
@@ -413,7 +407,7 @@ impl CopyBytes {
 /// Defines a copy event associated with EVM opcodes such as CALLDATACOPY,
 /// CODECOPY, CREATE, etc. More information:
 /// <https://github.com/privacy-scaling-explorations/zkevm-specs/blob/master/specs/copy-proof.md>.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct CopyEvent {
     /// Represents the start address at the source of the copy event.
     pub src_addr: u64,

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -465,7 +465,10 @@ impl CopyEvent {
 
     /// Whether the destination performs RW lookups in the state circuit.
     pub fn is_destination_rw(&self) -> bool {
-        self.dst_type == CopyDataType::Memory || self.dst_type == CopyDataType::TxLog
+        self.dst_type == CopyDataType::Memory
+            || self.dst_type == CopyDataType::TxLog
+            || self.dst_type == CopyDataType::AccessListAddresses
+            || self.dst_type == CopyDataType::AccessListStorageKeys
     }
 
     /// Whether the RLC of data must be computed.
@@ -483,6 +486,14 @@ impl CopyEvent {
 
     /// The number of RW lookups performed by this copy event.
     pub fn rw_counter_delta(&self) -> u64 {
+        if self.dst_type == CopyDataType::AccessListAddresses
+            || self.dst_type == CopyDataType::AccessListStorageKeys
+        {
+            // For access list, the placeholder is used for copy bytes which
+            // value will be replaced by address and storage key.
+            return self.full_length();
+        }
+
         (self.is_source_rw() as u64 + self.is_destination_rw() as u64) * (self.full_length() / 32)
     }
 }

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -233,7 +233,7 @@ impl CopyDataType {
     /// How many bits are necessary to represent a copy data type.
     pub const N_BITS: usize = 3usize;
 }
-const NUM_COPY_DATA_TYPES: usize = 6usize;
+const NUM_COPY_DATA_TYPES: usize = 8usize;
 pub struct CopyDataTypeIter {
     idx: usize,
     back_idx: usize,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -16,8 +16,8 @@ use crate::{
     exec_trace::OperationRef,
     operation::{
         AccountField, AccountOp, CallContextField, CallContextOp, MemoryOp, Op, OpEnum, Operation,
-        StackOp, Target, TxAccessListAccountOp, TxLogField, TxLogOp, TxReceiptField, TxReceiptOp,
-        RW,
+        StackOp, Target, TxAccessListAccountOp, TxAccessListAccountStorageOp, TxLogField, TxLogOp,
+        TxReceiptField, TxReceiptOp, RW,
     },
     precompile::{is_precompiled, PrecompileCalls},
     state_db::{CodeDB, StateDB},
@@ -591,7 +591,7 @@ impl<'a> CircuitInputStateRef<'a> {
     /// adds a reference to the stored operation ([`OperationRef`]) inside
     /// the bus-mapping instance of the current [`ExecStep`].  Then increase
     /// the `block_ctx` [`RWCounter`](crate::operation::RWCounter)  by one.
-    pub fn tx_accesslist_account_write(
+    pub fn tx_access_list_account_write(
         &mut self,
         step: &mut ExecStep,
         tx_id: usize,
@@ -605,6 +605,29 @@ impl<'a> CircuitInputStateRef<'a> {
             TxAccessListAccountOp {
                 tx_id,
                 address,
+                is_warm,
+                is_warm_prev,
+            },
+        )
+    }
+
+    /// Add address storage key to access list for the current transaction.
+    pub fn tx_access_list_storage_key_write(
+        &mut self,
+        step: &mut ExecStep,
+        tx_id: usize,
+        address: Address,
+        key: Word,
+        is_warm: bool,
+        is_warm_prev: bool,
+    ) -> Result<(), Error> {
+        self.push_op(
+            step,
+            RW::WRITE,
+            TxAccessListAccountStorageOp {
+                tx_id,
+                address,
+                key,
                 is_warm,
                 is_warm_prev,
             },

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -638,6 +638,7 @@ fn add_access_list_address_copy_event(
     exec_step: &mut ExecStep,
 ) -> Result<(), Error> {
     let tx_id = state.tx_ctx.id();
+    let rw_counter_start = state.block_ctx.rwc;
 
     // Build copy access list including addresses.
     let access_list = if let Some(access_list) = state.tx.access_list.clone() {
@@ -657,7 +658,6 @@ fn add_access_list_address_copy_event(
     };
 
     let tx_id = NumberOrHash::Number(tx_id);
-    let rw_counter_start = state.block_ctx.rwc;
 
     // Use placeholder bytes for copy steps.
     let copy_bytes = CopyBytes::new(vec![(0, false, false); access_list.len()], None, None);
@@ -665,10 +665,11 @@ fn add_access_list_address_copy_event(
     // Add copy event to copy table.
     let copy_event = CopyEvent {
         src_type: CopyDataType::AccessListAddresses,
-        src_id: tx_id,
+        dst_type: CopyDataType::AccessListAddresses,
+        src_id: tx_id.clone(),
+        dst_id: tx_id,
         src_addr: 1, // index starts from 1.
         src_addr_end: access_list.len() as u64 + 1,
-        dst_type: CopyDataType::AccessListAddresses,
         rw_counter_start,
         copy_bytes,
         access_list,
@@ -723,10 +724,11 @@ fn add_access_list_storage_key_copy_event(
     // Add copy event to copy table.
     let copy_event = CopyEvent {
         src_type: CopyDataType::AccessListStorageKeys,
-        src_id: tx_id,
+        dst_type: CopyDataType::AccessListStorageKeys,
+        src_id: tx_id.clone(),
+        dst_id: tx_id,
         src_addr: 1, // index starts from 1 in tx-table.
         src_addr_end: access_list.len() as u64 + 1,
-        dst_type: CopyDataType::AccessListStorageKeys,
         rw_counter_start,
         copy_bytes,
         access_list,

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -314,7 +314,7 @@ pub fn gen_begin_tx_steps(state: &mut CircuitInputStateRef) -> Result<ExecStep, 
                 log_id: None,
                 rw_counter_start,
                 copy_bytes: CopyBytes::new(bytes, None, None),
-                ..Default::default()
+                access_list: vec![],
             },
         );
     }
@@ -670,10 +670,11 @@ fn add_access_list_address_copy_event(
         dst_id: tx_id,
         src_addr: 1, // index starts from 1.
         src_addr_end: access_list.len() as u64 + 1,
+        dst_addr: 1,
         rw_counter_start,
         copy_bytes,
         access_list,
-        ..Default::default()
+        log_id: None,
     };
 
     state.push_copy(exec_step, copy_event);
@@ -729,10 +730,11 @@ fn add_access_list_storage_key_copy_event(
         dst_id: tx_id,
         src_addr: 1, // index starts from 1 in tx-table.
         src_addr_end: access_list.len() as u64 + 1,
+        dst_addr: 1,
         rw_counter_start,
         copy_bytes,
         access_list,
-        ..Default::default()
+        log_id: None,
     };
 
     state.push_copy(exec_step, copy_event);

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -1,3 +1,4 @@
+use super::TxExecSteps;
 use crate::{
     circuit_input_builder::{
         CircuitInputStateRef, CopyBytes, CopyDataType, CopyEvent, ExecState, ExecStep, NumberOrHash,
@@ -16,12 +17,9 @@ use eth_types::{
         gas_utils::{tx_access_list_gas_cost, tx_data_gas_cost},
         GasCost, MAX_REFUND_QUOTIENT_OF_GAS_USED,
     },
-    geth_types::access_list_size,
     Bytecode, ToWord, Word,
 };
 use ethers_core::utils::get_contract_address;
-
-use super::TxExecSteps;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct BeginEndTx;
@@ -146,7 +144,7 @@ pub fn gen_begin_tx_steps(state: &mut CircuitInputStateRef) -> Result<ExecStep, 
     for address in 1..=9 {
         let address = eth_types::Address::from_low_u64_be(address);
         let is_warm_prev = !state.sdb.add_account_to_access_list(address);
-        state.tx_accesslist_account_write(
+        state.tx_access_list_account_write(
             &mut exec_step,
             state.tx_ctx.id(),
             address,
@@ -171,7 +169,7 @@ pub fn gen_begin_tx_steps(state: &mut CircuitInputStateRef) -> Result<ExecStep, 
     let accessed_addresses = [call.caller_address, call.address];
     for address in accessed_addresses {
         let is_warm_prev = !state.sdb.add_account_to_access_list(address);
-        state.tx_accesslist_account_write(
+        state.tx_access_list_account_write(
             &mut exec_step,
             state.tx_ctx.id(),
             address,
@@ -316,6 +314,7 @@ pub fn gen_begin_tx_steps(state: &mut CircuitInputStateRef) -> Result<ExecStep, 
                 log_id: None,
                 rw_counter_start,
                 copy_bytes: CopyBytes::new(bytes, None, None),
+                ..Default::default()
             },
         );
     }
@@ -628,46 +627,107 @@ fn gen_tx_eip2930_ops(
         return Ok(());
     }
 
+    add_access_list_address_copy_event(state, exec_step)?;
+    add_access_list_storage_key_copy_event(state, exec_step)?;
+
+    Ok(())
+}
+
+fn add_access_list_address_copy_event(
+    state: &mut CircuitInputStateRef,
+    exec_step: &mut ExecStep,
+) -> Result<(), Error> {
+    let tx_id = state.tx_ctx.id();
+
+    // Build copy access list including addresses.
+    let access_list = if let Some(access_list) = state.tx.access_list.clone() {
+        let mut addresses = Vec::with_capacity(access_list.0.len());
+
+        for item in access_list.0.iter() {
+            // Add RW write operations for access list addresses
+            // (will lookup in copy circuit).
+            state.tx_access_list_account_write(exec_step, tx_id, item.address, true, false)?;
+
+            addresses.push((item.address, 0.into()));
+        }
+
+        addresses
+    } else {
+        vec![]
+    };
+
+    let tx_id = NumberOrHash::Number(tx_id);
+    let rw_counter_start = state.block_ctx.rwc;
+    let copy_bytes = CopyBytes::new(vec![(0, false, false); access_list.len()], None, None);
+
+    // Add copy event to copy table.
+    let copy_event = CopyEvent {
+        src_type: CopyDataType::AccessListAddresses,
+        src_id: tx_id,
+        src_addr: 1, // index starts from 1.
+        src_addr_end: access_list.len() as u64 + 1,
+        rw_counter_start,
+        copy_bytes,
+        access_list,
+        ..Default::default()
+    };
+
+    state.push_copy(exec_step, copy_event);
+
+    Ok(())
+}
+
+fn add_access_list_storage_key_copy_event(
+    state: &mut CircuitInputStateRef,
+    exec_step: &mut ExecStep,
+) -> Result<(), Error> {
+    let tx_id = state.tx_ctx.id();
+
+    // Build copy access list including addresses and storage keys.
+    let access_list = if let Some(access_list) = state.tx.access_list.clone() {
+        let mut address_storage_keys = vec![];
+
+        for item in access_list.0.iter() {
+            for storage_key in item.storage_keys.iter() {
+                let storage_key = storage_key.to_word();
+
+                // Add RW write operations for access list address storage keys
+                // (will lookup in copy circuit).
+                state.tx_access_list_storage_key_write(
+                    exec_step,
+                    tx_id,
+                    item.address,
+                    storage_key,
+                    true,
+                    false,
+                )?;
+
+                address_storage_keys.push((item.address, storage_key));
+            }
+        }
+
+        address_storage_keys
+    } else {
+        vec![]
+    };
+
+    let rw_counter_start = state.block_ctx.rwc;
     let tx_id = NumberOrHash::Number(state.tx_ctx.id());
-    let (address_size, storage_key_size) = access_list_size(&state.tx.access_list);
+    let copy_bytes = CopyBytes::new(vec![(0, false, false); access_list.len()], None, None);
 
-    // Add copy event for access-list addresses.
-    let rw_counter_start = state.block_ctx.rwc;
-    state.push_copy(
-        exec_step,
-        CopyEvent {
-            src_addr: 0,
-            src_addr_end: address_size,
-            src_type: CopyDataType::AccessListAddresses,
-            src_id: tx_id.clone(),
-            dst_addr: 0,
-            dst_type: CopyDataType::AccessListAddresses,
-            dst_id: tx_id.clone(),
-            log_id: None,
-            rw_counter_start,
-            // TODO
-            copy_bytes: CopyBytes::new(vec![], None, None),
-        },
-    );
+    // Add copy event to copy table.
+    let copy_event = CopyEvent {
+        src_type: CopyDataType::AccessListStorageKeys,
+        src_id: tx_id,
+        src_addr: 1, // index starts from 1 in tx-table.
+        src_addr_end: access_list.len() as u64 + 1,
+        rw_counter_start,
+        copy_bytes,
+        access_list,
+        ..Default::default()
+    };
 
-    // Add copy event for access-list storage keys.
-    let rw_counter_start = state.block_ctx.rwc;
-    state.push_copy(
-        exec_step,
-        CopyEvent {
-            src_addr: 0,
-            src_addr_end: storage_key_size,
-            src_type: CopyDataType::AccessListStorageKeys,
-            src_id: tx_id.clone(),
-            dst_addr: 0,
-            dst_type: CopyDataType::AccessListStorageKeys,
-            dst_id: tx_id,
-            log_id: None,
-            rw_counter_start,
-            // TODO
-            copy_bytes: CopyBytes::new(vec![], None, None),
-        },
-    );
+    state.push_copy(exec_step, copy_event);
 
     Ok(())
 }

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -658,6 +658,8 @@ fn add_access_list_address_copy_event(
 
     let tx_id = NumberOrHash::Number(tx_id);
     let rw_counter_start = state.block_ctx.rwc;
+
+    // Use placeholder bytes for copy steps.
     let copy_bytes = CopyBytes::new(vec![(0, false, false); access_list.len()], None, None);
 
     // Add copy event to copy table.
@@ -714,6 +716,8 @@ fn add_access_list_storage_key_copy_event(
 
     let rw_counter_start = state.block_ctx.rwc;
     let tx_id = NumberOrHash::Number(state.tx_ctx.id());
+
+    // Use placeholder bytes for copy steps.
     let copy_bytes = CopyBytes::new(vec![(0, false, false); access_list.len()], None, None);
 
     // Add copy event to copy table.

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -666,6 +666,7 @@ fn add_access_list_address_copy_event(
         src_id: tx_id,
         src_addr: 1, // index starts from 1.
         src_addr_end: access_list.len() as u64 + 1,
+        dst_type: CopyDataType::AccessListAddresses,
         rw_counter_start,
         copy_bytes,
         access_list,
@@ -721,6 +722,7 @@ fn add_access_list_storage_key_copy_event(
         src_id: tx_id,
         src_addr: 1, // index starts from 1 in tx-table.
         src_addr_end: access_list.len() as u64 + 1,
+        dst_type: CopyDataType::AccessListStorageKeys,
         rw_counter_start,
         copy_bytes,
         access_list,

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -686,6 +686,7 @@ fn add_access_list_storage_key_copy_event(
     exec_step: &mut ExecStep,
 ) -> Result<(), Error> {
     let tx_id = state.tx_ctx.id();
+    let rw_counter_start = state.block_ctx.rwc;
 
     // Build copy access list including addresses and storage keys.
     let access_list = if let Some(access_list) = state.tx.access_list.clone() {
@@ -715,7 +716,6 @@ fn add_access_list_storage_key_copy_event(
         vec![]
     };
 
-    let rw_counter_start = state.block_ctx.rwc;
     let tx_id = NumberOrHash::Number(state.tx_ctx.id());
 
     // Use placeholder bytes for copy steps.

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -120,7 +120,7 @@ fn gen_copy_event(
             log_id: None,
             rw_counter_start,
             copy_bytes,
-            ..Default::default()
+            access_list: vec![],
         })
     } else {
         let (read_steps, write_steps, prev_bytes) =
@@ -138,7 +138,7 @@ fn gen_copy_event(
             rw_counter_start,
             //fetch pre read and write bytes of CopyBytes
             copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(prev_bytes)),
-            ..Default::default()
+            access_list: vec![],
         })
     }
 }

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -120,6 +120,7 @@ fn gen_copy_event(
             log_id: None,
             rw_counter_start,
             copy_bytes,
+            ..Default::default()
         })
     } else {
         let (read_steps, write_steps, prev_bytes) =
@@ -137,6 +138,7 @@ fn gen_copy_event(
             rw_counter_start,
             //fetch pre read and write bytes of CopyBytes
             copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(prev_bytes)),
+            ..Default::default()
         })
     }
 }

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -382,7 +382,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             log_id: None,
                             rw_counter_start,
                             copy_bytes: CopyBytes::new(copy_steps, None, None),
-                            ..Default::default()
+                            access_list: vec![],
                         },
                     );
                     Some(input_bytes)
@@ -413,7 +413,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             log_id: None,
                             rw_counter_start,
                             copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
-                            ..Default::default()
+                            access_list: vec![],
                         },
                     );
                     Some(output_bytes)
@@ -453,7 +453,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                                 Some(write_steps),
                                 Some(prev_bytes),
                             ),
-                            ..Default::default()
+                            access_list: vec![],
                         },
                     );
                     Some(returned_bytes)

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -382,6 +382,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             log_id: None,
                             rw_counter_start,
                             copy_bytes: CopyBytes::new(copy_steps, None, None),
+                            ..Default::default()
                         },
                     );
                     Some(input_bytes)
@@ -412,6 +413,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                             log_id: None,
                             rw_counter_start,
                             copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
+                            ..Default::default()
                         },
                     );
                     Some(output_bytes)
@@ -451,6 +453,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                                 Some(write_steps),
                                 Some(prev_bytes),
                             ),
+                            ..Default::default()
                         },
                     );
                     Some(returned_bytes)

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -87,7 +87,7 @@ fn gen_copy_event(
         rw_counter_start,
         //fetch pre write bytes of CopyBytes
         copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
-        ..Default::default()
+        access_list: vec![],
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -87,6 +87,7 @@ fn gen_copy_event(
         rw_counter_start,
         //fetch pre write bytes of CopyBytes
         copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
+        ..Default::default()
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -386,7 +386,7 @@ fn handle_copy(
             dst_addr: 0,
             log_id: None,
             copy_bytes: CopyBytes::new(copy_steps, None, None),
-            ..Default::default()
+            access_list: vec![],
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -386,6 +386,7 @@ fn handle_copy(
             dst_addr: 0,
             log_id: None,
             copy_bytes: CopyBytes::new(copy_steps, None, None),
+            ..Default::default()
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -144,7 +144,7 @@ fn gen_copy_event(
         log_id: None,
         rw_counter_start,
         copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
-        ..Default::default()
+        access_list: vec![],
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -144,6 +144,7 @@ fn gen_copy_event(
         log_id: None,
         rw_counter_start,
         copy_bytes: CopyBytes::new(copy_steps, None, Some(prev_bytes)),
+        ..Default::default()
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -150,7 +150,7 @@ fn gen_copy_event(
         log_id: Some(state.tx_ctx.log_id as u64 + 1),
         rw_counter_start,
         copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
-        ..Default::default()
+        access_list: vec![],
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -150,6 +150,7 @@ fn gen_copy_event(
         log_id: Some(state.tx_ctx.log_id as u64 + 1),
         rw_counter_start,
         copy_bytes: CopyBytes::new(read_steps, Some(write_steps), None),
+        ..Default::default()
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -282,7 +282,7 @@ fn handle_copy(
             dst_addr: destination.offset.try_into().unwrap(),
             log_id: None,
             copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(dst_data_prev)),
-            ..Default::default()
+            access_list: vec![],
         },
     );
 
@@ -349,7 +349,7 @@ fn handle_create(
             dst_addr: 0,
             log_id: None,
             copy_bytes: CopyBytes::new(copy_steps, None, None),
-            ..Default::default()
+            access_list: vec![],
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -282,6 +282,7 @@ fn handle_copy(
             dst_addr: destination.offset.try_into().unwrap(),
             log_id: None,
             copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(dst_data_prev)),
+            ..Default::default()
         },
     );
 
@@ -348,6 +349,7 @@ fn handle_create(
             dst_addr: 0,
             log_id: None,
             copy_bytes: CopyBytes::new(copy_steps, None, None),
+            ..Default::default()
         },
     );
 

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -111,6 +111,7 @@ fn gen_copy_event(
         log_id: None,
         rw_counter_start,
         copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(prev_bytes)),
+        ..Default::default()
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -111,7 +111,7 @@ fn gen_copy_event(
         log_id: None,
         rw_counter_start,
         copy_bytes: CopyBytes::new(read_steps, Some(write_steps), Some(prev_bytes)),
-        ..Default::default()
+        access_list: vec![],
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -96,6 +96,7 @@ impl Opcode for Sha3 {
                 log_id: None,
                 rw_counter_start,
                 copy_bytes: CopyBytes::new(copy_steps, None, None),
+                ..Default::default()
             },
         );
 

--- a/bus-mapping/src/evm/opcodes/sha3.rs
+++ b/bus-mapping/src/evm/opcodes/sha3.rs
@@ -96,7 +96,7 @@ impl Opcode for Sha3 {
                 log_id: None,
                 rw_counter_start,
                 copy_bytes: CopyBytes::new(copy_steps, None, None),
-                ..Default::default()
+                access_list: vec![],
             },
         );
 

--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -38,7 +38,10 @@ use ethers_core::types;
 pub use ethers_core::{
     abi::ethereum_types::{BigEndianHash, U512},
     types::{
-        transaction::{eip2930::AccessList, response::Transaction},
+        transaction::{
+            eip2930::{AccessList, AccessListItem},
+            response::Transaction,
+        },
         Address, Block, Bytes, Signature, H160, H256, H64, U256, U64,
     },
 };

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -451,26 +451,30 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             .collect()
         });
 
-        meta.lookup_any("Tx access list address lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_access_list_address, CURRENT);
+        /* TODO: enable tx lookup for access list after merging EIP-1559 PR with tx-table update.
 
-            let tx_id = meta.query_advice(id, CURRENT);
-            let index = meta.query_advice(addr, CURRENT);
-            let address = meta.query_advice(value, CURRENT);
+                meta.lookup_any("Tx access list address lookup", |meta| {
+                    let cond = meta.query_fixed(q_enable, CURRENT)
+                        * meta.query_advice(is_access_list_address, CURRENT);
 
-            vec![
-                1.expr(),
-                tx_id,
-                TxContextFieldTag::AccessListAddress.expr(),
-                index,
-                address,
-            ]
-            .into_iter()
-            .zip(tx_table.table_exprs(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
+                    let tx_id = meta.query_advice(id, CURRENT);
+                    let index = meta.query_advice(addr, CURRENT);
+                    let address = meta.query_advice(value, CURRENT);
+
+                    vec![
+                        1.expr(),
+                        tx_id,
+                        TxContextFieldTag::AccessListAddress.expr(),
+                        index,
+                        address.expr(),
+                        address,
+                    ]
+                    .into_iter()
+                    .zip(tx_table.table_exprs(meta))
+                    .map(|(arg, table)| (cond.clone() * arg, table))
+                    .collect()
+                });
+        */
 
         meta.lookup_any("Rw access list address lookup", |meta| {
             let cond = meta.query_fixed(q_enable, CURRENT)
@@ -499,26 +503,31 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             .collect()
         });
 
-        meta.lookup_any("Tx access list storage key lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_access_list_storage_key, CURRENT);
+        /* TODO: enable tx lookup for access list after merging EIP-1559 PR with tx-table update.
 
-            let tx_id = meta.query_advice(id, CURRENT);
-            let index = meta.query_advice(addr, CURRENT);
-            let storage_key = meta.query_advice(value_prev, CURRENT);
+                meta.lookup_any("Tx access list storage key lookup", |meta| {
+                    let cond = meta.query_fixed(q_enable, CURRENT)
+                        * meta.query_advice(is_access_list_storage_key, CURRENT);
 
-            vec![
-                1.expr(),
-                tx_id,
-                TxContextFieldTag::AccessListStorageKey.expr(),
-                index,
-                storage_key,
-            ]
-            .into_iter()
-            .zip(tx_table.table_exprs(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
+                    let tx_id = meta.query_advice(id, CURRENT);
+                    let index = meta.query_advice(addr, CURRENT);
+                    let address = meta.query_advice(value, CURRENT);
+                    let storage_key = meta.query_advice(value_prev, CURRENT);
+
+                    vec![
+                        1.expr(),
+                        tx_id,
+                        TxContextFieldTag::AccessListStorageKey.expr(),
+                        index,
+                        storage_key,
+                        address,
+                    ]
+                    .into_iter()
+                    .zip(tx_table.table_exprs(meta))
+                    .map(|(arg, table)| (cond.clone() * arg, table))
+                    .collect()
+                });
+        */
 
         meta.lookup_any("Rw access list storage key lookup", |meta| {
             let cond = meta.query_fixed(q_enable, CURRENT)

--- a/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
+++ b/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
@@ -19,6 +19,8 @@ pub fn constrain_tag<F: Field>(
     is_bytecode: Column<Advice>,
     is_memory: Column<Advice>,
     is_tx_log: Column<Advice>,
+    is_access_list_address: Column<Advice>,
+    is_access_list_storage_key: Column<Advice>,
 ) {
     meta.create_gate("decode tag", |meta| {
         let enabled = meta.query_fixed(q_enable, CURRENT);
@@ -26,6 +28,8 @@ pub fn constrain_tag<F: Field>(
         let is_bytecode = meta.query_advice(is_bytecode, CURRENT);
         let is_memory = meta.query_advice(is_memory, CURRENT);
         let is_tx_log = meta.query_advice(is_tx_log, CURRENT);
+        let is_access_list_address = meta.query_advice(is_access_list_address, CURRENT);
+        let is_access_list_storage_key = meta.query_advice(is_access_list_storage_key, CURRENT);
         vec![
             // Match boolean indicators to their respective tag values.
             enabled.expr()
@@ -34,6 +38,12 @@ pub fn constrain_tag<F: Field>(
                 * (is_bytecode - tag.value_equals(CopyDataType::Bytecode, CURRENT)(meta)),
             enabled.expr() * (is_memory - tag.value_equals(CopyDataType::Memory, CURRENT)(meta)),
             enabled.expr() * (is_tx_log - tag.value_equals(CopyDataType::TxLog, CURRENT)(meta)),
+            enabled.expr()
+                * (is_access_list_address
+                    - tag.value_equals(CopyDataType::AccessListAddresses, CURRENT)(meta)),
+            enabled.expr()
+                * (is_access_list_storage_key
+                    - tag.value_equals(CopyDataType::AccessListStorageKeys, CURRENT)(meta)),
         ]
     });
 }

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -259,6 +259,8 @@ fn gen_tx_log_data() -> CircuitInputBuilder {
     builder
 }
 
+// TODO: add test for access list data.
+
 fn gen_create_data() -> CircuitInputBuilder {
     let code = bytecode! {
         PUSH21(Word::from("6B6020600060003760206000F3600052600C6014F3"))

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -291,6 +291,7 @@ fn gen_access_list_data() -> CircuitInputBuilder {
                 .gas_price(gwei(2))
                 .gas(Word::from(0x10000))
                 .value(eth(2))
+                .transaction_type(1) // Set tx type to EIP-2930.
                 .access_list(test_access_list);
         },
         |block, _tx| block.number(0xcafeu64),

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -12,12 +12,17 @@ use bus_mapping::{
     mock::BlockData,
     precompile::PrecompileCalls,
 };
-use eth_types::{bytecode, geth_types::GethData, word, ToWord, Word};
+use eth_types::{
+    address, bytecode, geth_types::GethData, word, AccessList, AccessListItem, ToWord, Word, H256,
+};
 use halo2_proofs::{
     dev::{MockProver, VerifyFailure},
     halo2curves::bn256::Fr,
 };
-use mock::{test_ctx::helpers::account_0_code_account_1_no_code, TestContext, MOCK_ACCOUNTS};
+use mock::{
+    eth, gwei, test_ctx::helpers::account_0_code_account_1_no_code, MockTransaction, TestContext,
+    MOCK_ACCOUNTS,
+};
 
 const K: u32 = 20;
 
@@ -259,7 +264,46 @@ fn gen_tx_log_data() -> CircuitInputBuilder {
     builder
 }
 
-// TODO: add test for access list data.
+fn gen_access_list_data() -> CircuitInputBuilder {
+    let test_access_list = AccessList(vec![
+        AccessListItem {
+            address: address!("0x0000000000000000000000000000000000001111"),
+            storage_keys: [10, 11].map(H256::from_low_u64_be).to_vec(),
+        },
+        AccessListItem {
+            address: address!("0x0000000000000000000000000000000000002222"),
+            storage_keys: [20, 22].map(H256::from_low_u64_be).to_vec(),
+        },
+        AccessListItem {
+            address: address!("0x0000000000000000000000000000000000003333"),
+            storage_keys: [30, 33].map(H256::from_low_u64_be).to_vec(),
+        },
+    ]);
+    let test_ctx = TestContext::<1, 1>::new(
+        None,
+        |accs| {
+            accs[0].address(MOCK_ACCOUNTS[0]).balance(eth(20));
+        },
+        |mut txs, _accs| {
+            txs[0]
+                .from(MOCK_ACCOUNTS[0])
+                .to(MOCK_ACCOUNTS[1])
+                .gas_price(gwei(2))
+                .gas(Word::from(0x10000))
+                .value(eth(2))
+                .access_list(test_access_list);
+        },
+        |block, _tx| block.number(0xcafeu64),
+    )
+    .unwrap();
+    let block: GethData = test_ctx.into();
+    let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
+    builder
+        .handle_block(&block.eth_block, &block.geth_traces)
+        .unwrap();
+
+    builder
+}
 
 fn gen_create_data() -> CircuitInputBuilder {
     let code = bytecode! {
@@ -341,6 +385,13 @@ fn copy_circuit_valid_sha3() {
 #[test]
 fn copy_circuit_valid_tx_log() {
     let builder = gen_tx_log_data();
+    let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
+    assert_eq!(test_copy_circuit_from_block(block), Ok(()));
+}
+
+#[test]
+fn copy_circuit_valid_access_list() {
+    let builder = gen_access_list_data();
     let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
     assert_eq!(test_copy_circuit_from_block(block), Ok(()));
 }
@@ -450,8 +501,6 @@ fn copy_circuit_invalid_tx_log() {
         .find(|err| matches!(err, VerifyFailure::Lookup { .. }))
         .expect("there should be a lookup error");
 }
-
-// todo: add invalid create/return/returndatacopy tests
 
 #[test]
 fn copy_circuit_precompile_call() {

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -174,6 +174,10 @@ pub enum TxFieldTag {
     TxHash,
     /// TxType: Type of the transaction
     TxType,
+    /// Access list address
+    AccessListAddress,
+    /// Access list storage key
+    AccessListStorageKey,
     /// Access list address count (EIP-2930)
     AccessListAddressesLen,
     /// Access list all storage key count (EIP-2930)
@@ -1794,13 +1798,27 @@ impl CopyTable {
 
             let is_pad = is_read_step && thread.addr >= thread.addr_end;
 
-            let value = Value::known(F::from(copy_step.value as u64));
+            let [value, value_prev] = if copy_event.src_type == CopyDataType::AccessListAddresses
+                || copy_event.src_type == CopyDataType::AccessListStorageKeys
+            {
+                let address_pair = copy_event.access_list[step_idx];
+                [
+                    address_pair.0.to_scalar().unwrap(),
+                    address_pair.1.to_scalar().unwrap(),
+                ]
+            } else {
+                [
+                    F::from(copy_step.value as u64),
+                    F::from(copy_step.prev_value as u64),
+                ]
+            }
+            .map(Value::known);
+
             let value_or_pad = if is_pad {
                 Value::known(F::zero())
             } else {
                 value
             };
-            let value_prev = Value::known(F::from(copy_step.prev_value as u64));
 
             if !copy_step.mask {
                 thread.front_mask = false;

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1801,7 +1801,7 @@ impl CopyTable {
             let [value, value_prev] = if copy_event.src_type == CopyDataType::AccessListAddresses
                 || copy_event.src_type == CopyDataType::AccessListStorageKeys
             {
-                let address_pair = copy_event.access_list[step_idx];
+                let address_pair = copy_event.access_list[step_idx / 2];
                 [
                     address_pair.0.to_scalar().unwrap(),
                     address_pair.1.to_scalar().unwrap(),

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -80,7 +80,7 @@ use halo2_proofs::plonk::SecondPhase;
 use itertools::Itertools;
 
 /// Number of rows of one tx occupies in the fixed part of tx table
-pub const TX_LEN: usize = 28;
+pub const TX_LEN: usize = 26;
 /// Offset of TxHash tag in the tx table
 pub const TX_HASH_OFFSET: usize = 21;
 /// Offset of ChainID tag in the tx table

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -80,7 +80,7 @@ use halo2_proofs::plonk::SecondPhase;
 use itertools::Itertools;
 
 /// Number of rows of one tx occupies in the fixed part of tx table
-pub const TX_LEN: usize = 26;
+pub const TX_LEN: usize = 28;
 /// Offset of TxHash tag in the tx table
 pub const TX_HASH_OFFSET: usize = 21;
 /// Offset of ChainID tag in the tx table


### PR DESCRIPTION
### Summary

- Add `access_list` to `CopyEvent`, and assign access list address to `value` and storage key to `value_prev` of copy table, and assign `addr` to `index` of tx table.

- Add both access list address and storage key copy events in begin-tx.

- In copy circuit, for access list do TX lookups as read steps, and RW lookups as write steps. Since there is no real bytes to copy, the copy bytes is just intialized to create read and write steps, and no word alignment (as other copy data type).

- Only enable RW lookups in copy circuit for now, just comment out TX lookups to wait for merging [this EIP-1559 PR](https://github.com/scroll-tech/zkevm-circuits/pull/1030) which implements tx table load for access list.

### Test

- I add a new test case [copy_circuit_valid_access_list](https://github.com/scroll-tech/zkevm-circuits/blob/f8a3b8a85a0684cf05a2e8baf84438983a906ace/zkevm-circuits/src/copy_circuit/test.rs#L394C4-L394C34) to test copy circuit. It could pass.

### TODO

- I will create another PR to enable TX lookups in copy circuit after merging [EIP-1559 PR](https://github.com/scroll-tech/zkevm-circuits/pull/1030).

### Asana

- https://app.asana.com/0/1202365709580304/1206015154508067/f