### PR TITLE
Refactor: one way to remove many arguments with HashMap

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -368,7 +368,6 @@ pub(crate) struct ExecutionConfig<F> {
 }
 
 impl<F: Field> ExecutionConfig<F> {
-    #[allow(clippy::too_many_arguments)]
     #[allow(clippy::redundant_closure_call)]
     pub(crate) fn configure(
         meta: &mut ConstraintSystem<F>,
@@ -889,7 +888,6 @@ impl<F: Field> ExecutionConfig<F> {
         });
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn configure_lookup(
         meta: &mut ConstraintSystem<F>,
         tables: HashMap<&str, &dyn LookupTable<F>>,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -12,7 +12,6 @@ use crate::{
     evm_circuit::{
         param::{EVM_LOOKUP_COLS, MAX_STEP_HEIGHT, N_PHASE2_COLUMNS, STEP_WIDTH},
         step::{ExecutionState, Step},
-        table::Table,
         util::{
             constraint_builder::{
                 BaseConstraintBuilder, ConstrainBuilderCommon, EVMConstraintBuilder,
@@ -374,20 +373,7 @@ impl<F: Field> ExecutionConfig<F> {
     pub(crate) fn configure(
         meta: &mut ConstraintSystem<F>,
         challenges: Challenges<Expression<F>>,
-        fixed_table: &dyn LookupTable<F>,
-        byte_table: &dyn LookupTable<F>,
-        tx_table: &dyn LookupTable<F>,
-        rw_table: &dyn LookupTable<F>,
-        bytecode_table: &dyn LookupTable<F>,
-        block_table: &dyn LookupTable<F>,
-        copy_table: &dyn LookupTable<F>,
-        keccak_table: &dyn LookupTable<F>,
-        sha256_table: &dyn LookupTable<F>,
-        exp_table: &dyn LookupTable<F>,
-        sig_table: &dyn LookupTable<F>,
-        modexp_table: &dyn LookupTable<F>,
-        ecc_table: &dyn LookupTable<F>,
-        pow_of_rand_table: &dyn LookupTable<F>,
+        tables: HashMap<&str, &dyn LookupTable<F>>,
     ) -> Self {
         let mut instrument = Instrument::default();
         let q_usable = meta.fixed_column();
@@ -653,25 +639,7 @@ impl<F: Field> ExecutionConfig<F> {
             instrument,
         };
 
-        Self::configure_lookup(
-            meta,
-            fixed_table,
-            byte_table,
-            tx_table,
-            rw_table,
-            bytecode_table,
-            block_table,
-            copy_table,
-            keccak_table,
-            sha256_table,
-            exp_table,
-            sig_table,
-            modexp_table,
-            ecc_table,
-            pow_of_rand_table,
-            &challenges,
-            &cell_manager,
-        );
+        Self::configure_lookup(meta, tables, &challenges, &cell_manager);
         config
     }
 
@@ -924,20 +892,7 @@ impl<F: Field> ExecutionConfig<F> {
     #[allow(clippy::too_many_arguments)]
     fn configure_lookup(
         meta: &mut ConstraintSystem<F>,
-        fixed_table: &dyn LookupTable<F>,
-        byte_table: &dyn LookupTable<F>,
-        tx_table: &dyn LookupTable<F>,
-        rw_table: &dyn LookupTable<F>,
-        bytecode_table: &dyn LookupTable<F>,
-        block_table: &dyn LookupTable<F>,
-        copy_table: &dyn LookupTable<F>,
-        keccak_table: &dyn LookupTable<F>,
-        sha256_table: &dyn LookupTable<F>,
-        exp_table: &dyn LookupTable<F>,
-        sig_table: &dyn LookupTable<F>,
-        modexp_table: &dyn LookupTable<F>,
-        ecc_table: &dyn LookupTable<F>,
-        pow_of_rand_table: &dyn LookupTable<F>,
+        tables: HashMap<&str, &dyn LookupTable<F>>,
         challenges: &Challenges<Expression<F>>,
         cell_manager: &CellManager<F>,
     ) {
@@ -945,22 +900,7 @@ impl<F: Field> ExecutionConfig<F> {
             if let CellType::Lookup(table) = column.cell_type {
                 let name = format!("{table:?}");
                 meta.lookup_any(Box::leak(name.into_boxed_str()), |meta| {
-                    let table_expressions = match table {
-                        Table::Fixed => fixed_table,
-                        Table::Tx => tx_table,
-                        Table::Rw => rw_table,
-                        Table::Bytecode => bytecode_table,
-                        Table::Block => block_table,
-                        Table::Copy => copy_table,
-                        Table::Keccak => keccak_table,
-                        Table::Sha256 => sha256_table,
-                        Table::Exp => exp_table,
-                        Table::Sig => sig_table,
-                        Table::ModExp => modexp_table,
-                        Table::Ecc => ecc_table,
-                        Table::PowOfRand => pow_of_rand_table,
-                    }
-                    .table_exprs(meta);
+                    let table_expressions = tables.get(table.as_ref()).unwrap().table_exprs(meta);
                     vec![(
                         column.expr(),
                         rlc::expr(&table_expressions, challenges.lookup_input()),
@@ -971,7 +911,11 @@ impl<F: Field> ExecutionConfig<F> {
         for column in cell_manager.columns().iter() {
             if let CellType::LookupByte = column.cell_type {
                 meta.lookup_any("Byte lookup", |meta| {
-                    let byte_table_expression = byte_table.table_exprs(meta)[0].clone();
+                    let byte_table_expression = tables
+                        .get(CellType::LookupByte.as_ref())
+                        .unwrap()
+                        .table_exprs(meta)[0]
+                        .clone();
                     vec![(column.expr(), byte_table_expression)]
                 });
             }

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -8,7 +8,7 @@ use eth_types::Field;
 use gadgets::util::Expr;
 use halo2_proofs::plonk::Expression;
 use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
+use strum_macros::{AsRefStr, EnumIter};
 
 #[derive(Clone, Copy, Debug, EnumIter)]
 pub enum FixedTableTag {
@@ -145,7 +145,7 @@ impl FixedTableTag {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, EnumIter)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, EnumIter, AsRefStr)]
 pub(crate) enum Table {
     Fixed,
     Tx,
@@ -583,5 +583,18 @@ impl<F: Field> Lookup<F> {
             .map(|expr| expr.degree())
             .max()
             .unwrap()
+    }
+}
+
+mod test {
+
+    #[test]
+    fn display_table() {
+        use crate::evm_circuit::Table;
+
+        assert_eq!(Table::Fixed.as_ref(), "Fixed");
+        assert_eq!(Table::Bytecode.as_ref(), "Bytecode");
+        assert_eq!(Table::Block.as_ref(), "Block");
+        assert_eq!(Table::Sha256.as_ref(), "Sha256");
     }
 }

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -23,6 +23,7 @@ use std::{
     collections::BTreeMap,
     hash::{Hash, Hasher},
 };
+use strum_macros::AsRefStr;
 
 pub(crate) mod common_gadget;
 pub(crate) mod constraint_builder;
@@ -305,7 +306,7 @@ impl<F: Field> StoredExpression<F> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, AsRefStr)]
 pub(crate) enum CellType {
     StoragePhase1,
     StoragePhase2,
@@ -774,5 +775,15 @@ impl<F: Field> Inverter<F> {
             Some(i) => *i,
             None => F::from(value).invert().unwrap(),
         }
+    }
+}
+
+mod test {
+
+    #[test]
+    fn display_cell_type() {
+        use crate::evm_circuit::util::CellType;
+
+        assert_eq!(CellType::LookupByte.as_ref(), "LookupByte");
     }
 }


### PR DESCRIPTION
### Description

Remove many args in function with HashMap and add trait to enum

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- Use HashMap to remove many tables args in function
- Add AsRefStr of trait to enum(Table, CellType)
- Use the str expression of enum as key to the HashMap

