### PR TITLE
[Fix] index of storae key in access list

### DIFF
--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -877,6 +877,7 @@ fn add_access_list_storage_key_copy_event(
     let rw_counter_start = state.block_ctx.rwc;
 
     // Build copy access list including addresses and storage keys.
+    let mut sks_acc: usize = 0;
     let access_list = state
         .tx
         .access_list
@@ -886,9 +887,9 @@ fn add_access_list_storage_key_copy_event(
                 .map(|item| {
                     item.storage_keys
                         .iter()
-                        .enumerate()
-                        .map(|(idx, &sk)| {
+                        .map(|&sk| {
                             let sk = sk.to_word();
+                            sks_acc += 1;
 
                             // Add RW write operations for access list address storage keys
                             // (will lookup in copy circuit).
@@ -910,7 +911,7 @@ fn add_access_list_storage_key_copy_event(
                             Ok(CopyAccessList::new(
                                 item.address,
                                 sk,
-                                idx as u64,
+                                sks_acc as u64,
                                 is_warm_prev,
                             ))
                         })

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -420,6 +420,7 @@ impl Transaction {
         let mut assignments: Vec<[Value<F>; 5]> = vec![];
 
         if self.access_list.is_some() {
+            let mut sks_acc: usize = 0;
             for (al_idx, al) in self.access_list.as_ref().unwrap().0.iter().enumerate() {
                 assignments.push([
                     Value::known(F::from(self.id as u64)),
@@ -429,11 +430,12 @@ impl Transaction {
                     Value::known(al.address.to_scalar().unwrap()),
                 ]);
 
-                for (sk_idx, sk) in al.storage_keys.iter().enumerate() {
+                for sk in al.storage_keys.iter() {
+                    sks_acc += 1;
                     assignments.push([
                         Value::known(F::from(self.id as u64)),
                         Value::known(F::from(TxContextFieldTag::AccessListStorageKey as u64)),
-                        Value::known(F::from(sk_idx as u64)),
+                        Value::known(F::from(sks_acc as u64)),
                         rlc_be_bytes(&sk.to_fixed_bytes(), challenges.evm_word()),
                         Value::known(al.address.to_scalar().unwrap()),
                     ]);


### PR DESCRIPTION
This PR try to fix issue #1132. It respect tx circuits's view, updating the index of storage key into a global increasement, for both copy event and tx.