### PR TITLE
1559 selector fix in RLP

### DIFF
--- a/zkevm-circuits/src/rlp_circuit_fsm.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm.rs
@@ -2828,7 +2828,7 @@ impl<F: Field> RlpCircuitConfig<F> {
             || "q_enable",
             self.rlp_table.q_enable,
             row,
-            || Value::known(F::zero()),
+            || Value::known(F::one()),
         )?;
         region.assign_advice(
             || "sm.state",

--- a/zkevm-circuits/src/rlp_circuit_fsm.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm.rs
@@ -1888,7 +1888,10 @@ impl<F: Field> RlpCircuitConfig<F> {
                 }
             );
 
-            cb.gate(meta.query_fixed(q_enabled, Rotation::cur()))
+            cb.gate(and::expr([
+                meta.query_fixed(q_enabled, Rotation::cur()),
+                not::expr(is_end(meta)),
+            ]))
         });
 
         // Operation-specific constraints


### PR DESCRIPTION
### Description

Correct selector `q_enable` for end rows within RLP circuit.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor (no updates to logic)
