### PR TITLE
fix (soundness): save access-list `is_warm_prev` to copy circuit

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -405,6 +405,9 @@ impl CopyBytes {
 }
 
 /// Transaction access list for copy event
+/// Save address, storage_key, storage_key_index and is_warm_prev
+/// to column value_word_rlc, value_word_rlc_prev, value and
+/// value_prev in copy circuit.
 #[derive(Clone, Debug)]
 pub struct CopyAccessList {
     /// Access list address
@@ -416,15 +419,24 @@ pub struct CopyAccessList {
     /// storage key, it saves the internal index of storage key, which starts
     /// from zero for each address list.
     pub storage_key_index: u64,
+    /// Identify if address or storage key is warm previously, since the access
+    /// list could have duplicate addresses or storage keys.
+    pub is_warm_prev: bool,
 }
 
 impl CopyAccessList {
     /// Create a copy access list.
-    pub fn new(address: Address, storage_key: Word, storage_key_index: u64) -> Self {
+    pub fn new(
+        address: Address,
+        storage_key: Word,
+        storage_key_index: u64,
+        is_warm_prev: bool,
+    ) -> Self {
         Self {
             address,
             storage_key,
             storage_key_index,
+            is_warm_prev,
         }
     }
 }

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -784,7 +784,15 @@ fn add_access_list_address_copy_event(
                     is_warm_prev,
                 )?;
 
-                Ok(CopyAccessList::new(item.address, Word::zero(), 0))
+                // Save address, storage_key, storage_key_index and is_warm_prev
+                // to column value_word_rlc, value_word_rlc_prev, value and
+                // value_prev in copy circuit.
+                Ok(CopyAccessList::new(
+                    item.address,
+                    Word::zero(),
+                    0,
+                    is_warm_prev,
+                ))
             })
             .collect::<Result<Vec<_>, Error>>()
     })?;
@@ -855,7 +863,15 @@ fn add_access_list_storage_key_copy_event(
                                 is_warm_prev,
                             )?;
 
-                            Ok(CopyAccessList::new(item.address, sk, idx as u64))
+                            // Save address, storage_key, storage_key_index and is_warm_prev
+                            // to column value_word_rlc, value_word_rlc_prev, value and
+                            // value_prev in copy circuit.
+                            Ok(CopyAccessList::new(
+                                item.address,
+                                sk,
+                                idx as u64,
+                                is_warm_prev,
+                            ))
                         })
                         .collect::<Result<Vec<_>, _>>()
                 })

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -478,6 +478,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
 
             let tx_id = meta.query_advice(id, CURRENT);
             let address = meta.query_advice(value_word_rlc, CURRENT);
+            let is_warm_prev = meta.query_advice(value_prev, CURRENT);
 
             vec![
                 1.expr(),
@@ -488,8 +489,8 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 address, // access list address
                 0.expr(),
                 0.expr(),
-                1.expr(), // is_warm
-                0.expr(), // is_warm_prev
+                1.expr(),     // is_warm
+                is_warm_prev, // is_warm_prev
                 0.expr(),
                 0.expr(),
             ]
@@ -527,6 +528,7 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             let tx_id = meta.query_advice(id, CURRENT);
             let address = meta.query_advice(value_word_rlc, CURRENT);
             let storage_key = meta.query_advice(value_word_rlc_prev, CURRENT);
+            let is_warm_prev = meta.query_advice(value_prev, CURRENT);
 
             vec![
                 1.expr(),
@@ -536,9 +538,9 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
                 tx_id,
                 address, // access list address
                 0.expr(),
-                storage_key, // access list storage key
-                1.expr(),    // is_warm
-                0.expr(),    // is_warm_prev
+                storage_key,  // access list storage key
+                1.expr(),     // is_warm
+                is_warm_prev, // is_warm_prev
                 0.expr(),
                 0.expr(),
             ]


### PR DESCRIPTION
### Summary

We do RW lookups for access list addresses and storage keys in copy circuit. Since the access list could have `duplicate` addresses or storage keys, `is_warm_prev` should be saved to copy circuit to avoid always lookuping with false is_warm_prev (the first address or storage key).

Testool result (`4` Fail and `28` Panic, same as previous):
https://circuit-release.s3.us-west-2.amazonaws.com/testool/default.1705540312.04a2a84.html