### PR TITLE
[FIX] Handling oog for sha256 precompile

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1768,9 +1768,7 @@ impl<'a> CircuitInputStateRef<'a> {
                 if is_precompiled(&code_address) {
                     let precompile_call: PrecompileCalls = code_address[19].into();
                     match precompile_call {
-                        PrecompileCalls::Sha256
-                        | PrecompileCalls::Ripemd160
-                        | PrecompileCalls::Blake2F => {
+                        PrecompileCalls::Ripemd160 | PrecompileCalls::Blake2F => {
                             // Log the precompile address and gas left. Since this failure is mainly
                             // caused by out of gas.
                             log::trace!(

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
@@ -73,7 +73,11 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
                 GasCost::PRECOMPILE_ECRECOVER_BASE.expr(),
             ),
             // These are handled in PrecompileFailedGadget
-            // addr_bits.value_equals(PrecompileCalls::Sha256),
+            (
+                addr_bits.value_equals(PrecompileCalls::Sha256),
+                GasCost::PRECOMPILE_SHA256_BASE.expr()
+                    + n_words.quotient() * GasCost::PRECOMPILE_SHA256_PER_WORD.expr(),
+            ),
             // addr_bits.value_equals(PrecompileCalls::Ripemd160),
             // addr_bits.value_equals(PrecompileCalls::Blake2F),
             (
@@ -197,6 +201,11 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
                 let n_words = (call.call_data_length + 31) / 32;
                 precompile_call.base_gas_cost().as_u64()
                     + n_words * GasCost::PRECOMPILE_IDENTITY_PER_WORD.as_u64()
+            }
+            PrecompileCalls::Sha256 => {
+                let n_words = (call.call_data_length + 31) / 32;
+                precompile_call.base_gas_cost().as_u64()
+                    + n_words * GasCost::PRECOMPILE_SHA256_PER_WORD.as_u64()
             }
             PrecompileCalls::Bn128Add | PrecompileCalls::Bn128Mul | PrecompileCalls::Ecrecover => {
                 precompile_call.base_gas_cost().as_u64()


### PR DESCRIPTION
This PR enable `ErrorOOGPrecompileGadget` handling the oog state of sha256-precompile, which is incorrectly disable in previous code.

The gas cost of SHA256 precompile is almost the same as identify precompile so the code required is trivial.