### PR TITLE
CopyCircuit hi-lo changes

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -350,11 +350,35 @@ impl_expr!(CopyDataType, u64::from);
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CopyStep {
     /// Byte value copied in this step.
-    pub value: u8,
+    pub half_word: [u8; 16],
     /// Byte value before this step.
-    pub prev_value: u8,
+    pub prev_half_word: [u8; 16],
     /// mask indicates this byte won't be copied.
-    pub mask: bool,
+    pub mask: [bool; 16],
+}
+
+impl From<&[(u8, bool, bool)]> for CopyStep {
+    fn from(steps: &[(u8, bool, bool)]) -> Self {
+        assert_eq!(steps.len(), 16, "steps length should be 16");
+        let bytes: [u8; 16] = steps
+            .iter()
+            .copied()
+            .map(|(v, _, _)| v)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        Self {
+            half_word: bytes,
+            prev_half_word: bytes,
+            mask: steps
+                .iter()
+                .copied()
+                .map(|(_, _, m)| m)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        }
+    }
 }
 
 /// Defines an enum type that can hold either a number or a hash value.

--- a/gadgets/src/less_than.rs
+++ b/gadgets/src/less_than.rs
@@ -53,6 +53,18 @@ impl<F: Field, const N_BYTES: usize> LtConfig<F, N_BYTES> {
         let rotation = rotation.unwrap_or_else(Rotation::cur);
         sum::expr(self.diff.iter().map(|c| meta.query_advice(*c, rotation)))
     }
+
+    /// Annotates the Lt chip's columns.
+    pub fn annotate<N, AR>(&self, region: &mut Region<'_, F>, name: N)
+    where
+        N: Fn() -> AR,
+        AR: Into<String>,
+    {
+        region.name_column(|| format!("{}.lt", name().into()), self.lt);
+        for (idx, diff_column) in self.diff.iter().enumerate() {
+            region.name_column(|| format!("{}.diff[{}]", name().into(), idx), *diff_column);
+        }
+    }
 }
 
 /// Chip that compares lhs < rhs.

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -11,13 +11,13 @@ mod test;
 #[cfg(any(feature = "test", test, feature = "test-circuits"))]
 pub use dev::CopyCircuit as TestCopyCircuit;
 
-use crate::util::word;
-use array_init::array_init;
+use crate::{evm_circuit::param::N_BYTES_MEMORY_ADDRESS, util::word};
 use bus_mapping::circuit_input_builder::{CopyDataType, CopyEvent};
 use eth_types::{Field, Word};
 use gadgets::{
     binary_number::BinaryNumberChip,
     is_equal::{IsEqualChip, IsEqualConfig, IsEqualInstruction},
+    less_than::LtInstruction,
     util::{not, select, Expr},
 };
 use halo2_proofs::{
@@ -26,18 +26,20 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::{array, collections::BTreeMap, marker::PhantomData};
 
+use gadgets::less_than::{LtChip, LtConfig};
 #[cfg(feature = "onephase")]
 use halo2_proofs::plonk::FirstPhase as SecondPhase;
 #[cfg(not(feature = "onephase"))]
 use halo2_proofs::plonk::SecondPhase;
+use halo2_proofs::plonk::TableColumn;
 
 use crate::{
-    evm_circuit::util::constraint_builder::BaseConstraintBuilder,
+    evm_circuit::util::{constraint_builder::BaseConstraintBuilder, math_gadget::LtGadget},
     table::{
         BytecodeFieldTag, BytecodeTable, CopyTable, LookupTable, RwTable, RwTableTag,
-        TxContextFieldTag, TxTable,
+        TxContextFieldTag, TxTable, U8Table,
     },
     util::{Challenges, SubCircuit, SubCircuitConfig},
     witness,
@@ -45,11 +47,9 @@ use crate::{
 };
 
 use self::copy_gadgets::{
-    constrain_address, constrain_bytes_left, constrain_event_rlc_acc, constrain_first_last,
-    constrain_forward_parameters, constrain_id, constrain_is_pad, constrain_mask,
-    constrain_masked_value, constrain_must_terminate, constrain_non_pad_non_mask,
-    constrain_rw_counter, constrain_rw_word_complete, constrain_tag, constrain_value_rlc,
-    constrain_word_index,
+    constrain_address, constrain_event_rlc_acc, constrain_first_last, constrain_forward_parameters,
+    constrain_id, constrain_is_pad, constrain_must_terminate, constrain_non_pad_non_mask,
+    constrain_rw_counter, constrain_tag, constrain_value_rlc,
 };
 
 /// The current row.
@@ -67,32 +67,32 @@ const DISABLED_ROWS: usize = 2;
 /// The rw table shared between evm circuit and state circuit
 #[derive(Clone, Debug)]
 pub struct CopyCircuitConfig<F> {
-    /// Whether this row denotes a step. A read row is a step and a write row is
-    /// not.
+    /// Whether this row denotes a step.
+    /// A read row is a step and a write row is not.
     pub q_step: Selector,
     /// Whether the row is the last read-write pair for a copy event.
     pub is_last: Column<Advice>,
-    /// The value copied in this copy step.
-    pub value: Column<Advice>,
-    /// The value before the write.
-    pub value_prev: Column<Advice>,
+    /// The half-word limbs copied in this copy step.
+    pub value_limbs: [Column<Advice>; 16],
     /// The word value for memory lookup.
-    //pub value_word_rlc: Column<Advice>,
-    pub value_word: word::Word<Column<Advice>>,
+    pub value_word: Column<Advice>,
     /// The word value for memory lookup, before the write.
-    // pub value_word_rlc_prev: Column<Advice>,
-    pub value_word_prev: word::Word<Column<Advice>>,
-    /// The index of the current byte within a word [0..31].
-    pub word_index: Column<Advice>,
-    /// mask indicates when a row is not part of the copy, but it is needed to complete the front
-    /// or the back of the first or last memory word.
-    pub mask: Column<Advice>,
-    /// Whether the row is part of the front mask, before the copy data.
-    pub front_mask: Column<Advice>,
+    pub value_word_prev: Column<Advice>,
     /// Random linear combination accumulator of the non-masked copied data.
     pub value_acc: Column<Advice>,
-    /// Whether the row is padding for out-of-bound reads when source address >= src_addr_end.
-    pub is_pad: Column<Advice>,
+    /// Whether the cell is part of the front mask, before the copy data.
+    /// is_front_mask == true when address < addr_copy_start,
+    /// LtGadget compares address < addr_copy_start
+    pub is_front_mask: [LtConfig<F, N_BYTES_MEMORY_ADDRESS>; 16],
+    /// Whether the cell is not part of the back mask, after the copy data.
+    /// is_back_mask == !is_front_mask == true when address >= addr_copy_end,
+    /// LtGadget compares address < addr_copy_end
+    pub is_not_back_mask: [LtConfig<F, N_BYTES_MEMORY_ADDRESS>; 16],
+    /// Whether the cell is in bound reads when source address < src_addr_end.
+    /// LtGadget compares address < src_addr_end
+    pub is_inbound_read: [LtConfig<F, N_BYTES_MEMORY_ADDRESS>; 16],
+    /// non pad and non mask witness to reduce the degree of lookups.
+    pub non_pad_non_mask: [Column<Advice>; 16],
     /// Booleans to indicate what copy data type exists at the current row.
     pub is_tx_calldata: Column<Advice>,
     /// Booleans to indicate what copy data type exists at the current row.
@@ -112,12 +112,6 @@ pub struct CopyCircuitConfig<F> {
     /// The Copy Table contains the columns that are exposed via the lookup
     /// expressions
     pub copy_table: CopyTable,
-    /// Detect when the address reaches the limit src_addr_end.
-    pub is_src_end: IsEqualConfig<F>,
-    /// Whether this is the end of a word (last byte).
-    pub is_word_end: IsEqualConfig<F>,
-    /// non pad and non mask witness to reduce the degree of lookups.
-    pub non_pad_non_mask: Column<Advice>,
     // External tables
     /// TxTable
     pub tx_table: TxTable,
@@ -125,6 +119,8 @@ pub struct CopyCircuitConfig<F> {
     pub rw_table: RwTable,
     /// BytecodeTable
     pub bytecode_table: BytecodeTable,
+    /// u8 lookup Table
+    pub u8_table: U8Table,
 }
 
 /// Circuit configuration arguments
@@ -141,6 +137,8 @@ pub struct CopyCircuitConfigArgs<F: Field> {
     pub q_enable: Column<Fixed>,
     /// Challenges
     pub challenges: Challenges<Expression<F>>,
+    /// u8 lookup Table
+    pub u8_table: U8Table,
 }
 
 impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
@@ -157,30 +155,44 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             copy_table,
             q_enable,
             challenges,
+            u8_table,
         }: Self::ConfigArgs,
     ) -> Self {
         let q_step = meta.complex_selector();
         let is_last = meta.advice_column();
-        let value = meta.advice_column();
-        let value_prev = meta.advice_column();
+        let value_limbs = array::from_fn(|_| meta.advice_column());
 
         // RLC accumulators in the second phase.
         // let code_hash = word::Word::new([meta.advice_column(), meta.advice_column()]);
 
-        let value_word = word::Word::new([meta.advice_column(), meta.advice_column()]);
-        let value_word_prev = word::Word::new([meta.advice_column(), meta.advice_column()]);
+        let value_word = meta.advice_column();
+        let value_word_prev = meta.advice_column();
         let value_acc = meta.advice_column_in(SecondPhase);
 
         let [is_pad, is_tx_calldata, is_bytecode, is_memory, is_tx_log, is_access_list_address, is_access_list_storage_key] =
-            array_init(|_| meta.advice_column());
+            array::from_fn(|_| meta.advice_column());
         let is_first = copy_table.is_first;
         let id = copy_table.id;
         let addr = copy_table.addr;
         let src_addr_end = copy_table.src_addr_end;
+        let addr_copy_start = copy_table.addr_copy_start;
+        let addr_copy_end = copy_table.addr_copy_end;
         let real_bytes_left = copy_table.real_bytes_left;
-        let word_index = meta.advice_column();
-        let mask = meta.advice_column();
-        let front_mask = meta.advice_column();
+
+        let mut lt_init = |lhs_base: Column<Advice>, rhs: Column<Advice>| {
+            array::from_fn(|idx| {
+                LtChip::configure(
+                    meta,
+                    |meta| meta.query_selector(q_step),
+                    |meta| meta.query_advice(lhs_base, CURRENT) + idx.expr(),
+                    |meta| meta.query_advice(rhs, CURRENT),
+                    u8_table.into(),
+                )
+            })
+        };
+        let is_front_mask = lt_init(addr, addr_copy_start);
+        let is_not_back_mask = lt_init(addr, addr_copy_end);
+        let is_inbound_read = lt_init(addr, src_addr_end);
 
         let rlc_acc = copy_table.rlc_acc;
         let rw_counter = copy_table.rw_counter;
@@ -193,21 +205,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
         bytecode_table.annotate_columns(meta);
         copy_table.annotate_columns(meta);
 
-        let is_src_end = IsEqualChip::configure(
-            meta,
-            |meta| meta.query_selector(q_step),
-            |meta| meta.query_advice(addr, CURRENT),
-            |meta| meta.query_advice(src_addr_end, CURRENT),
-        );
-
-        let is_word_end = IsEqualChip::configure(
-            meta,
-            |meta| meta.query_fixed(q_enable, CURRENT),
-            |meta| meta.query_advice(word_index, CURRENT),
-            |_meta| 31.expr(),
-        );
-
-        let non_pad_non_mask = meta.advice_column();
+        let non_pad_non_mask = array::from_fn(|_| meta.advice_column());
 
         constrain_tag(
             meta,
@@ -238,9 +236,11 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             // Detect the last row of an event, which is always a writer row.
             let is_last_col = is_last;
             let is_last = meta.query_advice(is_last, CURRENT);
-            // Detect the rows which process the last byte of a word. The next word starts at
-            // NEXT_STEP.
-            let is_word_end = is_word_end.expr();
+            let is_front_mask_exprs = is_front_mask.clone().map(|chip| chip.is_lt(meta, None));
+            let is_not_back_mask_exprs =
+                is_not_back_mask.clone().map(|chip| chip.is_lt(meta, None));
+            let is_not_back_mask_exprs = is_inbound_read.clone().map(|chip| chip.is_lt(meta, None));
+            let is_inbound_read_exprs = is_inbound_read.clone().map(|chip| chip.is_lt(meta, None));
 
             constrain_id(
                 cb,
@@ -263,38 +263,45 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
 
             constrain_forward_parameters(cb, meta, is_continue.expr(), id, tag, src_addr_end);
 
-            let (is_pad, is_pad_next) = constrain_is_pad(
+            // let (is_pad, is_pad_next) = constrain_is_pad(
+            //     cb,
+            //     meta,
+            //     is_reader.expr(),
+            //     is_first.expr(),
+            //     is_last_col,
+            //     is_pad,
+            //     addr,
+            //     src_addr_end,
+            //     &is_src_end,
+            // );
+
+            // let (mask, mask_next, front_mask) = {
+            //     // The first 31 bytes may be front_mask, but not the last byte of the first word.
+            //     // LOG, access-list address and storage-key have no front mask at all.
+            //     let forbid_front_mask =
+            //         is_word_end.expr() + is_tx_log.expr() + is_access_list.expr();
+            //
+            //     constrain_mask(
+            //         cb,
+            //         meta,
+            //         is_first.expr(),
+            //         is_continue.expr(),
+            //         mask,
+            //         front_mask,
+            //         forbid_front_mask,
+            //     )
+            // };
+
+            constrain_non_pad_non_mask(
                 cb,
                 meta,
-                is_reader.expr(),
-                is_first.expr(),
-                is_last_col,
-                is_pad,
-                addr,
-                src_addr_end,
-                &is_src_end,
+                non_pad_non_mask,
+                is_front_mask_exprs.clone(),
+                is_not_back_mask_exprs.clone(),
+                is_inbound_read_exprs.clone(),
             );
 
-            let (mask, mask_next, front_mask) = {
-                // The first 31 bytes may be front_mask, but not the last byte of the first word.
-                // LOG, access-list address and storage-key have no front mask at all.
-                let forbid_front_mask =
-                    is_word_end.expr() + is_tx_log.expr() + is_access_list.expr();
-
-                constrain_mask(
-                    cb,
-                    meta,
-                    is_first.expr(),
-                    is_continue.expr(),
-                    mask,
-                    front_mask,
-                    forbid_front_mask,
-                )
-            };
-
-            constrain_non_pad_non_mask(cb, meta, non_pad_non_mask, is_pad.expr(), mask.expr());
-
-            constrain_masked_value(cb, meta, mask.expr(), value, value_prev);
+            //constrain_masked_value(cb, meta, mask.expr(), value, value_prev);
 
             constrain_value_rlc(
                 cb,
@@ -303,10 +310,9 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 is_continue.expr(),
                 is_last_col,
                 non_pad_non_mask,
-                is_pad_next.expr(),
-                mask_next.expr(),
+                is_inbound_read.clone(),
                 value_acc,
-                value,
+                value_limbs,
                 challenges.keccak_input(),
             );
 
@@ -328,155 +334,130 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             //     );
             // }
 
-            constrain_word_index(
-                cb,
-                meta,
-                is_first.expr(),
-                is_continue.expr(),
-                is_word_end.expr(),
-                word_index,
-            );
-
-            constrain_bytes_left(
-                cb,
-                meta,
-                is_first.expr(),
-                is_continue.expr(),
-                mask.expr(),
-                real_bytes_left,
-            );
-
-            constrain_address(cb, meta, is_continue.expr(), front_mask.expr(), addr);
+            constrain_address(cb, meta, is_continue.expr(), addr);
 
             {
                 let is_rw_word_type = meta.query_advice(is_memory, CURRENT) + is_tx_log.expr();
                 let is_rw_type = is_rw_word_type.expr() + is_access_list.expr();
-
-                // No word align for access list address and storage key.
-                let is_row_end = select::expr(
-                    is_access_list.expr(),
-                    not::expr(is_reader),
-                    is_word_end.expr(),
-                );
 
                 constrain_rw_counter(
                     cb,
                     meta,
                     is_last.expr(),
                     is_rw_type.expr(),
-                    is_row_end.expr(),
                     rw_counter,
                     rwc_inc_left,
                 );
-
-                constrain_rw_word_complete(cb, is_last_step, is_rw_word_type.expr(), is_word_end);
             }
 
             cb.gate(meta.query_fixed(q_enable, CURRENT))
         });
 
-        // memory word lookup
-        meta.lookup_any("Memory word lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_memory, CURRENT)
-                * is_word_end.is_equal_expression.expr();
+        // TODO: feat/copy-hi-lo
+        // // memory word lookup
+        // meta.lookup_any("Memory word lookup", |meta| {
+        //     let cond = meta.query_fixed(q_enable, CURRENT)
+        //         * meta.query_advice(is_memory, CURRENT)
+        //         * is_word_end.is_equal_expression.expr();
+        //
+        //     let addr_slot = meta.query_advice(addr, CURRENT) - 31.expr();
+        //
+        //     vec![
+        //         1.expr(),
+        //         meta.query_advice(rw_counter, CURRENT),
+        //         not::expr(meta.query_selector(q_step)),
+        //         RwTableTag::Memory.expr(),
+        //         meta.query_advice(id.lo(), Rotation::cur()), // call_id
+        //         addr_slot,
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         meta.query_advice(value_word.lo(), CURRENT),
+        //         meta.query_advice(value_word.hi(), CURRENT),
+        //         meta.query_advice(value_word_prev.lo(), CURRENT),
+        //         meta.query_advice(value_word_prev.hi(), CURRENT),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //     ]
+        //     .into_iter()
+        //     .zip(rw_table.table_exprs(meta))
+        //     .map(|(arg, table)| (cond.clone() * arg, table))
+        //     .collect()
+        // });
 
-            let addr_slot = meta.query_advice(addr, CURRENT) - 31.expr();
+        // TODO: feat/copy-hi-lo
+        // meta.lookup_any("TxLog word lookup", |meta| {
+        //     let cond = meta.query_fixed(q_enable, CURRENT)
+        //         * meta.query_advice(is_tx_log, CURRENT)
+        //         * is_word_end.is_equal_expression.expr();
+        //
+        //     let addr_slot = meta.query_advice(addr, CURRENT) - 31.expr();
+        //
+        //     vec![
+        //         1.expr(),
+        //         meta.query_advice(rw_counter, CURRENT),
+        //         1.expr(),
+        //         RwTableTag::TxLog.expr(),
+        //         //meta.query_advice(id, CURRENT), // tx_id
+        //         meta.query_advice(id.lo(), CURRENT), // tx_id
+        //         addr_slot,                           // byte_index || field_tag || log_id
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         meta.query_advice(value_word.lo(), CURRENT),
+        //         meta.query_advice(value_word.hi(), CURRENT),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //     ]
+        //     .into_iter()
+        //     .zip(rw_table.table_exprs(meta))
+        //     .map(|(arg, table)| (cond.clone() * arg, table))
+        //     .collect()
+        // });
 
-            vec![
-                1.expr(),
-                meta.query_advice(rw_counter, CURRENT),
-                not::expr(meta.query_selector(q_step)),
-                RwTableTag::Memory.expr(),
-                meta.query_advice(id.lo(), Rotation::cur()), // call_id
-                addr_slot,
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                meta.query_advice(value_word.lo(), CURRENT),
-                meta.query_advice(value_word.hi(), CURRENT),
-                meta.query_advice(value_word_prev.lo(), CURRENT),
-                meta.query_advice(value_word_prev.hi(), CURRENT),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-            ]
-            .into_iter()
-            .zip(rw_table.table_exprs(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
-
-        meta.lookup_any("TxLog word lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_tx_log, CURRENT)
-                * is_word_end.is_equal_expression.expr();
-
-            let addr_slot = meta.query_advice(addr, CURRENT) - 31.expr();
-
-            vec![
-                1.expr(),
-                meta.query_advice(rw_counter, CURRENT),
-                1.expr(),
-                RwTableTag::TxLog.expr(),
-                //meta.query_advice(id, CURRENT), // tx_id
-                meta.query_advice(id.lo(), CURRENT), // tx_id
-                addr_slot,                           // byte_index || field_tag || log_id
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                meta.query_advice(value_word.lo(), CURRENT),
-                meta.query_advice(value_word.hi(), CURRENT),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-            ]
-            .into_iter()
-            .zip(rw_table.table_exprs(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
-
-        meta.lookup_any("Bytecode lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_bytecode, CURRENT)
-                * meta.query_advice(non_pad_non_mask, CURRENT);
-
-            vec![
-                1.expr(),
-                meta.query_advice(id.lo(), CURRENT),
-                meta.query_advice(id.hi(), CURRENT),
-                BytecodeFieldTag::Byte.expr(),
-                meta.query_advice(addr, CURRENT),
-                meta.query_advice(value, CURRENT),
-            ]
-            .into_iter()
-            .zip_eq(bytecode_table.table_exprs_mini(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
-
-        meta.lookup_any("Tx calldata lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_tx_calldata, CURRENT)
-                * meta.query_advice(non_pad_non_mask, CURRENT);
-
-            vec![
-                1.expr(),
-                meta.query_advice(id.lo(), CURRENT),
-                TxContextFieldTag::CallData.expr(),
-                meta.query_advice(addr, CURRENT),
-                meta.query_advice(value, CURRENT),
-            ]
-            .into_iter()
-            .zip(tx_table.table_exprs(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
+        // TODO: feat/copy-hi-lo
+        // meta.lookup_any("Bytecode lookup", |meta| {
+        //     let cond = meta.query_fixed(q_enable, CURRENT)
+        //         * meta.query_advice(is_bytecode, CURRENT)
+        //         * meta.query_advice(non_pad_non_mask, CURRENT);
+        //
+        //     vec![
+        //         1.expr(),
+        //         meta.query_advice(id.lo(), CURRENT),
+        //         meta.query_advice(id.hi(), CURRENT),
+        //         BytecodeFieldTag::Byte.expr(),
+        //         meta.query_advice(addr, CURRENT),
+        //         meta.query_advice(value, CURRENT),
+        //     ]
+        //     .into_iter()
+        //     .zip_eq(bytecode_table.table_exprs_mini(meta))
+        //     .map(|(arg, table)| (cond.clone() * arg, table))
+        //     .collect()
+        // });
+        //
+        // meta.lookup_any("Tx calldata lookup", |meta| {
+        //     let cond = meta.query_fixed(q_enable, CURRENT)
+        //         * meta.query_advice(is_tx_calldata, CURRENT)
+        //         * meta.query_advice(non_pad_non_mask, CURRENT);
+        //
+        //     vec![
+        //         1.expr(),
+        //         meta.query_advice(id.lo(), CURRENT),
+        //         TxContextFieldTag::CallData.expr(),
+        //         meta.query_advice(addr, CURRENT),
+        //         meta.query_advice(value, CURRENT),
+        //     ]
+        //     .into_iter()
+        //     .zip(tx_table.table_exprs(meta))
+        //     .map(|(arg, table)| (cond.clone() * arg, table))
+        //     .collect()
+        // });
 
         /* TODO: enable tx lookup for access list after merging EIP-1559 PR with tx-table update.
 
@@ -503,37 +484,38 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 });
         */
 
-        meta.lookup_any("Rw access list address lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_access_list_address, CURRENT);
-
-            let tx_id = meta.query_advice(id.lo(), CURRENT);
-            let address = meta.query_advice(value, CURRENT);
-
-            vec![
-                1.expr(),
-                meta.query_advice(rw_counter, CURRENT),
-                1.expr(),
-                RwTableTag::TxAccessListAccount.expr(),
-                tx_id,
-                address, // access list address
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                1.expr(), // is_warm_lo
-                0.expr(), // is_warm_hi
-                0.expr(), // is_warm_prev_lo
-                0.expr(), // is_warm_prev_hi
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-            ]
-            .into_iter()
-            .zip(rw_table.table_exprs(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
+        // TODO: feat/copy-hi-lo
+        // meta.lookup_any("Rw access list address lookup", |meta| {
+        //     let cond = meta.query_fixed(q_enable, CURRENT)
+        //         * meta.query_advice(is_access_list_address, CURRENT);
+        //
+        //     let tx_id = meta.query_advice(id.lo(), CURRENT);
+        //     let address = meta.query_advice(value, CURRENT);
+        //
+        //     vec![
+        //         1.expr(),
+        //         meta.query_advice(rw_counter, CURRENT),
+        //         1.expr(),
+        //         RwTableTag::TxAccessListAccount.expr(),
+        //         tx_id,
+        //         address, // access list address
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         1.expr(), // is_warm_lo
+        //         0.expr(), // is_warm_hi
+        //         0.expr(), // is_warm_prev_lo
+        //         0.expr(), // is_warm_prev_hi
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //     ]
+        //     .into_iter()
+        //     .zip(rw_table.table_exprs(meta))
+        //     .map(|(arg, table)| (cond.clone() * arg, table))
+        //     .collect()
+        // });
 
         /* TODO: enable tx lookup for access list after merging EIP-1559 PR with tx-table update.
 
@@ -561,52 +543,52 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 });
         */
 
-        meta.lookup_any("Rw access list storage key lookup", |meta| {
-            let cond = meta.query_fixed(q_enable, CURRENT)
-                * meta.query_advice(is_access_list_storage_key, CURRENT);
-
-            let tx_id = meta.query_advice(id.lo(), CURRENT);
-            let address = meta.query_advice(value, CURRENT);
-            let storage_key_lo = meta.query_advice(value_word_prev.lo(), CURRENT);
-            let storage_key_hi = meta.query_advice(value_word_prev.hi(), CURRENT);
-
-            vec![
-                1.expr(),
-                meta.query_advice(rw_counter, CURRENT),
-                1.expr(),
-                RwTableTag::TxAccessListAccountStorage.expr(),
-                tx_id,
-                address, // access list address
-                0.expr(),
-                storage_key_lo, // access list storage_key_lo
-                storage_key_hi, // access list storage_key_hi
-                1.expr(),       // is_warm_lo
-                0.expr(),       // is_warm_hi
-                0.expr(),       // is_warm_prev_lo
-                0.expr(),       // is_warm_prev_hi
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-            ]
-            .into_iter()
-            .zip(rw_table.table_exprs(meta))
-            .map(|(arg, table)| (cond.clone() * arg, table))
-            .collect()
-        });
+        // TODO: feat/copy-hi-lo
+        // meta.lookup_any("Rw access list storage key lookup", |meta| {
+        //     let cond = meta.query_fixed(q_enable, CURRENT)
+        //         * meta.query_advice(is_access_list_storage_key, CURRENT);
+        //
+        //     let tx_id = meta.query_advice(id.lo(), CURRENT);
+        //     let address = meta.query_advice(value, CURRENT);
+        //     let storage_key_lo = meta.query_advice(value_word_prev.lo(), CURRENT);
+        //     let storage_key_hi = meta.query_advice(value_word_prev.hi(), CURRENT);
+        //
+        //     vec![
+        //         1.expr(),
+        //         meta.query_advice(rw_counter, CURRENT),
+        //         1.expr(),
+        //         RwTableTag::TxAccessListAccountStorage.expr(),
+        //         tx_id,
+        //         address, // access list address
+        //         0.expr(),
+        //         storage_key_lo, // access list storage_key_lo
+        //         storage_key_hi, // access list storage_key_hi
+        //         1.expr(),       // is_warm_lo
+        //         0.expr(),       // is_warm_hi
+        //         0.expr(),       // is_warm_prev_lo
+        //         0.expr(),       // is_warm_prev_hi
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //         0.expr(),
+        //     ]
+        //     .into_iter()
+        //     .zip(rw_table.table_exprs(meta))
+        //     .map(|(arg, table)| (cond.clone() * arg, table))
+        //     .collect()
+        // });
 
         Self {
             q_step,
             is_last,
-            value,
-            value_prev,
+            value_limbs,
             value_word,
             value_word_prev,
-            word_index,
-            mask,
-            front_mask,
             value_acc,
-            is_pad,
+            is_front_mask,
+            is_not_back_mask,
+            is_inbound_read,
+            non_pad_non_mask,
             is_tx_calldata,
             is_bytecode,
             is_memory,
@@ -614,13 +596,11 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             is_access_list_address,
             is_access_list_storage_key,
             q_enable,
-            is_src_end,
-            is_word_end,
-            non_pad_non_mask,
             copy_table,
             tx_table,
             rw_table,
             bytecode_table,
+            u8_table,
         }
     }
 }
@@ -632,9 +612,10 @@ impl<F: Field> CopyCircuitConfig<F> {
         &self,
         region: &mut Region<F>,
         offset: &mut usize,
+        is_front_mask_chip: &[LtChip<F, N_BYTES_MEMORY_ADDRESS>; 16],
+        is_not_back_mask_chip: &[LtChip<F, N_BYTES_MEMORY_ADDRESS>; 16],
+        is_inbound_read_chip: &[LtChip<F, N_BYTES_MEMORY_ADDRESS>; 16],
         tag_chip: &BinaryNumberChip<F, CopyDataType, { CopyDataType::N_BITS }>,
-        is_src_end_chip: &IsEqualChip<F>,
-        lt_word_end_chip: &IsEqualChip<F>,
         challenges: Challenges<Value<F>>,
         copy_event: &CopyEvent,
     ) -> Result<(), Error> {
@@ -646,18 +627,7 @@ impl<F: Field> CopyCircuitConfig<F> {
             let is_read = step_idx % 2 == 0;
 
             // Copy table assignments
-            for (&column, &(value, label)) in
-                <CopyTable as LookupTable<F>>::advice_columns(&self.copy_table)
-                    .iter()
-                    .zip_eq(table_row)
-            {
-                region.assign_advice(
-                    || format!("{label} at row: {offset}"),
-                    column,
-                    *offset,
-                    || value,
-                )?;
-            }
+            table_row.assign(&self.copy_table, region, *offset)?;
 
             // q_step
             if is_read {
@@ -671,62 +641,34 @@ impl<F: Field> CopyCircuitConfig<F> {
                 || Value::known(F::one()),
             )?;
 
-            // is_last, value, is_pad
-            for (column, &(value, label)) in [
-                self.is_last,
-                self.value,
-                self.value_prev,
-                self.value_word.lo(),
-                self.value_word.hi(),
-                self.value_word_prev.lo(),
-                self.value_word_prev.hi(),
-                self.value_acc,
-                self.is_pad,
-                self.mask,
-                self.front_mask,
-                self.word_index,
-            ]
-            .iter()
-            .zip_eq(circuit_row)
+            // is_last, value_word, value_word_prev, value_acc
+            circuit_row.assign(self, region, *offset)?;
+            for (idx, ((is_front_mask, is_not_back_mask), is_inbound_read)) in is_front_mask_chip
+                .iter()
+                .zip(is_not_back_mask_chip)
+                .zip(is_inbound_read_chip)
+                .enumerate()
             {
+                let address = table_row.addr + F::from(idx as u64);
+                is_front_mask.assign(region, *offset, address, table_row.addr_copy_start)?;
+                is_not_back_mask.assign(region, *offset, address, table_row.addr_copy_end)?;
+                is_inbound_read.assign(region, *offset, address, table_row.src_addr_end)?;
+
+                let is_front_mask = address < table_row.addr_copy_start;
+                let is_not_back_mask = address < table_row.addr_copy_end;
+                let is_masked = is_front_mask || !is_not_back_mask;
+                let is_inbound_read = address < table_row.src_addr_end;
+                let non_pad_non_mask = !is_masked && is_inbound_read;
                 region.assign_advice(
-                    || format!("{} at row: {}", label, *offset),
-                    *column,
+                    || format!("non_pad_non_mask[{idx}] at row: {offset}"),
+                    self.non_pad_non_mask[idx],
                     *offset,
-                    || value,
+                    || Value::known(F::from(non_pad_non_mask)),
                 )?;
             }
 
             // tag
             tag_chip.assign(region, *offset, tag)?;
-
-            // lt chip
-            if is_read {
-                let addr = table_row[3].0;
-                is_src_end_chip.assign(
-                    region,
-                    *offset,
-                    addr,
-                    Value::known(F::from(copy_event.src_addr_end)),
-                )?;
-            }
-
-            lt_word_end_chip.assign(
-                region,
-                *offset,
-                Value::known(F::from((step_idx as u64 / 2) % 32)), // word index
-                Value::known(F::from(31u64)),
-            )?;
-
-            let pad = unwrap_value(circuit_row[8].0);
-            let mask = unwrap_value(circuit_row[9].0);
-            let non_pad_non_mask = pad.is_zero_vartime() && mask.is_zero_vartime();
-            region.assign_advice(
-                || format!("non_pad_non_mask at row: {offset}"),
-                self.non_pad_non_mask,
-                *offset,
-                || Value::known(F::from(non_pad_non_mask)),
-            )?;
 
             region.assign_advice(
                 || format!("is_tx_calldata at row: {}", *offset),
@@ -795,25 +737,37 @@ impl<F: Field> CopyCircuitConfig<F> {
         };
         let filler_rows = max_copy_rows - copy_rows_needed - DISABLED_ROWS;
 
+        let is_front_mask_chip = self.is_front_mask.map(LtChip::construct);
+        let is_not_back_mask_chip = self.is_not_back_mask.map(LtChip::construct);
+        let is_inbound_read_chip = self.is_inbound_read.map(LtChip::construct);
         let tag_chip = BinaryNumberChip::construct(self.copy_table.tag);
-        let is_src_end_chip = IsEqualChip::construct(self.is_src_end.clone());
-        let lt_word_end_chip = IsEqualChip::construct(self.is_word_end.clone());
 
         layouter.assign_region(
             || "assign copy table",
             |mut region| {
                 region.name_column(|| "is_last", self.is_last);
-                region.name_column(|| "value", self.value);
-                region.name_column(|| "value_prev", self.value_prev);
-                region.name_column(|| "value_word_lo", self.value_word.lo());
-                region.name_column(|| "value_word_hi", self.value_word.hi());
-                region.name_column(|| "value_word_lo", self.value_word_prev.lo());
-                region.name_column(|| "value_word_hi", self.value_word_prev.hi());
-                region.name_column(|| "word_index", self.word_index);
-                region.name_column(|| "mask", self.mask);
-                region.name_column(|| "front_mask", self.front_mask);
-                region.name_column(|| "is_pad", self.is_pad);
-                region.name_column(|| "non_pad_non_mask", self.non_pad_non_mask);
+                region.name_column(|| "value_word", self.value_word);
+                region.name_column(|| "value_word_prev", self.value_word_prev);
+                region.name_column(|| "value_acc", self.value_acc);
+                for i in 0..16 {
+                    region.name_column(|| format!("value_limbs[{}]", i), self.value_limbs[i]);
+                    region.name_column(
+                        || format!("is_front_mask[{}].lt", i),
+                        self.is_front_mask[i].lt,
+                    );
+                    region.name_column(
+                        || format!("is_not_back_mask[{}].lt", i),
+                        self.is_not_back_mask[i].lt,
+                    );
+                    region.name_column(
+                        || format!("is_inbound_read[{}].lt", i),
+                        self.is_inbound_read[i].lt,
+                    );
+                    region.name_column(
+                        || format!("non_pad_non_mask[{}]", i),
+                        self.non_pad_non_mask[i],
+                    );
+                }
 
                 let mut offset = 0;
                 for (ev_idx, copy_event) in copy_events.iter().enumerate() {
@@ -832,9 +786,10 @@ impl<F: Field> CopyCircuitConfig<F> {
                     self.assign_copy_event(
                         &mut region,
                         &mut offset,
+                        &is_front_mask_chip,
+                        &is_not_back_mask_chip,
+                        &is_inbound_read_chip,
                         &tag_chip,
-                        &is_src_end_chip,
-                        &lt_word_end_chip,
                         challenges,
                         copy_event,
                     )?;
@@ -846,9 +801,10 @@ impl<F: Field> CopyCircuitConfig<F> {
                         &mut region,
                         &mut offset,
                         true,
+                        &is_front_mask_chip,
+                        &is_not_back_mask_chip,
+                        &is_inbound_read_chip,
                         &tag_chip,
-                        &is_src_end_chip,
-                        &lt_word_end_chip,
                     )?;
                 }
                 assert_eq!(offset % 2, 0, "enabled rows must come in pairs");
@@ -858,9 +814,10 @@ impl<F: Field> CopyCircuitConfig<F> {
                         &mut region,
                         &mut offset,
                         false,
+                        &is_front_mask_chip,
+                        &is_not_back_mask_chip,
+                        &is_inbound_read_chip,
                         &tag_chip,
-                        &is_src_end_chip,
-                        &lt_word_end_chip,
                     )?;
                 }
 
@@ -875,9 +832,10 @@ impl<F: Field> CopyCircuitConfig<F> {
         region: &mut Region<F>,
         offset: &mut usize,
         enabled: bool,
+        is_front_mask_chip: &[LtChip<F, N_BYTES_MEMORY_ADDRESS>; 16],
+        is_not_back_mask_chip: &[LtChip<F, N_BYTES_MEMORY_ADDRESS>; 16],
+        is_inbound_read_chip: &[LtChip<F, N_BYTES_MEMORY_ADDRESS>; 16],
         tag_chip: &BinaryNumberChip<F, CopyDataType, { CopyDataType::N_BITS }>,
-        is_src_end_chip: &IsEqualChip<F>,
-        lt_word_end_chip: &IsEqualChip<F>,
     ) -> Result<(), Error> {
         // q_enable
         region.assign_fixed(
@@ -940,65 +898,27 @@ impl<F: Field> CopyCircuitConfig<F> {
             || Value::known(F::zero()),
         )?;
         // value
-        region.assign_advice(
-            || format!("assign value {}", *offset),
-            self.value,
-            *offset,
-            || Value::known(F::zero()),
-        )?;
-        // value_prev
-        region.assign_advice(
-            || format!("assign value_prev {}", *offset),
-            self.value_prev,
-            *offset,
-            || Value::known(F::zero()),
-        )?;
+        for (i, col) in self.value_limbs.iter().enumerate() {
+            region.assign_advice(
+                || format!("assign value_limbs[{i}] {offset}"),
+                *col,
+                *offset,
+                || Value::known(F::zero()),
+            )?;
+        }
         // value_word_rlc
         region.assign_advice(
-            || format!("assign value_word_lo {}", *offset),
-            self.value_word.lo(),
-            *offset,
-            || Value::known(F::zero()),
-        )?;
-        region.assign_advice(
-            || format!("assign value_word_hi {}", *offset),
-            self.value_word.hi(),
+            || format!("assign value_word {}", *offset),
+            self.value_word,
             *offset,
             || Value::known(F::zero()),
         )?;
         // value_word_rlc_prev
         region.assign_advice(
-            || format!("assign value_word_prev_lo {}", *offset),
-            self.value_word_prev.lo(),
+            || format!("assign value_word_prev {}", *offset),
+            self.value_word_prev,
             *offset,
             || Value::known(F::zero()),
-        )?;
-        region.assign_advice(
-            || format!("assign value_word_prev_hi {}", *offset),
-            self.value_word_prev.hi(),
-            *offset,
-            || Value::known(F::zero()),
-        )?;
-        // word_index
-        region.assign_advice(
-            || format!("assign word_index {}", *offset),
-            self.word_index,
-            *offset,
-            || Value::known(F::zero()),
-        )?;
-        // mask
-        region.assign_advice(
-            || format!("assign mask {}", *offset),
-            self.mask,
-            *offset,
-            || Value::known(F::one()),
-        )?;
-        // front mask
-        region.assign_advice(
-            || format!("assign front mask {}", *offset),
-            self.front_mask,
-            *offset,
-            || Value::known(F::one()),
         )?;
 
         // value_acc
@@ -1012,13 +932,6 @@ impl<F: Field> CopyCircuitConfig<F> {
         region.assign_advice(
             || format!("assign rlc_acc {}", *offset),
             self.copy_table.rlc_acc,
-            *offset,
-            || Value::known(F::zero()),
-        )?;
-        // is_pad
-        region.assign_advice(
-            || format!("assign is_pad {}", *offset),
-            self.is_pad,
             *offset,
             || Value::known(F::zero()),
         )?;
@@ -1039,25 +952,25 @@ impl<F: Field> CopyCircuitConfig<F> {
         )?;
         // tag
         tag_chip.assign(region, *offset, &CopyDataType::Padding)?;
-        // Assign IsEqual gadgets
-        is_src_end_chip.assign(
-            region,
-            *offset,
-            Value::known(F::zero()),
-            Value::known(F::one()),
-        )?;
-        lt_word_end_chip.assign(
-            region,
-            *offset,
-            Value::known(F::zero()),
-            Value::known(F::from(31u64)),
-        )?;
-        region.assign_advice(
-            || format!("non_pad_non_mask at row: {offset}"),
-            self.non_pad_non_mask,
-            *offset,
-            || Value::known(F::zero()),
-        )?;
+
+        for ((is_front_mask, is_not_back_mask), is_inbound_read) in is_front_mask_chip
+            .iter()
+            .zip(is_not_back_mask_chip)
+            .zip(is_inbound_read_chip)
+        {
+            is_front_mask.assign(region, *offset, F::one(), F::zero())?;
+            is_not_back_mask.assign(region, *offset, F::one(), F::zero())?;
+            is_inbound_read.assign(region, *offset, F::one(), F::zero())?;
+        }
+
+        for (idx, non_pad_non_mask) in self.non_pad_non_mask.iter().enumerate() {
+            region.assign_advice(
+                || format!("non_pad_non_mask[{idx}] at row: {offset}"),
+                *non_pad_non_mask,
+                *offset,
+                || Value::known(F::zero()),
+            )?;
+        }
 
         for column in [
             self.is_tx_calldata,

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -39,7 +39,7 @@ use crate::{
     evm_circuit::util::{constraint_builder::BaseConstraintBuilder, math_gadget::LtGadget},
     table::{
         BytecodeFieldTag, BytecodeTable, CopyTable, LookupTable, RwTable, RwTableTag,
-        TxContextFieldTag, TxTable, U8Table,
+        TxContextFieldTag, TxTable, U8Table, UXTable,
     },
     util::{Challenges, SubCircuit, SubCircuitConfig},
     witness,
@@ -120,7 +120,7 @@ pub struct CopyCircuitConfig<F> {
     /// BytecodeTable
     pub bytecode_table: BytecodeTable,
     /// u8 lookup Table
-    pub u8_table: U8Table,
+    pub u8_table: UXTable<8>,
 }
 
 /// Circuit configuration arguments
@@ -138,7 +138,7 @@ pub struct CopyCircuitConfigArgs<F: Field> {
     /// Challenges
     pub challenges: Challenges<Expression<F>>,
     /// u8 lookup Table
-    pub u8_table: U8Table,
+    pub u8_table: UXTable<8>,
 }
 
 impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
@@ -186,7 +186,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                     |meta| meta.query_selector(q_step),
                     |meta| meta.query_advice(lhs_base, CURRENT) + idx.expr(),
                     |meta| meta.query_advice(rhs, CURRENT),
-                    u8_table.into(),
+                    u8_table.col,
                 )
             })
         };

--- a/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
+++ b/zkevm-circuits/src/copy_circuit/copy_gadgets.rs
@@ -1,16 +1,22 @@
 use super::{CURRENT, NEXT_ROW, NEXT_STEP};
+use crate::{
+    evm_circuit::{
+        param::N_BYTES_MEMORY_ADDRESS,
+        util::constraint_builder::{BaseConstraintBuilder, ConstrainBuilderCommon},
+    },
+    util::word,
+};
 use bus_mapping::circuit_input_builder::CopyDataType;
 use eth_types::Field;
 use gadgets::{
     binary_number::BinaryNumberConfig,
     is_equal::IsEqualConfig,
+    less_than::LtConfig,
     util::{and, not, or, select, sum, Expr},
 };
-use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Expression, Fixed, VirtualCells};
-
-use crate::{
-    evm_circuit::util::constraint_builder::{BaseConstraintBuilder, ConstrainBuilderCommon},
-    util::word,
+use halo2_proofs::{
+    plonk::{Advice, Column, ConstraintSystem, Expression, Fixed, VirtualCells},
+    poly::Rotation,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -172,108 +178,122 @@ pub fn constrain_is_pad<F: Field>(
     (is_pad, is_pad_next)
 }
 
-/// Verify the shape of the mask.
-/// Return (mask, mask at NEXT_STEP, front_mask).
-pub fn constrain_mask<F: Field>(
-    cb: &mut BaseConstraintBuilder<F>,
-    meta: &mut VirtualCells<'_, F>,
-    is_first: Expression<F>,
-    is_continue: Expression<F>,
-    mask: Column<Advice>,
-    front_mask: Column<Advice>,
-    forbid_front_mask: Expression<F>,
-) -> (Expression<F>, Expression<F>, Expression<F>) {
-    cb.condition(is_first.expr(), |cb| {
-        // Apply the same constraints on the first reader and first writer rows.
-        for rot in [CURRENT, NEXT_ROW] {
-            let back_mask = meta.query_advice(mask, rot) - meta.query_advice(front_mask, rot);
-            cb.require_zero("back_mask starts at 0", back_mask);
-        }
-    });
-
-    // Split the mask into front and back segments.
-    // If front_mask=1, then mask=1 and back_mask=0.
-    // If back_mask=1, then mask=1 and front_mask=0.
-    // Otherwise, mask=0.
-    let mask_next = meta.query_advice(mask, NEXT_STEP);
-    let mask = meta.query_advice(mask, CURRENT);
-    let front_mask_next = meta.query_advice(front_mask, NEXT_STEP);
-    let front_mask = meta.query_advice(front_mask, CURRENT);
-    let back_mask_next = mask_next.expr() - front_mask_next.expr();
-    let back_mask = mask.expr() - front_mask.expr();
-    cb.require_boolean("mask is boolean", mask.expr());
-    cb.require_boolean("front_mask is boolean", front_mask.expr());
-    cb.require_boolean("back_mask is boolean", back_mask.expr());
-
-    // The front mask comes before the back mask, with at least 1 non-masked byte
-    // in-between.
-    cb.condition(is_continue.expr(), |cb| {
-        cb.require_boolean(
-            "front_mask cannot go from 0 back to 1",
-            front_mask.expr() - front_mask_next,
-        );
-        cb.require_boolean(
-            "back_mask cannot go from 1 back to 0",
-            back_mask_next.expr() - back_mask,
-        );
-        cb.require_zero(
-            "front_mask is not immediately followed by back_mask",
-            and::expr([front_mask.expr(), back_mask_next.expr()]),
-        );
-    });
-
-    cb.condition(forbid_front_mask, |cb| {
-        cb.require_zero(
-            "front_mask = 0 by the end of the first word",
-            front_mask.expr(),
-        );
-    });
-
-    /* Note: other words may be completely masked, because reader and writer may have different word counts. A fully masked word is a no-op, not contributing to value_acc, and its word_rlc equals word_rlc_prev.
-    cb.require_zero(
-        "back_mask=0 at the start of the next word",
-        and::expr([
-            is_word_end.expr(),
-            back_mask_next.expr(),
-        ]),
-    );*/
-
-    (mask, mask_next, front_mask)
-}
+// /// Verify the shape of the mask.
+// /// Return (mask, mask at NEXT_STEP, front_mask).
+// pub fn constrain_mask<F: Field>(
+//     cb: &mut BaseConstraintBuilder<F>,
+//     meta: &mut VirtualCells<'_, F>,
+//     is_first: Expression<F>,
+//     is_continue: Expression<F>,
+//     mask: Column<Advice>,
+//     front_mask: Column<Advice>,
+//     forbid_front_mask: Expression<F>,
+// ) -> (Expression<F>, Expression<F>, Expression<F>) {
+//     cb.condition(is_first.expr(), |cb| {
+//         // Apply the same constraints on the first reader and first writer rows.
+//         for rot in [CURRENT, NEXT_ROW] {
+//             let back_mask = meta.query_advice(mask, rot) - meta.query_advice(front_mask, rot);
+//             cb.require_zero("back_mask starts at 0", back_mask);
+//         }
+//     });
+//
+//     // Split the mask into front and back segments.
+//     // If front_mask=1, then mask=1 and back_mask=0.
+//     // If back_mask=1, then mask=1 and front_mask=0.
+//     // Otherwise, mask=0.
+//     let mask_next = meta.query_advice(mask, NEXT_STEP);
+//     let mask = meta.query_advice(mask, CURRENT);
+//     let front_mask_next = meta.query_advice(front_mask, NEXT_STEP);
+//     let front_mask = meta.query_advice(front_mask, CURRENT);
+//     let back_mask_next = mask_next.expr() - front_mask_next.expr();
+//     let back_mask = mask.expr() - front_mask.expr();
+//     cb.require_boolean("mask is boolean", mask.expr());
+//     cb.require_boolean("front_mask is boolean", front_mask.expr());
+//     cb.require_boolean("back_mask is boolean", back_mask.expr());
+//
+//     // The front mask comes before the back mask, with at least 1 non-masked byte
+//     // in-between.
+//     cb.condition(is_continue.expr(), |cb| {
+//         cb.require_boolean(
+//             "front_mask cannot go from 0 back to 1",
+//             front_mask.expr() - front_mask_next,
+//         );
+//         cb.require_boolean(
+//             "back_mask cannot go from 1 back to 0",
+//             back_mask_next.expr() - back_mask,
+//         );
+//         cb.require_zero(
+//             "front_mask is not immediately followed by back_mask",
+//             and::expr([front_mask.expr(), back_mask_next.expr()]),
+//         );
+//     });
+//
+//     cb.condition(forbid_front_mask, |cb| {
+//         cb.require_zero(
+//             "front_mask = 0 by the end of the first word",
+//             front_mask.expr(),
+//         );
+//     });
+//
+//     /* Note: other words may be completely masked, because reader and writer may have different
+// word counts. A fully masked word is a no-op, not contributing to value_acc, and its word_rlc
+// equals word_rlc_prev.     cb.require_zero(
+//         "back_mask=0 at the start of the next word",
+//         and::expr([
+//             is_word_end.expr(),
+//             back_mask_next.expr(),
+//         ]),
+//     );*/
+//
+//     (mask, mask_next, front_mask)
+// }
 
 /// Verify non_pad_non_mask = !is_pad AND !mask.
 pub fn constrain_non_pad_non_mask<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,
-    non_pad_non_mask: Column<Advice>,
-    is_pad: Expression<F>,
-    mask: Expression<F>,
+    non_pad_non_mask: [Column<Advice>; 16],
+    is_front_mask: [Expression<F>; 16],
+    is_not_back_mask: [Expression<F>; 16],
+    is_inbound_read: [Expression<F>; 16],
 ) {
-    cb.require_equal(
-        "non_pad_non_mask = !pad AND !mask",
-        meta.query_advice(non_pad_non_mask, CURRENT),
-        and::expr([not::expr(is_pad), not::expr(mask)]),
-    );
+    non_pad_non_mask
+        .into_iter()
+        .zip(
+            is_front_mask
+                .into_iter()
+                .zip(is_not_back_mask)
+                .zip(is_inbound_read),
+        )
+        .for_each(
+            |(non_pad_non_mask, ((is_front_mask, is_not_back_mask), is_inbound_read))| {
+                cb.require_equal(
+                    "non_pad_non_mask = !is_pad AND is_not_front_mask AND is_inbound_read",
+                    meta.query_advice(non_pad_non_mask, CURRENT),
+                    and::expr([not::expr(is_front_mask), is_not_back_mask, is_inbound_read]),
+                );
+            },
+        );
 }
 
-/// Verify that the mask applies to the value written.
-pub fn constrain_masked_value<F: Field>(
-    cb: &mut BaseConstraintBuilder<F>,
-    meta: &mut VirtualCells<'_, F>,
-    mask: Expression<F>,
-    value: Column<Advice>,
-    value_prev: Column<Advice>,
-) {
-    // When a byte is masked, it must not be overwritten, so its value equals its value
-    // before the write.
-    cb.condition(mask, |cb| {
-        cb.require_equal(
-            "value == value_prev on masked rows",
-            meta.query_advice(value, CURRENT),
-            meta.query_advice(value_prev, CURRENT),
-        );
-    });
-}
+// /// Verify that the mask applies to the value written.
+// pub fn constrain_masked_value<F: Field>(
+//     cb: &mut BaseConstraintBuilder<F>,
+//     meta: &mut VirtualCells<'_, F>,
+//     mask: Expression<F>,
+//     value: Column<Advice>,
+//     value_prev: Column<Advice>,
+// ) {
+//     // When a byte is masked, it must not be overwritten, so its value equals its value
+//     // before the write.
+//     cb.condition(mask, |cb| {
+//         cb.require_equal(
+//             "value == value_prev on masked rows",
+//             meta.query_advice(value, CURRENT),
+//             meta.query_advice(value_prev, CURRENT),
+//         );
+//     });
+// }
 
 /// Calculate the RLC of the non-masked data.
 #[allow(clippy::too_many_arguments)]
@@ -283,13 +303,33 @@ pub fn constrain_value_rlc<F: Field>(
     is_first: Expression<F>,
     is_continue: Expression<F>,
     is_last: Column<Advice>,
-    non_pad_non_mask: Column<Advice>,
-    is_pad_next: Expression<F>,
-    mask_next: Expression<F>,
+    non_pad_non_mask: [Column<Advice>; 16],
+    is_inbound_read: [LtConfig<F, N_BYTES_MEMORY_ADDRESS>; 16],
     value_acc: Column<Advice>,
-    value: Column<Advice>,
+    value_limbs: [Column<Advice>; 16],
     challenge: Expression<F>,
 ) {
+    let calc_rlc = |meta: &mut VirtualCells<'_, F>, acc: Expression<F>, rot: Rotation| {
+        let value_exprs = value_limbs.map(|limb| meta.query_advice(limb, rot));
+        let non_pad_non_mask_exprs = non_pad_non_mask.map(|col| meta.query_advice(col, rot));
+        value_exprs
+            .into_iter()
+            .zip(non_pad_non_mask_exprs)
+            .zip(
+                is_inbound_read
+                    .clone()
+                    .map(|chip| chip.is_lt(meta, Some(rot))),
+            )
+            .fold(acc, |acc, ((limb, non_pad_non_mask), is_inbound_read)| {
+                let value = select::expr(is_inbound_read, limb, 0.expr());
+                select::expr(
+                    non_pad_non_mask,
+                    acc.expr() * challenge.clone() + value,
+                    acc,
+                )
+            })
+    };
+
     // Initial values derived from the event.
     cb.condition(is_first.expr(), |cb| {
         // Apply the same constraints on the first reader and first writer rows.
@@ -297,7 +337,7 @@ pub fn constrain_value_rlc<F: Field>(
             cb.require_equal(
                 "value_acc init to the first value, or 0 if padded or masked",
                 meta.query_advice(value_acc, rot),
-                meta.query_advice(value, rot) * meta.query_advice(non_pad_non_mask, rot),
+                calc_rlc(meta, 0.expr(), rot),
             );
         }
     });
@@ -305,14 +345,9 @@ pub fn constrain_value_rlc<F: Field>(
     // Accumulate the next value into the next value_acc.
     cb.condition(is_continue.expr(), |cb| {
         let current = meta.query_advice(value_acc, CURRENT);
-        // If source padding, replace the value with 0.
-        let value_or_pad = meta.query_advice(value, NEXT_STEP) * not::expr(is_pad_next.expr());
-        let accumulated = current.expr() * challenge + value_or_pad;
-        // If masked, copy the accumulator forward, otherwise update it.
-        let copy_or_acc = select::expr(mask_next, current, accumulated);
         cb.require_equal(
             "value_acc(2) == value_acc(0) * r + value(2), or copy value_acc(0)",
-            copy_or_acc,
+            calc_rlc(meta, current.expr(), NEXT_STEP),
             meta.query_advice(value_acc, NEXT_STEP),
         );
     });
@@ -411,82 +446,17 @@ pub fn constrain_word_rlc<F: Field>(
     });
 }
 
-/// Maintain the index within words, looping between 0 and 31 inclusive.
-pub fn constrain_word_index<F: Field>(
-    cb: &mut BaseConstraintBuilder<F>,
-    meta: &mut VirtualCells<'_, F>,
-    is_first: Expression<F>,
-    is_continue: Expression<F>,
-    is_word_end: Expression<F>,
-    word_index: Column<Advice>,
-) {
-    // Initial values derived from the event.
-    cb.condition(is_first.expr(), |cb| {
-        // Apply the same constraints on the first reader and first writer rows.
-        for rot in [CURRENT, NEXT_ROW] {
-            cb.require_zero("word_index starts at 0", meta.query_advice(word_index, rot));
-        }
-    });
-
-    // Update the index into the current or next word.
-    cb.condition(is_continue.expr(), |cb| {
-        let inc_or_reset = select::expr(
-            is_word_end.expr(),
-            0.expr(),
-            meta.query_advice(word_index, CURRENT) + 1.expr(),
-        );
-        cb.require_equal(
-            "word_index increments or resets to 0",
-            inc_or_reset,
-            meta.query_advice(word_index, NEXT_STEP),
-        );
-    });
-}
-
-/// Update the counter of bytes and verify that all bytes are consumed.
-pub fn constrain_bytes_left<F: Field>(
-    cb: &mut BaseConstraintBuilder<F>,
-    meta: &mut VirtualCells<'_, F>,
-    is_first: Expression<F>,
-    is_continue: Expression<F>,
-    mask: Expression<F>,
-    bytes_left: Column<Advice>,
-) {
-    let [current, next_row, next_step] =
-        [CURRENT, NEXT_ROW, NEXT_STEP].map(|at| meta.query_advice(bytes_left, at));
-
-    // Initial values derived from the event.
-    cb.condition(is_first.expr(), |cb| {
-        cb.require_equal("writer initial length", current.expr(), next_row);
-    });
-
-    // Decrement real_bytes_left for the next step, on non-masked rows.
-    let new_value = current - not::expr(mask);
-    // At the end, it must reach 0.
-    let update_or_finish = select::expr(is_continue, next_step, 0.expr());
-    cb.require_equal(
-        "bytes_left[2] == bytes_left[0] - !mask, or 0 at the end",
-        new_value,
-        update_or_finish,
-    );
-}
-
 /// Update the address.
 pub fn constrain_address<F: Field>(
     cb: &mut BaseConstraintBuilder<F>,
     meta: &mut VirtualCells<'_, F>,
     is_continue: Expression<F>,
-    front_mask: Expression<F>,
     addr: Column<Advice>,
 ) {
     cb.condition(is_continue, |cb| {
-        // The address is incremented by 1, except in the front mask. There must be the
-        // right amount of front mask until the row matches up with the
-        // initial address of the event.
-        let addr_diff = not::expr(front_mask);
         cb.require_equal(
-            "rows[0].addr + !front_mask == rows[2].addr",
-            meta.query_advice(addr, CURRENT) + addr_diff,
+            "rows[0].addr + 16 == rows[2].addr",
+            meta.query_advice(addr, CURRENT) + 16.expr(),
             meta.query_advice(addr, NEXT_STEP),
         );
     });
@@ -521,12 +491,11 @@ pub fn constrain_rw_counter<F: Field>(
     meta: &mut VirtualCells<'_, F>,
     is_last: Expression<F>, // The last row.
     is_rw_type: Expression<F>,
-    is_row_end: Expression<F>,
     rw_counter: Column<Advice>,
     rwc_inc_left: Column<Advice>,
 ) {
     // Decrement rwc_inc_left for the next row, when an RW operation happens.
-    let rwc_diff = is_rw_type.expr() * is_row_end.expr();
+    let rwc_diff = is_rw_type.expr();
     let new_value = meta.query_advice(rwc_inc_left, CURRENT) - rwc_diff;
     // At the end, it must reach 0.
     let update_or_finish = select::expr(
@@ -548,21 +517,4 @@ pub fn constrain_rw_counter<F: Field>(
             meta.query_advice(rw_counter, NEXT_ROW) + meta.query_advice(rwc_inc_left, NEXT_ROW),
         );
     });
-}
-
-/// Ensure the word operation completes for RW.
-pub fn constrain_rw_word_complete<F: Field>(
-    cb: &mut BaseConstraintBuilder<F>,
-    is_last_step: Expression<F>, // Both the last reader and writer rows.
-    is_rw_word_type: Expression<F>,
-    is_word_end: Expression<F>,
-) {
-    cb.require_zero(
-        "is_last_step requires is_word_end for word-based types",
-        and::expr([
-            is_last_step.expr(),
-            is_rw_word_type.expr(),
-            not::expr(is_word_end.expr()),
-        ]),
-    );
 }

--- a/zkevm-circuits/src/copy_circuit/dev.rs
+++ b/zkevm-circuits/src/copy_circuit/dev.rs
@@ -2,7 +2,7 @@ pub use super::CopyCircuit;
 
 use crate::{
     copy_circuit::{CopyCircuitConfig, CopyCircuitConfigArgs},
-    table::{BytecodeTable, CopyTable, RwTable, TxTable},
+    table::{BytecodeTable, CopyTable, RwTable, TxTable, U8Table},
     util::{Challenges, SubCircuit, SubCircuitConfig},
 };
 use eth_types::Field;
@@ -29,6 +29,7 @@ impl<F: Field> Circuit<F> for CopyCircuit<F> {
         let copy_table = CopyTable::construct(meta, q_enable);
         let challenges = Challenges::construct(meta);
         let challenge_exprs = challenges.exprs(meta);
+        let u8_table = U8Table::construct(meta);
 
         (
             CopyCircuitConfig::new(
@@ -40,6 +41,7 @@ impl<F: Field> Circuit<F> for CopyCircuit<F> {
                     copy_table,
                     q_enable,
                     challenges: challenge_exprs,
+                    u8_table,
                 },
             ),
             challenges,
@@ -52,6 +54,7 @@ impl<F: Field> Circuit<F> for CopyCircuit<F> {
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
         let challenge_values = config.1.values(&layouter);
+        config.0.u8_table.load(&mut layouter)?;
 
         config.0.tx_table.load(
             &mut layouter,

--- a/zkevm-circuits/src/copy_circuit/dev.rs
+++ b/zkevm-circuits/src/copy_circuit/dev.rs
@@ -2,7 +2,7 @@ pub use super::CopyCircuit;
 
 use crate::{
     copy_circuit::{CopyCircuitConfig, CopyCircuitConfigArgs},
-    table::{BytecodeTable, CopyTable, RwTable, TxTable, U8Table},
+    table::{BytecodeTable, CopyTable, RwTable, TxTable, U8Table, UXTable},
     util::{Challenges, SubCircuit, SubCircuitConfig},
 };
 use eth_types::Field;
@@ -29,7 +29,7 @@ impl<F: Field> Circuit<F> for CopyCircuit<F> {
         let copy_table = CopyTable::construct(meta, q_enable);
         let challenges = Challenges::construct(meta);
         let challenge_exprs = challenges.exprs(meta);
-        let u8_table = U8Table::construct(meta);
+        let u8_table = UXTable::construct(meta);
 
         (
             CopyCircuitConfig::new(

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -310,7 +310,7 @@ impl SubCircuitConfig<Fr> for SuperCircuitConfig<Fr> {
                 copy_table,
                 q_enable: q_copy_table,
                 challenges: challenges_expr.clone(),
-                u8_table,
+                u8_table: ux8_table,
             },
         );
         log_circuit_info(meta, "copy circuit");

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -309,6 +309,7 @@ impl SubCircuitConfig<Fr> for SuperCircuitConfig<Fr> {
                 copy_table,
                 q_enable: q_copy_table,
                 challenges: challenges_expr.clone(),
+                u8_table,
             },
         );
         log_circuit_info(meta, "copy circuit");

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -4,7 +4,7 @@ use crate::{
     copy_circuit::util::number_or_hash_to_word,
     evm_circuit::util::{
         constraint_builder::{BaseConstraintBuilder, ConstrainBuilderCommon},
-        rlc,
+        from_bytes, rlc,
     },
     exp_circuit::param::{OFFSET_INCREMENT, ROWS_PER_STEP},
     impl_expr,
@@ -1682,18 +1682,20 @@ pub struct CopyTable {
     /// 2. The hi/lo limbs of bytecode hash for CopyDataType::Bytecode
     /// 3. Transaction ID for CopyDataType::TxCalldata, CopyDataType::TxLog
     pub id: word::Word<Column<Advice>>,
-    /// The source/destination address for this copy step.  Can be memory
-    /// address, byte index in the bytecode, tx call data, and tx log data.
+    /// The start source/destination address for this copy step.
+    /// Can be memory address, byte index in the bytecode, tx call data, and tx log data.
     pub addr: Column<Advice>,
     /// The end of the source buffer for the copy event.  Any data read from an
     /// address greater than or equal to this value will be 0.
     pub src_addr_end: Column<Advice>,
+    /// The start of the src/dest address for the copy event.
+    /// Might not aligned by 32 bytes, indicating masked bytes.
+    pub addr_copy_start: Column<Advice>,
+    /// The end of the src/dest address for the copy event.
+    /// Might not aligned by 32 bytes, indicating masked bytes.
+    pub addr_copy_end: Column<Advice>,
     /// The number of non-masked bytes left to be copied.
     pub real_bytes_left: Column<Advice>,
-    /// mask indicates the byte is actual coped or padding to memory word
-    pub value_wrod_rlc: Column<Advice>, // TODO: rm
-    /// mask indicates the byte is actual coped or padding to memory word
-    //pub mask: Column<Advice>,
     /// An accumulator value in the RLC representation. This is used for
     /// specific purposes, for instance, when `tag == CopyDataType::RlcAcc`.
     /// Having an additional column for the `rlc_acc` simplifies the lookup
@@ -1709,8 +1711,90 @@ pub struct CopyTable {
     pub tag: BinaryNumberConfig<CopyDataType, { CopyDataType::N_BITS }>,
 }
 
-type CopyTableRow<F> = [(Value<F>, &'static str); 9];
-type CopyCircuitRow<F> = [(Value<F>, &'static str); 12];
+pub struct CopyTableRowAssignment<F> {
+    is_first: F,
+    id: word::Word<Value<F>>,
+    addr: F,
+    src_addr_end: F,
+    real_bytes_left: F,
+    rlc_acc: Value<F>,
+    rw_counter: F,
+    rwc_inc_left: F,
+}
+
+impl<F: Field> CopyTableRowAssignment<F> {
+    pub fn assign(
+        &self,
+        table: &CopyTable,
+        region: &mut Region<'_, F>,
+        offset: usize,
+    ) -> Result<(), Error> {
+        region.assign_advice(
+            || format!("is_first at row: {offset}"),
+            table.is_first,
+            offset,
+            || Value::known(self.is_first),
+        )?;
+        region.assign_advice(
+            || format!("id_lo at row: {offset}"),
+            table.id.lo(),
+            offset,
+            || self.id.lo(),
+        )?;
+        region.assign_advice(
+            || format!("id_hi at row: {offset}"),
+            table.id.hi(),
+            offset,
+            || self.id.hi(),
+        )?;
+        region.assign_advice(
+            || format!("addr at row: {offset}"),
+            table.addr,
+            offset,
+            || Value::known(self.addr),
+        )?;
+        region.assign_advice(
+            || format!("src_addr_end at row: {offset}"),
+            table.src_addr_end,
+            offset,
+            || Value::known(self.src_addr_end),
+        )?;
+        region.assign_advice(
+            || format!("real_bytes_left at row: {offset}"),
+            table.real_bytes_left,
+            offset,
+            || Value::known(self.real_bytes_left),
+        )?;
+        region.assign_advice(
+            || format!("rlc_acc at row: {offset}"),
+            table.rlc_acc,
+            offset,
+            || self.rlc_acc,
+        )?;
+        region.assign_advice(
+            || format!("rw_counter at row: {offset}"),
+            table.rw_counter,
+            offset,
+            || Value::known(self.rw_counter),
+        )?;
+        region.assign_advice(
+            || format!("rwc_inc_left at row: {offset}"),
+            table.rwc_inc_left,
+            offset,
+            || Value::known(self.rwc_inc_left),
+        )?;
+
+        Ok(())
+    }
+}
+
+pub struct CopyCircuitRowAssignment<F> {
+    is_first: F,
+    value_limbs: [F; 16],
+    value_word: F,
+    value_word_prev: F,
+    value_acc: Value<F>,
+}
 
 /// CopyThread is the state used while generating rows of the copy table.
 struct CopyThread<F: Field> {
@@ -1722,10 +1806,6 @@ struct CopyThread<F: Field> {
     addr_end: u64,
     bytes_left: u64,
     value_acc: Value<F>,
-    //word_rlc: Value<F>,
-    value_word: word::Word<Value<F>>,
-    //word_rlc_prev: Value<F>,
-    value_word_prev: word::Word<Value<F>>,
 }
 
 impl CopyTable {
@@ -1738,24 +1818,75 @@ impl CopyTable {
             tag: BinaryNumberChip::configure(meta, q_enable, None),
             addr: meta.advice_column(),
             src_addr_end: meta.advice_column(),
+            addr_copy_start: meta.advice_column(),
+            addr_copy_end: meta.advice_column(),
             real_bytes_left: meta.advice_column(),
-            value_wrod_rlc: meta.advice_column(), // TODO: rm
             rlc_acc: meta.advice_column_in(SecondPhase),
             rw_counter: meta.advice_column(),
             rwc_inc_left: meta.advice_column(),
         }
     }
 
-    /// Generate the copy table and copy circuit assignments from a copy event.
     pub fn assignments<F: Field>(
         copy_event: &CopyEvent,
         challenges: Challenges<Value<F>>,
-    ) -> Vec<(CopyDataType, CopyTableRow<F>, CopyCircuitRow<F>)> {
+    ) -> Vec<(
+        CopyDataType,
+        CopyTableRowAssignment<F>,
+        CopyCircuitRowAssignment<F>,
+    )> {
         assert!(copy_event.src_addr_end >= copy_event.src_addr);
         assert!(
             copy_event.src_type != CopyDataType::Padding
                 && copy_event.dst_type != CopyDataType::Padding,
             "Padding is an internal type"
+        );
+
+        let is_access_list = copy_event.src_type == CopyDataType::AccessListAddresses
+            || copy_event.src_type == CopyDataType::AccessListStorageKeys;
+
+        if is_access_list {
+            Self::assignment_access_list(copy_event, challenges)
+        } else {
+            Self::assignments_inner(copy_event, challenges)
+        }
+    }
+
+    // TODO: move access list to its own table, it messes up the copy circuit logic
+    fn assignment_access_list<F: Field>(
+        copy_event: &CopyEvent,
+        challenges: Challenges<Value<F>>,
+    ) -> Vec<(
+        CopyDataType,
+        CopyTableRowAssignment<F>,
+        CopyCircuitRowAssignment<F>,
+    )> {
+        assert!(
+            copy_event.src_type == CopyDataType::AccessListAddresses
+                || copy_event.src_type == CopyDataType::AccessListStorageKeys,
+            "must be access list copy"
+        );
+
+        let mut assignments = Vec::new();
+
+        todo!();
+
+        assignments
+    }
+
+    /// Generate the copy table and copy circuit assignments from a copy event.
+    fn assignments_inner<F: Field>(
+        copy_event: &CopyEvent,
+        challenges: Challenges<Value<F>>,
+    ) -> Vec<(
+        CopyDataType,
+        CopyTableRowAssignment<F>,
+        CopyCircuitRowAssignment<F>,
+    )> {
+        assert!(
+            copy_event.src_type != CopyDataType::AccessListAddresses
+                && copy_event.src_type != CopyDataType::AccessListStorageKeys,
+            "must not be access list copy"
         );
 
         let mut assignments = Vec::new();
@@ -1776,17 +1907,29 @@ impl CopyTable {
             Value::known(F::zero())
         };
 
-        let read_steps = copy_event.copy_bytes.bytes.iter();
+        assert!(
+            copy_event.copy_bytes.bytes.len() % 32 == 0,
+            "must be aligned by 32 bytes"
+        );
+        let read_steps = copy_event.copy_bytes.bytes.chunks_exact(16);
         let copy_steps = if let Some(ref write_steps) = copy_event.copy_bytes.aux_bytes {
-            read_steps.zip(write_steps.iter())
+            assert!(write_steps.len() == read_steps.len());
+            read_steps.zip(write_steps.chunks_exact(16))
         } else {
-            read_steps.zip(copy_event.copy_bytes.bytes.iter())
+            read_steps.zip(copy_event.copy_bytes.bytes.chunks_exact(16))
         };
 
-        let prev_write_bytes: Vec<u8> = copy_event
+        let prev_write_bytes: Vec<[u8; 16]> = copy_event
             .copy_bytes
             .bytes_write_prev
-            .clone()
+            .map(|bytes| {
+                assert_eq!(bytes.len() % 32, 0, "must be aligned by 32 bytes");
+                assert_eq!(bytes.len(), copy_event.copy_bytes.bytes.len());
+                bytes
+                    .chunks_exact(16)
+                    .map(|chunk| chunk.to_vec().try_into().unwrap())
+                    .collect()
+            })
             .unwrap_or_default();
 
         let mut rw_counter = copy_event.rw_counter_start();
@@ -1805,8 +1948,6 @@ impl CopyTable {
             addr_end: copy_event.src_addr_end,
             bytes_left: copy_event.copy_length(),
             value_acc: Value::known(F::zero()),
-            value_word: word::Word::new([Value::known(F::zero()), Value::known(F::zero())]),
-            value_word_prev: word::Word::new([Value::known(F::zero()), Value::known(F::zero())]),
         };
 
         let mut writer = CopyThread {
@@ -1818,32 +1959,19 @@ impl CopyTable {
             addr_end: copy_event.dst_addr + copy_event.full_length(),
             bytes_left: reader.bytes_left,
             value_acc: Value::known(F::zero()),
-            value_word: word::Word::new([Value::known(F::zero()), Value::known(F::zero())]),
-            value_word_prev: word::Word::new([Value::known(F::zero()), Value::known(F::zero())]),
         };
 
-        let is_access_list = copy_event.src_type == CopyDataType::AccessListAddresses
-            || copy_event.src_type == CopyDataType::AccessListStorageKeys;
         for (step_idx, (is_read_step, mut copy_step)) in copy_steps
             .flat_map(|(read_step, write_step)| {
-                let read_step = CopyStep {
-                    value: read_step.0,
-                    prev_value: read_step.0,
-                    mask: read_step.2,
-                };
-                let write_step = CopyStep {
-                    value: write_step.0,
-                    // Will overwrite if previous values are given.
-                    prev_value: write_step.0,
-                    mask: write_step.2,
-                };
+                let read_step = CopyStep::from(read_step);
+                let write_step = CopyStep::from(write_step);
                 once((true, read_step)).chain(once((false, write_step)))
             })
             .enumerate()
         {
             // re-assign with correct `prev_value` in copy_step
             if !is_read_step && !prev_write_bytes.is_empty() {
-                copy_step.prev_value = *prev_write_bytes.get(step_idx / 2).unwrap();
+                copy_step.prev_half_word = prev_write_bytes[step_idx / 2];
             }
             let copy_step = copy_step;
 
@@ -1863,62 +1991,40 @@ impl CopyTable {
 
             let is_first = step_idx == 0;
             let is_last = step_idx as u64 == copy_event.full_length() * 2 - 1;
+            let is_lo = step_idx % 4 < 2;
 
-            let is_pad = is_read_step && thread.addr >= thread.addr_end;
+            let is_pad: [bool; 16] = (0..16u64)
+                .map(|offset| is_read_step && thread.addr + offset >= thread.addr_end)
+                .collect::<Vec<bool>>()
+                .try_into()
+                .unwrap();
 
-            let [value, value_prev] = if is_access_list {
-                let address_pair = copy_event.access_list[step_idx / 2];
-                [
-                    address_pair.0.to_scalar().unwrap(),
-                    address_pair.1.to_scalar().unwrap(),
-                ]
+            let value_limbs: [F; 16] = copy_step.half_word.map(|b| F::from(b as u64));
+
+            let value_or_pad = is_pad
+                .iter()
+                .zip_eq(value_limbs.iter())
+                .map(|(&pad, &value)| if pad { F::zero() } else { value })
+                .map(Value::known)
+                .collect::<Vec<Value<F>>>();
+            thread.value_acc = value_or_pad.into_iter().zip(copy_step.mask).fold(
+                thread.value_acc,
+                |acc, (value, is_mask)| {
+                    if is_mask {
+                        acc
+                    } else {
+                        acc * Value::known(F::from(256u64)) + value
+                    }
+                },
+            );
+
+            let value_word_limb: F = from_bytes::value(&copy_step.half_word);
+
+            let value_word_limb_prev: F = if is_read_step {
+                value_word_limb // Reader does not change the word.
             } else {
-                [
-                    F::from(copy_step.value as u64),
-                    F::from(copy_step.prev_value as u64),
-                ]
-            }
-            .map(Value::known);
-
-            let value_or_pad = if is_pad {
-                Value::known(F::zero())
-            } else {
-                value
+                from_bytes::value(&copy_step.prev_half_word)
             };
-
-            if !copy_step.mask {
-                thread.front_mask = false;
-                thread.value_acc = thread.value_acc * challenges.keccak_input() + value_or_pad;
-            }
-            if (step_idx / 2) % 32 == 0 {
-                // reset
-                thread.value_word =
-                    word::Word::new([Value::known(F::zero()), Value::known(F::zero())]);
-                thread.value_word_prev =
-                    word::Word::new([Value::known(F::zero()), Value::known(F::zero())]);
-                *value_word_bytes = [0; 32];
-                *value_word_prev_bytes = [0; 32];
-            }
-
-            let word_index = (step_idx as u64 / 2) % 32;
-            value_word_bytes[word_index as usize] = copy_step.value;
-
-            let u256_word = U256::from_big_endian(value_word_bytes);
-            thread.value_word = word::Word::from(u256_word).into_value();
-
-            thread.value_word_prev = if is_read_step {
-                thread.value_word // Reader does not change the word.
-            } else {
-                value_word_prev_bytes[word_index as usize] = copy_step.prev_value;
-                let u256_word_prev = U256::from_big_endian(value_word_prev_bytes);
-                word::Word::from(u256_word_prev).into_value()
-            };
-
-            if is_access_list {
-                let address_pair = copy_event.access_list[step_idx / 2];
-                thread.value_word = word::Word::from(address_pair.0).into_value();
-                thread.value_word_prev = word::Word::from(address_pair.1).into_value();
-            }
 
             // For LOG, format the address including the log_id.
             let addr = if thread.tag == CopyDataType::TxLog {
@@ -1931,43 +2037,31 @@ impl CopyTable {
 
             assignments.push((
                 thread.tag,
-                [
-                    (Value::known(F::from(is_first)), "is_first"),
-                    (thread.id.lo(), "id_lo"),
-                    (thread.id.hi(), "id_hi"),
-                    (Value::known(addr), "addr"),
-                    (Value::known(F::from(thread.addr_end)), "src_addr_end"),
-                    (Value::known(F::from(thread.bytes_left)), "real_bytes_left"),
-                    (rlc_acc, "rlc_acc"),
-                    (Value::known(F::from(rw_counter)), "rw_counter"),
-                    (Value::known(F::from(rwc_inc_left)), "rwc_inc_left"),
-                ],
-                [
-                    (Value::known(F::from(is_last)), "is_last"),
-                    (value, "value"),
-                    (value_prev, "value_prev"),
-                    (thread.value_word.lo(), "value_word lo"),
-                    (thread.value_word.hi(), "value_word hi"),
-                    (thread.value_word_prev.lo(), "value_word_prev lo"),
-                    (thread.value_word_prev.hi(), "value_word_prev hi"),
-                    (thread.value_acc, "value_acc"),
-                    (Value::known(F::from(is_pad)), "is_pad"),
-                    (Value::known(F::from(copy_step.mask)), "mask"),
-                    (Value::known(F::from(thread.front_mask)), "front_mask"),
-                    (Value::known(F::from(word_index)), "word_index"),
-                ],
+                CopyTableRowAssignment {
+                    is_first: F::from(is_first),
+                    id: thread.id,
+                    addr,
+                    src_addr_end: F::from(thread.addr_end),
+                    real_bytes_left: F::from(thread.bytes_left),
+                    rlc_acc,
+                    rw_counter: F::from(rw_counter),
+                    rwc_inc_left: F::from(rwc_inc_left),
+                },
+                CopyCircuitRowAssignment {
+                    is_first: F::from(is_first),
+                    value_limbs,
+                    value_word: value_word_limb,
+                    value_word_prev: value_word_limb_prev,
+                    value_acc: thread.value_acc,
+                },
             ));
 
             // Increment the address.
-            if !thread.front_mask {
-                thread.addr += 1;
-            }
+            thread.addr += 16;
             // Decrement the number of steps left.
-            if !copy_step.mask {
-                thread.bytes_left -= 1;
-            }
+            thread.bytes_left -= copy_step.mask.into_iter().filter(|&b| !b).count() as u64;
             // No word operation for access list data types.
-            let is_row_end = is_access_list || (step_idx / 2) % 32 == 31;
+            let is_row_end = (step_idx / 2) % 2 == 1;
             // Update the RW counter.
             if is_row_end && thread.is_rw {
                 rw_counter += 1;
@@ -2005,7 +2099,6 @@ impl CopyTable {
                 offset += 1;
 
                 let tag_chip = BinaryNumberChip::construct(self.tag);
-                let copy_table_columns = <CopyTable as LookupTable<F>>::advice_columns(self);
                 for copy_event in block.copy_events.iter() {
                     for (tag, row, _) in Self::assignments(copy_event, *challenges) {
                         region.assign_fixed(
@@ -2014,14 +2107,7 @@ impl CopyTable {
                             offset,
                             || Value::known(F::one()),
                         )?;
-                        for (&column, (value, label)) in copy_table_columns.iter().zip_eq(row) {
-                            region.assign_advice(
-                                || format!("{label} at row: {offset}"),
-                                column,
-                                offset,
-                                || value,
-                            )?;
-                        }
+                        row.assign(self, &mut region, offset)?;
                         tag_chip.assign(&mut region, offset, &tag)?;
                         offset += 1;
                     }
@@ -2043,6 +2129,8 @@ impl<F: Field> LookupTable<F> for CopyTable {
             self.id.hi().into(),
             self.addr.into(),
             self.src_addr_end.into(),
+            self.addr_copy_start.into(),
+            self.addr_copy_end.into(),
             self.real_bytes_left.into(),
             self.rlc_acc.into(),
             self.rw_counter.into(),
@@ -2059,6 +2147,8 @@ impl<F: Field> LookupTable<F> for CopyTable {
             String::from("id_hi"),
             String::from("addr"),
             String::from("src_addr_end"),
+            String::from("addr_copy_start"),
+            String::from("addr_copy_end"),
             String::from("real_bytes_left"),
             String::from("rlc_acc"),
             String::from("rw_counter"),
@@ -2078,6 +2168,8 @@ impl<F: Field> LookupTable<F> for CopyTable {
             self.tag.value(Rotation::next())(meta),           // dst_tag
             meta.query_advice(self.addr, Rotation::cur()),    // src_addr
             meta.query_advice(self.src_addr_end, Rotation::cur()), // src_addr_end
+            meta.query_advice(self.addr_copy_start, Rotation::cur()), // src_addr_copy_start
+            meta.query_advice(self.addr_copy_end, Rotation::cur()), // src_addr_copy_end
             meta.query_advice(self.addr, Rotation::next()),   // dst_addr
             meta.query_advice(self.real_bytes_left, Rotation::cur()), // real_length
             meta.query_advice(self.rlc_acc, Rotation::cur()), // rlc_acc


### PR DESCRIPTION
## Layout Changes

### CopyCircuitConfig

Dream's design: https://hackmd.io/geYBzdKjRdmO948KCGnh-Q?view

#### Changes
- is_front_mask: Advice => [LtChip; 16], LtGadget compares  `address < addr_copy_start`.
  `is_front_mask` implies a byte cell has `address < addr_copy_start`, which means it's a masked byte and won't be accumlated in the rlc value.

#### Adds
- value_limbs: [Advice; 16], holds the half word bytes value.
- is_not_back_mask: [LtChip; 16], LtGadget compare `address < addr_copy_end`.
   This strange naming is for disambiguation, since result needs to be opposite.
  `!is_not_back_mask` implies a byte cell has `address >= address_copy_end`, which means it's a masked byte and won't be accumlated in the rlc value.
- is_inbound_read: [LtChip; 16], compare `src_addr_end` > `address`. 
  The `addr_copy_end` might be larger than `src_addr_end`.
  `!is_inbound_read` implies a byte cell has `address >= src_addr_end`, which means it's a out-of-bound read, it's value should be 0.

#### Removes
- value: replaced by `value_limbs`
- value_prev: no longer used
- word_index: no longer used
- mask: replaced by `is_front_mask || !is_not_back_mask`
- is_pad: replaced by `!is_inbound_read`
- is_src_end: replaced by `is_inbound_read`
- is_word_end: no longer used

### CopyTable

#### Adds
- addr_copy_start: The start of the src/dest address for the copy event. Might not aligned by 32 bytes, indicating masked bytes.
- addr_copy_end: The end of the src/dest address for the copy event. Might not aligned by 32 bytes, indicating masked bytes.

#### Changes
- address: holds current half-word address, always aligned and increase by 16
 
## Constraint Changes

### CopyCircuitConfig

- `value_acc == value_acc' + sum(value_i * !(is_front_mask || !is_not_back_mask))`
- `!is_inbound_read` implies `value == 0`