### PR TITLE
Feat: parallelize mpt table loading

### DIFF
--- a/zkevm-circuits/src/mpt_circuit.rs
+++ b/zkevm-circuits/src/mpt_circuit.rs
@@ -138,12 +138,24 @@ impl SubCircuit<Fr> for MptCircuit<Fr> {
         layouter: &mut impl Layouter<Fr>,
     ) -> Result<(), Error> {
         config.0.assign(layouter, &self.proofs, self.row_limit)?;
-        config.1.load(
-            layouter,
-            &self.mpt_updates,
-            self.row_limit,
-            challenges.evm_word(),
-        )?;
+        // use par assignment of mpt table by default.
+        // to use serial version, you must set `PARALLEL_SYN=false`.
+        let use_seq = std::env::var("PARALLEL_SYN").map_or(false, |s| s == *"false");
+        if !use_seq {
+            config.1.load_par(
+                layouter,
+                &self.mpt_updates,
+                self.row_limit,
+                challenges.evm_word(),
+            )?;
+        } else {
+            config.1.load(
+                layouter,
+                &self.mpt_updates,
+                self.row_limit,
+                challenges.evm_word(),
+            )?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
### Description

This pr implements parallel assignment of the mpt table. This is the final step to the https://github.com/scroll-tech/mpt-circuit/pull/99 in which that pr they only parallelized the mpt circuit assignment.

