### PR TITLE
fix: move access-list address and storage key from `value` and `value_prev` to `word_rlc` and `word_rlc_prev` in copy circuit

### DIFF
--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -459,7 +459,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
 
                     let tx_id = meta.query_advice(id, CURRENT);
                     let index = meta.query_advice(addr, CURRENT);
-                    let address = meta.query_advice(value, CURRENT);
+                    let address = meta.query_advice(value_word_rlc, CURRENT);
 
                     vec![
                         1.expr(),
@@ -481,7 +481,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 * meta.query_advice(is_access_list_address, CURRENT);
 
             let tx_id = meta.query_advice(id, CURRENT);
-            let address = meta.query_advice(value, CURRENT);
+            let address = meta.query_advice(value_word_rlc, CURRENT);
 
             vec![
                 1.expr(),
@@ -511,8 +511,8 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
 
                     let tx_id = meta.query_advice(id, CURRENT);
                     let index = meta.query_advice(addr, CURRENT);
-                    let address = meta.query_advice(value, CURRENT);
-                    let storage_key = meta.query_advice(value_prev, CURRENT);
+                    let address = meta.query_advice(value_word_rlc, CURRENT);
+                    let storage_key = meta.query_advice(value_word_rlc_prev, CURRENT);
 
                     vec![
                         1.expr(),
@@ -534,8 +534,8 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 * meta.query_advice(is_access_list_storage_key, CURRENT);
 
             let tx_id = meta.query_advice(id, CURRENT);
-            let address = meta.query_advice(value, CURRENT);
-            let storage_key = meta.query_advice(value_prev, CURRENT);
+            let address = meta.query_advice(value_word_rlc, CURRENT);
+            let storage_key = meta.query_advice(value_word_rlc_prev, CURRENT);
 
             vec![
                 1.expr(),


### PR DESCRIPTION
### Summary

Since the `value_prev` column should be deleted after refactor.

- move access-list address from `value` column to `word_rlc`.
- move access-list storage key from `value_prev` column to `word_rlc_prev`.
- update table assignment and copy circuit.
- the test case `copy_circuit_valid_access_list` could pass.
- the RW lookups for access-list address and storage key could work.

Will test tx lookups with EIP-1559 PR https://github.com/scroll-tech/zkevm-circuits/pull/1030.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206261998975756