### PR TITLE
chore(docs): typo fix

### DIFF
--- a/docs/Keccak_Circuit.md
+++ b/docs/Keccak_Circuit.md
@@ -221,7 +221,7 @@ This is a util struict that returns a description of how a 64-bit word will be s
 - `uniform` is true, then `target_sizes` consists of dividing 64 bit positions into even `part_size` plus a possible remainder; 
 - `uniform` is false, then `target_sizes` consists of dividing both the `rot` (rotation) and (64-`rot`)-bit words into even `part_size` but named `part_a` and `part_b` plus a possible remainder for each. 
 
-The parts splitted from the word is then determined bit-by-bit from `target_size`, so that each part will consist of a collection of bit positions that it represents, starting from 0-th bit position. The way bit positions are determined ensures that if
+The parts split from the word is then determined bit-by-bit from `target_size`, so that each part will consist of a collection of bit positions that it represents, starting from 0-th bit position. The way bit positions are determined ensures that if
 
 - `uniform` is true, then the remaining `rot`-sized bits [63-`rot`+1,...,63] are divided by `part_size` plus a remainder, and first 64-`rot` bits are determined by a section compensating previous remainder, plus divide by `part_size`, and plus the remainder from `target_size` division; 
 - `uniform` is false, then the remaining `rot`-sized bits [63-`rot`+1,...,63] are divided by `part_size` plus remainder, and first 64-`rot` bits determined by `part_size` plus a remainder.
@@ -245,7 +245,7 @@ where $\verb#input#[i]$ is the (sparse-word-representation) bit value of `input`
 
 The module splits a $64$-bit word in sparse-word-representation into `parts` according to a given `part_size` using `Word_Parts` with `uniform=true`. 
 
-When this module is called, it will use `CellManager` to allocate a region to store the `input_parts`, which are to be the partition returned by `WordParts`. It then merges the splitted `part_size` interval that contains 0 into one part with size `part_size` in the `output_parts`, while stores the original splitted `input_parts` that are divided by 0 as two separate parts.
+When this module is called, it will use `CellManager` to allocate a region to store the `input_parts`, which are to be the partition returned by `WordParts`. It then merges the split `part_size` interval that contains 0 into one part with size `part_size` in the `output_parts`, while stores the original split `input_parts` that are divided by 0 as two separate parts.
 
 The returned parts from this module are the `output_parts`, which are used for inputs in uniform lookup to check relations constrained by Keccak-permutation operations that involve rotations, such as $\rho/\pi/\chi$ steps.
 
@@ -364,7 +364,7 @@ There are 3 consecutive regions for     `rho_pi_chi_cells`:
 
 #### Constraints 
 
-Lookup in `normalize_4` table already gives a constraint. This is for the $os[i][j]$ step left in the $\theta$-step. Further, since `split_uniform` will combine small parts that are seperated by $0$, lookup to `normalize_4` of these small parts in a uniform way. 
+Lookup in `normalize_4` table already gives a constraint. This is for the $os[i][j]$ step left in the $\theta$-step. Further, since `split_uniform` will combine small parts that are separated by $0$, lookup to `normalize_4` of these small parts in a uniform way. 
 
 #### Rationale
 

--- a/docs/MPT_Circuit.md
+++ b/docs/MPT_Circuit.md
@@ -199,19 +199,19 @@ Notice that the zkTrie adds only one bit of common prefix at each level of its d
 
 #### PathType::Common
 
-`PathType::Common` refers to the sitation that the old and new path share the same topological configuration.
+`PathType::Common` refers to the situation that the old and new path share the same topological configuration.
 
 This can correspond to the topological configuration change on the whole path in the modify operation, or the common path (not extended one) of the insert to/delete from append, or the insert to/delete from fill operations. 
 
 #### PathType::ExtensionNew
 
-`PathType::ExtensionNew` refers to the sitation that the new path extends the old path in its toplogical configuration.
+`PathType::ExtensionNew` refers to the situation that the new path extends the old path in its toplogical configuration.
 
 This can correspond to the extended part of the path in insert to append, insert to fill operations.
 
 #### PathType::ExtensionOld
 
-`PathType::ExtensionOld` refers to the sitation that the old path extends the new path in its toplogical configuration.
+`PathType::ExtensionOld` refers to the situation that the old path extends the new path in its toplogical configuration.
 
 This can correspond to the extended part of the path in delete from append, delete from fill operations.
 

--- a/docs/Modexp_Circuit.md
+++ b/docs/Modexp_Circuit.md
@@ -47,7 +47,7 @@ i.e.,
 \underbrace{\xi_{108}\xi_{109}\cdots  \xi_{215}}_{x_1}
 \underbrace{\xi_{216}\xi_{217}\cdots  \xi_{255}}_{x_2}}
 ```
-in little-endian. This guarentees that $x_0\leq 2^{108}$, $x_1\leq 2^{108}$ and $x_2\leq 2^{108}$, so each of $x_0, x_1, x_2$ can be fit into an $\mathbb{F}_r$ element of Halo2.
+in little-endian. This guarantees that $x_0\leq 2^{108}$, $x_1\leq 2^{108}$ and $x_2\leq 2^{108}$, so each of $x_0, x_1, x_2$ can be fit into an $\mathbb{F}_r$ element of Halo2.
 
 In addition, $x_3$ stands for $x_3=x\mod r$.
 
@@ -353,7 +353,7 @@ A remaining constraint in (2) to ensure that $xy = kp + d$ is the comparison d<p
 
 This method takes two U256 `Number` denoted as `lhs` and `rhs` and returns `1` if `lhs<rhs`, returns `0` if otherwise.
 
-To achieve this, it devides `lhs` and `rhs` into limbs `lhs.limb[0], lhs.limb[1], lhs.limb[2]` and `rhs.limb[0], rhs.limb[1], rhs.limb[2]`. Then 
+To achieve this, it divides `lhs` and `rhs` into limbs `lhs.limb[0], lhs.limb[1], lhs.limb[2]` and `rhs.limb[0], rhs.limb[1], rhs.limb[2]`. Then 
 - if `lhs.limb[2]<rhs.limb[2]`, returns `1`;
 - elseif `lhs.limb[1]<rhs.limb[1]`, returns `1`;
 - elseif `lhs.limb[0]<rhs.limb[0]`, returns `1`;


### PR DESCRIPTION
minor typo fixing in the docs, nothing major

"splitted" is a nonstandard form I believe, correct is "split". can revert if needed.