### PR TITLE
Feat: copy chunk digests in blob data to chunk_pi_hash in aggregation circuit

### DIFF
--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -1,5 +1,4 @@
 use ark_std::{end_timer, start_timer};
-use halo2_base::QuantumCell;
 use halo2_ecc::bigint::CRTInteger;
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
@@ -445,19 +444,19 @@ impl Circuit<Fr> for AggregationCircuit {
                     }
                 }
 
-                // TODO: evaluation_le and challenge_le are all of type QuantumCell::Witness
-                //       which is not what we expected
-                // for (c, ec) in evaluation_le
-                //     .iter()
-                //     .zip_eq(expected_blob_cells.y.iter().rev()) {
-                //     region.constrain_equal(c.cell(), ec.cell())?;
-                // }
-                //
-                // for (c, ec) in challenge_le
-                //     .iter()
-                //     .zip_eq(expected_blob_cells.z.iter().rev()) {
-                //     region.constrain_equal(c.cell(), ec.cell())?;
-                // }
+                for (c, ec) in evaluation_le
+                    .iter()
+                    .zip_eq(expected_blob_cells.y.iter().rev())
+                {
+                    region.constrain_equal(c.cell(), ec.cell())?;
+                }
+
+                for (c, ec) in challenge_le
+                    .iter()
+                    .zip_eq(expected_blob_cells.z.iter().rev())
+                {
+                    region.constrain_equal(c.cell(), ec.cell())?;
+                }
 
                 Ok(())
             },

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -297,12 +297,10 @@ impl Circuit<Fr> for AggregationCircuit {
             // - batch_public_input_hash
             // - chunk\[i\].piHash for i in \[0, MAX_AGG_SNARKS)
             // - batch_data_hash_preimage
-            // - z
-            // - y
             let preimages = self.batch_hash.extract_hash_preimages();
             assert_eq!(
                 preimages.len(),
-                MAX_AGG_SNARKS + 5,
+                MAX_AGG_SNARKS + 3,
                 "error extracting preimages"
             );
             end_timer!(timer);

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -297,10 +297,13 @@ impl Circuit<Fr> for AggregationCircuit {
             // - batch_public_input_hash
             // - chunk\[i\].piHash for i in \[0, MAX_AGG_SNARKS)
             // - batch_data_hash_preimage
+            // - chunk[i]'s tx_data_hash for i in [0, MAX_AGG_SNARKS)
+            // - batch's metadata
+            // - z's preimage
             let preimages = self.batch_hash.extract_hash_preimages();
             assert_eq!(
                 preimages.len(),
-                MAX_AGG_SNARKS + 3,
+                MAX_AGG_SNARKS * 2 + 4,
                 "error extracting preimages"
             );
             end_timer!(timer);
@@ -425,6 +428,11 @@ impl Circuit<Fr> for AggregationCircuit {
             &self.batch_hash,
             &barycentric_assignments,
         )?;
+
+        blob_data_exports
+            .chunk_data_digests
+            .iter()
+            .for_each(|chunk_data_digest| {});
 
         end_timer!(witness_time);
         Ok(())

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -143,10 +143,28 @@ impl RlcConfig {
     }
 
     #[inline]
+    pub(crate) fn one_hundred_and_sixty_eight_cell(&self, region_index: RegionIndex) -> Cell {
+        Cell {
+            region_index,
+            row_offset: 10,
+            column: self.fixed.into(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn two_hundred_and_thirty_two_cell(&self, region_index: RegionIndex) -> Cell {
+        Cell {
+            region_index,
+            row_offset: 11,
+            column: self.fixed.into(),
+        }
+    }
+
+    #[inline]
     pub(crate) fn empty_keccak_cell_i(&self, region_index: RegionIndex, index: usize) -> Cell {
         Cell {
             region_index,
-            row_offset: 10 + index,
+            row_offset: 12 + index,
             column: self.fixed.into(),
         }
     }

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -39,13 +39,25 @@ impl RlcConfig {
             9,
             || Value::known(Fr::from(256)),
         )?;
+        region.assign_fixed(
+            || "const 168",
+            self.fixed,
+            10,
+            || Value::known(Fr::from(168)),
+        )?;
+        region.assign_fixed(
+            || "const 200",
+            self.fixed,
+            11,
+            || Value::known(Fr::from(200)),
+        )?;
 
         let empty_keccak = keccak256([]);
         for (i, &byte) in empty_keccak.iter().enumerate() {
             region.assign_fixed(
                 || "const empty_keccak[i]",
                 self.fixed,
-                10 + i,
+                12 + i,
                 || Value::known(Fr::from(byte as u64)),
             )?;
         }
@@ -152,7 +164,7 @@ impl RlcConfig {
     }
 
     #[inline]
-    pub(crate) fn two_hundred_and_thirty_two_cell(&self, region_index: RegionIndex) -> Cell {
+    pub(crate) fn two_hundred_cell(&self, region_index: RegionIndex) -> Cell {
         Cell {
             region_index,
             row_offset: 11,

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -256,9 +256,7 @@ impl BatchHash {
         //
         // This is eventually used in the chunk PI hash (defined above).
         for chunk in self.chunks_with_padding.iter() {
-            if !chunk.is_padding && !chunk.tx_bytes.is_empty() {
-                res.push(chunk.tx_bytes.clone());
-            }
+            res.push(chunk.tx_bytes.clone());
         }
 
         // flattened RLP-signed tx bytes for all L2 txs in batch.
@@ -274,6 +272,7 @@ impl BatchHash {
         //     keccak256(chunk[MAX_AGG_SNARKS-1].tx_bytes)
         // )
         let blob_data = self.to_blob_data();
+        res.push(blob_data.to_metadata_bytes());
         res.push(
             std::iter::empty()
                 .chain(keccak256(blob_data.to_metadata_bytes()))

--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -15,7 +15,7 @@ pub(crate) const INPUT_LEN_PER_ROUND: usize = 136;
 pub(crate) const LOG_DEGREE: u32 = 19;
 
 // ================================
-// indices for hash table
+// indices for chunk pi hash table
 // ================================
 //
 // the preimages are arranged as
@@ -30,6 +30,22 @@ pub(crate) const PREV_STATE_ROOT_INDEX: usize = 8;
 pub(crate) const POST_STATE_ROOT_INDEX: usize = 40;
 pub(crate) const WITHDRAW_ROOT_INDEX: usize = 72;
 pub(crate) const CHUNK_DATA_HASH_INDEX: usize = 104;
+
+// ================================
+// indices for batch pi hash table
+// ================================
+//
+// the preimages are arranged as
+// - chain_id:          8 bytes
+// - prev_state_root    32 bytes
+// - post_state_root    32 bytes
+// - withdraw_root      32 bytes
+// - chunk_data_hash    32 bytes
+// - z                  32 bytes
+// - y                  32 bytes
+
+pub(crate) const BATCH_Z_INDEX: usize = 136;
+pub(crate) const BATCH_Y_INDEX: usize = 168;
 
 // ================================
 // aggregator parameters

--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -44,8 +44,8 @@ pub(crate) const CHUNK_DATA_HASH_INDEX: usize = 104;
 // - z                  32 bytes
 // - y                  32 bytes
 
-pub(crate) const BATCH_Z_INDEX: usize = 136;
-pub(crate) const BATCH_Y_INDEX: usize = 168;
+pub(crate) const BATCH_Z_OFFSET: usize = 136;
+pub(crate) const BATCH_Y_OFFSET: usize = 168;
 
 // ================================
 // aggregator parameters

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -34,7 +34,7 @@ use zkevm_circuits::{
 
 use crate::{
     constants::{
-        BATCH_Y_INDEX, BATCH_Z_INDEX, CHAIN_ID_LEN, DIGEST_LEN, INPUT_LEN_PER_ROUND, LOG_DEGREE,
+        BATCH_Y_OFFSET, BATCH_Z_OFFSET, CHAIN_ID_LEN, DIGEST_LEN, INPUT_LEN_PER_ROUND, LOG_DEGREE,
         MAX_AGG_SNARKS,
     },
     util::{
@@ -229,8 +229,8 @@ pub(crate) fn assign_batch_hashes(
 
     let batch_pi_input = &extracted_hash_cells.hash_input_cells[0..INPUT_LEN_PER_ROUND * 2];
     let expected_blob_cells = ExpectedBlobCells {
-        z: batch_pi_input[BATCH_Z_INDEX..BATCH_Z_INDEX + 32].to_vec(),
-        y: batch_pi_input[BATCH_Y_INDEX..BATCH_Y_INDEX + 32].to_vec(),
+        z: batch_pi_input[BATCH_Z_OFFSET..BATCH_Z_OFFSET + 32].to_vec(),
+        y: batch_pi_input[BATCH_Y_OFFSET..BATCH_Y_OFFSET + 32].to_vec(),
         chunk_tx_data_hashes: (0..MAX_AGG_SNARKS)
             .into_iter()
             .map(|i| {

--- a/aggregator/src/util.rs
+++ b/aggregator/src/util.rs
@@ -20,7 +20,7 @@ pub(crate) fn get_max_keccak_updates(max_snarks: usize) -> usize {
     //     y
     // ]
     //
-    // In total there are 232 bytes. Therefore 2 pi rounds are required,
+    // In total there are 200 bytes. Therefore 2 keccak-f rounds are required,
     // as in a single round we can absorb 136 bytes (INPUT_LEN_PER_ROUND).
     let pi_rounds = 2;
     // Hash for each chunk is derived from hashing the chunk's
@@ -33,7 +33,8 @@ pub(crate) fn get_max_keccak_updates(max_snarks: usize) -> usize {
     //     tx_data_hash
     // ]
     //
-    // Each chunk hash therefore also requires 2 keccak rounds for 200 bytes.
+    // In total there are 168 bytes, therefore each chunk hash
+    // also requires 2 keccak rounds for 168 bytes.
     let chunk_hash_rounds = 2 * max_snarks;
     let data_hash_rounds = get_data_hash_keccak_updates(max_snarks);
 
@@ -194,12 +195,14 @@ pub(crate) fn parse_hash_preimage_cells(
     Vec<&[AssignedCell<Fr, Fr>]>,
     &[AssignedCell<Fr, Fr>],
 ) {
-    // each pi hash has INPUT_LEN_PER_ROUND bytes as input
-    // keccak will pad the input with another INPUT_LEN_PER_ROUND bytes
     // we extract all those bytes
+    // batch_pi_hash's input has 200 bytes which means
+    // its keccak takes two rounds of keccak-f permutation
     let batch_pi_hash_preimage = &hash_input_cells[0..INPUT_LEN_PER_ROUND * 2];
     let mut chunk_pi_hash_preimages = vec![];
     for i in 0..MAX_AGG_SNARKS {
+        // each chunk_pi_hash's input has 168 bytes which means
+        // each chunk takes two rounds of keccak-f permutation
         chunk_pi_hash_preimages.push(
             &hash_input_cells[INPUT_LEN_PER_ROUND * 2 * (i + 1)..INPUT_LEN_PER_ROUND * 2 * (i + 2)],
         );


### PR DESCRIPTION
This PR aims to do three things:
- [x] update preimage cells of batch pi hash (136 cells -> 200 cells)
- [x] update preimage cells of chunk pi hash (136 cells -> 168 cells)
- [x] add copy contraints between `chunk_data_digests` (allocated in `BlobDataConfig`) to preimage cells of chunk_pi_hash (allocated in aggregation circuit).
- [x] add copy contraints between `z, y` (allocated in `BarycentricEvaluationConfig`) to preimage cells of batch_pi_hash (allocated in aggregation circuit).