### PR TITLE
testool: parse access-list from json and yaml

### DIFF
--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -193,7 +193,7 @@ fn into_traceconfig(st: StateTest) -> (String, TraceConfig, StateTestResult) {
                 gas_fee_cap: U256::zero(),
                 gas_tip_cap: U256::zero(),
                 call_data: st.data,
-                access_list: None,
+                access_list: st.access_list,
                 v: sig.v,
                 r: sig.r,
                 s: sig.s,

--- a/testool/src/statetest/spec.rs
+++ b/testool/src/statetest/spec.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail, Context};
-use eth_types::{geth_types::Account, Address, Bytes, Word, H256, U256};
+use eth_types::{geth_types::Account, AccessList, Address, Bytes, Word, H256, U256};
 use ethers_core::{k256::ecdsa::SigningKey, utils::secret_key_to_address};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -57,6 +57,7 @@ pub struct StateTest {
     pub nonce: U256,
     pub value: U256,
     pub data: Bytes,
+    pub access_list: Option<AccessList>,
     pub pre: BTreeMap<Address, Account>,
     pub result: StateTestResult,
     pub exception: bool,
@@ -282,6 +283,7 @@ impl StateTest {
             nonce: U256::zero(),
             value,
             data: data.into(),
+            access_list: None,
             pre,
             result: HashMap::new(),
             exception: false,

--- a/testool/src/statetest/yaml.rs
+++ b/testool/src/statetest/yaml.rs
@@ -3,7 +3,7 @@ use super::{
     spec::{AccountMatch, Env, StateTest, DEFAULT_BASE_FEE},
 };
 use crate::{utils::MainnetFork, Compiler};
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use eth_types::{geth_types::Account, Address, Bytes, H256, U256};
 use ethers_core::{k256::ecdsa::SigningKey, utils::secret_key_to_address};
 use std::{
@@ -12,8 +12,6 @@ use std::{
     str::FromStr,
 };
 use yaml_rust::Yaml;
-
-type Label = String;
 
 #[derive(Debug, Clone)]
 enum Ref {
@@ -152,14 +150,14 @@ impl<'a> YamlStateTestBuilder<'a> {
 
             // generate all the tests defined in the transaction by generating product of
             // data x gas x value
-            for (idx_data, data) in data_s.iter().enumerate() {
+            for (idx_data, calldata) in data_s.iter().enumerate() {
                 for (idx_gas, gas_limit) in gas_limit_s.iter().enumerate() {
                     for (idx_value, value) in value_s.iter().enumerate() {
                         // find the first result that fulfills the pattern
                         for (exception, data_refs, gas_refs, value_refs, result) in &expects {
                             // check if this result can be applied to the current test
                             let mut data_label = String::new();
-                            if let Some(label) = &data.1 {
+                            if let Some(label) = &calldata.label {
                                 if !data_refs.contains_label(label) {
                                     continue;
                                 }
@@ -192,7 +190,8 @@ impl<'a> YamlStateTestBuilder<'a> {
                                 gas_price,
                                 nonce,
                                 value: *value,
-                                data: data.0.clone(),
+                                data: calldata.data.clone(),
+                                access_list: calldata.access_list.clone(),
                                 exception: *exception,
                             });
                             break;
@@ -322,12 +321,15 @@ impl<'a> YamlStateTestBuilder<'a> {
 
     /// returns the element as calldata bytes, supports 0x, :raw, :abi, :yul and
     /// { LLL }
-    fn parse_calldata(&mut self, yaml: &Yaml) -> Result<(Bytes, Option<Label>)> {
+    fn parse_calldata(&mut self, yaml: &Yaml) -> Result<parse::Calldata> {
         if let Some(as_str) = yaml.as_str() {
-            return parse::parse_calldata(self.compiler, as_str);
-        } else if let Some(as_map) = yaml.as_hash() {
+            return parse::parse_calldata(self.compiler, as_str, &None);
+        }
+        if let Some(as_map) = yaml.as_hash() {
             if let Some(Yaml::String(data)) = as_map.get(&Yaml::String("data".to_string())) {
-                return parse::parse_calldata(self.compiler, data);
+                let raw_access_list =
+                    parse_raw_access_list(as_map.get(&Yaml::String("accessList".to_string())))?;
+                return parse::parse_calldata(self.compiler, data, &raw_access_list);
             } else {
                 bail!("do not know what to do with calldata(3): {:?}", yaml);
             }
@@ -435,6 +437,51 @@ impl<'a> YamlStateTestBuilder<'a> {
     }
 }
 
+fn parse_raw_access_list(access_list: Option<&Yaml>) -> Result<Option<parse::RawAccessList>> {
+    if let Some(Yaml::Array(access_items)) = access_list {
+        let access_list = access_items
+            .iter()
+            .map(|item| {
+                item.as_hash().map_or(
+                    Err(anyhow!("Parsed access list item must be a hash")),
+                    |item| {
+                        let address = if let Some(Yaml::String(address)) =
+                            item.get(&Yaml::String("address".to_string()))
+                        {
+                            address.to_string()
+                        } else {
+                            bail!("Parsed access list address must be a string");
+                        };
+
+                        let storage_keys = if let Some(Yaml::Array(storage_keys)) =
+                            item.get(&Yaml::String("storageKeys".to_string()))
+                        {
+                            storage_keys
+                                .iter()
+                                .map(|key| {
+                                    if let Yaml::Integer(key) = key {
+                                        Ok(format!("0x{:064x}", key))
+                                    } else {
+                                        bail!("Parsed access list storage key must be an integer");
+                                    }
+                                })
+                                .collect::<Result<_>>()?
+                        } else {
+                            bail!("Parsed access list storage keys must be an array");
+                        };
+
+                        Ok(parse::RawAccessListItem::new(address, storage_keys))
+                    },
+                )
+            })
+            .collect::<Result<_>>()?;
+
+        return Ok(Some(access_list));
+    }
+
+    Ok(None)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -442,7 +489,7 @@ mod test {
         config::TestSuite,
         statetest::{run_test, CircuitsConfig, StateTestError},
     };
-    use eth_types::address;
+    use eth_types::{address, AccessList, AccessListItem};
 
     const TEMPLATE: &str = r#"
 arith:
@@ -468,7 +515,12 @@ arith:
   transaction:
     data:
     - :raw 0x00
-    - :label data1 :raw 0x01
+    - data: :label data1 :raw 0x01
+      accessList:
+      - address: 0xF00000000000000000000000000000000000F101
+        storageKeys:
+        - 0x60A7
+        - 0xBEEF
     gasLimit:
     - '80000000'
     - '80000001'
@@ -594,17 +646,19 @@ arith:
     }
 
     #[test]
-    fn parse() -> Result<()> {
+    fn test_yaml_parse() -> Result<()> {
         let mut tc = YamlStateTestBuilder::new(&Compiler::default())
             .load_yaml("", &Template::default().to_string())?;
-        let current = tc.remove(0);
+
+        // Check the last test.
+        let current = tc.pop().unwrap();
 
         let a94f5 = address!("a94f5374fce5edbc8e2a8697c15331677e6ebf0b");
         let ccccc = address!("cccccccccccccccccccccccccccccccccccccccc");
 
         let expected = StateTest {
             path: "".into(),
-            id: "arith_d0_g0_v0".into(),
+            id: "arith_d1(data1)_g1_v1".into(),
             env: Env {
                 current_base_fee: U256::from(DEFAULT_BASE_FEE),
                 current_coinbase: address!("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"),
@@ -621,11 +675,15 @@ arith:
             )?),
             from: a94f5,
             to: Some(ccccc),
-            gas_limit: 80000000,
+            gas_limit: 80000001,
             gas_price: U256::from(10u64),
             nonce: U256::zero(),
-            value: U256::one(),
-            data: Bytes::from(&[0]),
+            value: U256::from(2),
+            data: Bytes::from(&[1]),
+            access_list: Some(AccessList(vec![AccessListItem {
+                address: address!("0xf00000000000000000000000000000000000f101"),
+                storage_keys: vec![H256::from_low_u64_be(0x60a7), H256::from_low_u64_be(0xbeef)],
+            }])),
             pre: BTreeMap::from([
                 (
                     ccccc,
@@ -634,7 +692,6 @@ arith:
                         balance: U256::from(1000000000000u64),
                         code: Bytes::from(&[0x60, 0x01, 0x00]),
                         nonce: U256::zero(),
-
                         storage: HashMap::from([(U256::zero(), U256::one())]),
                     },
                 ),
@@ -645,7 +702,6 @@ arith:
                         balance: U256::from(1000000000000u64),
                         code: Bytes::default(),
                         nonce: U256::zero(),
-
                         storage: HashMap::new(),
                     },
                 ),
@@ -654,10 +710,10 @@ arith:
                 ccccc,
                 AccountMatch {
                     address: ccccc,
-                    balance: Some(U256::from(1000000000001u64)),
-                    nonce: Some(U256::from(0)),
-                    code: Some(Bytes::from(&[0x60, 0x01, 0x00])),
-                    storage: HashMap::from([(U256::zero(), U256::one())]),
+                    balance: Some(U256::from(10u64)),
+                    nonce: None,
+                    code: None,
+                    storage: HashMap::new(),
                 },
             )]),
             exception: false,


### PR DESCRIPTION
### Summary

- parse access-list from json (as [ttEIP2930/accessListAddressPrefix00Filler.json](https://github.com/ethereum/tests/blob/747a4828f36c5fc8ab4f288d1cf4f1fe6662f3d6/src/TransactionTestsFiller/ttEIP2930/accessListAddressPrefix00Filler.json#L10)) and yaml (as [stEIP1559/intrinsicFiller.yml](https://github.com/ethereum/tests/blob/747a4828f36c5fc8ab4f288d1cf4f1fe6662f3d6/src/GeneralStateTestsFiller/stEIP1559/intrinsicFiller.yml#L136)) files.

- update parsing unit-tests.