### PR TITLE
[Fix]Update test parameters

### DIFF
--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -139,7 +139,10 @@ impl<P: JsonRpcClient> GethClient<P> {
     /// transaction of the block.
     pub async fn trace_block_by_hash(&self, hash: Hash) -> Result<Vec<GethExecTrace>, Error> {
         let hash = serialize(&hash);
-        let cfg = serialize(&GethLoggerConfig::default());
+        let cfg = serialize(&GethLoggerConfig {
+            timeout: Some("300s".to_string()),
+            ..Default::default()
+        });
         let resp: ResultGethExecTraces = self
             .0
             .request("debug_traceBlockByHash", [hash, cfg])

--- a/integration-tests/tests/mainnet.rs
+++ b/integration-tests/tests/mainnet.rs
@@ -57,18 +57,18 @@ async fn test_mock_prove_tx() {
     }
     let cli = get_client();
     let params = CircuitsParams {
-        max_rws: 100_000,
-        max_copy_rows: 100_000, // dynamic
+        max_rws: 1_000_000,
+        max_copy_rows: 1_000_000, // dynamic
         max_txs: 10,
-        max_calldata: 40_000,
+        max_calldata: 500_000,
         max_inner_blocks: 8,
-        max_bytecode: 100_000,
-        max_mpt_rows: 40_000,
-        max_poseidon_rows: 100_000,
+        max_bytecode: 500_000,
+        max_mpt_rows: 100_000,
+        max_poseidon_rows: 1_000_000,
         max_keccak_rows: 0,
         max_exp_steps: 5_000,
         max_evm_rows: 0,
-        max_rlp_rows: 42_000,
+        max_rlp_rows: 800_000,
         ..Default::default()
     };
 


### PR DESCRIPTION
There is many tx in mainnet would require very big circuit and the current parameters for super circuit is not enough. Also the debug API may even timeout with default settings so we need to upgrade them both.