### PR TITLE
RlpDecodingTable Id Column Phase Correction

### DIFF
--- a/zkevm-circuits/src/rlp_circuit_fsm.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm.rs
@@ -215,7 +215,7 @@ impl RlpDecodingTable {
     /// Construct the decoding table.
     pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
-            id: meta.advice_column(),
+            id: meta.advice_column_in(SecondPhase),
             tx_id: meta.advice_column(),
             format: meta.advice_column(),
             depth: meta.advice_column(),


### PR DESCRIPTION
### Description

Fixes the phase of advice column `id` on `RlpDecodingTable`. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

