### PR TITLE
fix audit: constrain tx_l1_fee gadget

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -153,6 +153,12 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         });
         cb.condition(tx_l1_msg.is_l1_msg(), |cb| {
             cb.require_zero("l1fee is 0 for l1msg", tx_data_gas_cost.expr());
+            // also constrain fee value of tx_l1_fee gadget is zero, such other gadgets can use it
+            // with certain value for l1 type.
+            cb.require_zero(
+                "l1fee is 0 for tx_l1_fee gadget",
+                tx_l1_fee.tx_l1_fee_word().expr(),
+            );
         });
         // the rw delta caused by l1 related handling
         let l1_rw_delta = select::expr(


### PR DESCRIPTION
### Description

audit item:  The tx_l1_fee gadget might be under constrained, 
fix by adding constrain l1_fee_word zero if it is l1 msg tx

split single PR for each audit item from https://github.com/scroll-tech/zkevm-circuits/pull/1147
### Issue Link

[_link issue here_]

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

[_explanation_]

<hr>

## How to fill a PR description 

Please give a concise description of your PR.

The target readers could be future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.

MUST: Reference the issue to resolve

### Single responsability

Is RECOMMENDED to create single responsibility commits, but not mandatory.

Anyway, you MUST enumerate the changes in a unitary way, e.g.

```
This PR contains:
- Cleanup of xxxx, yyyy
- Changed xxxx to yyyy in order to bla bla
- Added xxxx function to ...
- Refactored ....
```

### Design choices

RECOMMENDED to:
- What types of design choices did you face?
- What decisions you have made?
- Any valuable information that could help reviewers to think critically
