### PR TITLE
[Fix] SHA256 circuit: Wrong final condition base on padding position

### DIFF
--- a/zkevm-circuits/src/sha256_circuit/circuit.rs
+++ b/zkevm-circuits/src/sha256_circuit/circuit.rs
@@ -466,7 +466,7 @@ impl CircuitConfig {
     ) -> Result<BlockInheritments, Error> {
         // if no padding or the padding is in padding size pos, this block is not final
         let is_final = if let Some(pos) = padding_pos {
-            pos <= 24
+            pos < 56
         } else {
             false
         };
@@ -1199,13 +1199,21 @@ mod tests {
     }
 
     #[test]
-    fn sha256_padding_continue() {
-        let circuit = MyCircuit(vec![(vec![b'a'; 62], None)]);
-        let prover = match MockProver::<Fr>::run(17, &circuit, vec![]) {
-            Ok(prover) => prover,
-            Err(e) => panic!("{e:#?}"),
-        };
-        assert_eq!(prover.verify(), Ok(()));
+    fn sha256_padding() {
+        for sz in [32usize, 37, 55, 56, 58, 62, 64] {
+            let circuit = MyCircuit(vec![
+                (vec![0xff; sz], None),
+                (vec![], Some(DIGEST_NIL)),
+                (vec![], Some(DIGEST_NIL)),
+                (vec![], Some(DIGEST_NIL)),
+                (vec![], Some(DIGEST_NIL)),
+            ]);
+            let prover = match MockProver::<Fr>::run(17, &circuit, vec![]) {
+                Ok(prover) => prover,
+                Err(e) => panic!("{e:#?}"),
+            };
+            assert_eq!(prover.verify(), Ok(()));
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR has fixed sha256 circuit, in which the condition for "final block" is error since a wrong specify for padding position.

This PR should fixed the current issues found by testtools