### PR TITLE
[Fix]Input parsing for modexp precompile

### DIFF
--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -287,8 +287,11 @@ impl ModExpAuxData {
     /// Create a new instance of modexp auxiliary data.
     pub fn new(input: &[u8], output: &[u8], return_bytes: &[u8]) -> Self {
         let mut resized_input = input.to_vec();
+        if resized_input.len() < 96 {
+            resized_input.resize(96, 0);
+        }
 
-        let (input_valid, [base_len, exp_len, modulus_len]) = Self::check_input(input);
+        let (input_valid, [base_len, exp_len, modulus_len]) = Self::check_input(&resized_input);
 
         let base_mem_len = if input_valid { base_len.as_usize() } else { 0 };
         let exp_mem_len = if input_valid { exp_len.as_usize() } else { 0 };

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -1622,6 +1622,27 @@ mod test {
         CircuitTestBuilder::new_from_test_ctx(ctx).run();
     }
 
+    /// from failed testtool case
+    #[test]
+    fn begin_tx_precompile_fail_modexp() {
+        let ctx = TestContext::<1, 1>::new(
+            None,
+            |accs| {
+                accs[0].address(MOCK_ACCOUNTS[0]).balance(eth(20));
+            },
+            |mut txs, accs| {
+                txs[0]
+                    .from(accs[0].address)
+                    .to(address!("0x0000000000000000000000000000000000000005"))
+                    .input(Bytes::from_str("0x00000000008000000000000000000000000000000000000000000000000000000000000400000000000000000000000a").unwrap());
+            },
+            |block, _tx| block.number(0xcafeu64),
+        )
+        .unwrap();
+
+        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+    }
+
     /// testool case EmptyTransaction3_d0_g0_v0
     #[test]
     fn begin_tx_create_empty_tx() {

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/modexp.rs
@@ -825,7 +825,7 @@ impl<F: Field> ExecutionGadget<F> for ModExpGadget<F> {
             cb.curr.state.gas_left.expr(),
         );
 
-        let required_input_len = 192.expr();
+        let required_input_len = MODEXP_INPUT_LIMIT.expr();
         let pad_right = LtGadget::construct(cb, call_data_length.expr(), required_input_len.expr());
         let padding = cb.condition(pad_right.expr(), |cb| {
             PaddingGadget::construct(
@@ -1533,6 +1533,26 @@ mod test {
                 ret_size: 0x21.into(),
                 address: PrecompileCalls::Modexp.address().to_word(),
                 gas: 1000.into(),
+                ..Default::default()
+            },
+            PrecompileCallArgs {
+                name: "from test tool: zero padding and invalid size",
+                setup_code: bytecode! {
+                    // Base size
+                    PUSH32(word!("0x0000000000800000000000000000000000000000000000000000000000000000"))
+                    PUSH1(0x00)
+                    MSTORE
+                    // Esize
+                    PUSH32(word!("0x000000400000000000000000000000a000000000000000000000000000000000"))
+                    PUSH1(0x20)
+                    MSTORE
+                },
+                call_data_offset: 0x0.into(),
+                call_data_length: 0x30.into(),
+                ret_offset: 0xe0.into(),
+                ret_size: 0x20.into(),
+                address: PrecompileCalls::Modexp.address().to_word(),
+                gas: 100000.into(),
                 ..Default::default()
             },
         ]


### PR DESCRIPTION
Mode exp precompile read first 96-bytes of inputs as the expected lengths for the following base, exp and modulus value. In current code, if the input bytes is less than 96, code would wrongly parse the U256 length number with array less than 32 bytes and obtain error value.

For example, if the input has only 1 bytes as '0x01', the code would parse base length as `1`, however, the correct value should be `0x01000000000000000000000000000000` (256 bit integer in big-endian).

It cause the failure of test case `modexpRandomInput_d1_g0_v0` and has been fixed in this PR.