### PR TITLE
chore: downgrade revm-precompile from v5.1.0 to v5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "reth-primitives",
- "revm-precompile 4.1.0 (git+https://github.com/bluealloy/revm)",
+ "revm-precompile 5.0.0",
  "serde",
  "serde_json",
  "snark-verifier",
@@ -93,33 +93,33 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973deb9e9d5db1f28c2a478073aeb435f1c07f72cf5935caa0c421e6b68f2db1"
+checksum = "e96c81b05c893348760f232c4cc6a6a77fd91cfb09885d4eaad25cd03bd7732e"
 dependencies = [
  "alloy-rlp",
  "num_enum 0.7.2",
  "serde",
- "strum 0.26.1",
+ "strum 0.26.2",
 ]
 
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "thiserror",
+ "serde",
 ]
 
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-serde",
  "serde",
 ]
 
@@ -171,11 +171,12 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-engine-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
+ "alloy-serde",
  "jsonrpsee-types",
  "serde",
  "thiserror",
@@ -184,10 +185,11 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -195,15 +197,26 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde",
  "itertools 0.12.1",
  "jsonrpsee-types",
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4389,8 +4402,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#6801869c0d3e5ebf1b187d64694ec7ca13d809ea"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -4399,8 +4412,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#6801869c0d3e5ebf1b187d64694ec7ca13d809ea"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -4410,8 +4423,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#6801869c0d3e5ebf1b187d64694ec7ca13d809ea"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -4423,8 +4436,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#6801869c0d3e5ebf1b187d64694ec7ca13d809ea"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -4445,14 +4458,14 @@ dependencies = [
  "reth-codecs",
  "reth-ethereum-forks",
  "reth-rpc-types",
- "revm 6.1.0",
- "revm-primitives 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm 7.1.0",
+ "revm-primitives 3.0.0",
  "roaring",
  "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "sha2",
- "strum 0.26.1",
+ "strum 0.26.2",
  "tempfile",
  "thiserror",
  "zstd 0.12.4",
@@ -4460,8 +4473,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#6801869c0d3e5ebf1b187d64694ec7ca13d809ea"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4472,7 +4485,7 @@ dependencies = [
  "secp256k1 0.27.0",
  "serde",
  "serde_json",
- "serde_with 3.6.1",
+ "serde_with 3.7.0",
  "thiserror",
  "url",
 ]
@@ -4496,25 +4509,26 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "6.1.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d35316fc02d99e42831356c71e882f5d385c77b78f64a44ae82f2f9a4b8b72f"
+checksum = "217d21144d329f21d5245b8e6a46e0d6d0a527d9917d7a087f225b161e529169"
 dependencies = [
  "auto_impl",
  "cfg-if 1.0.0",
+ "dyn-clone",
  "revm-interpreter",
- "revm-precompile 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-precompile 5.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-interpreter"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa10c2dc1e8f4934bdc763a2c09371bcec29e50c22e55e3eb325ee0cba09064"
+checksum = "776848391ed76d5103ca1aa1632cd21b521e2870afb30b63723da862d69efd0f"
 dependencies = [
- "revm-primitives 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 3.0.0",
  "serde",
 ]
 
@@ -4536,31 +4550,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db828d49d329560a70809d9d1fa0c74695edb49f50c5332db3eb24483076deac"
+checksum = "e3fd1856a7cb09197a02669d779e1afb5a627b0888a24814ba2b6a1ad4c3ff8d"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
  "k256 0.13.3",
  "once_cell",
- "revm-primitives 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripemd",
- "secp256k1 0.28.2",
- "sha2",
- "substrate-bn",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "4.1.0"
-source = "git+https://github.com/bluealloy/revm#13ce01318b0c707b46430c405fb261243d281cd2"
-dependencies = [
- "aurora-engine-modexp",
- "c-kzg",
- "k256 0.13.3",
- "once_cell",
- "revm-primitives 2.1.0 (git+https://github.com/bluealloy/revm)",
+ "revm-primitives 3.0.0",
  "ripemd",
  "secp256k1 0.28.2",
  "sha2",
@@ -4587,28 +4585,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecd125aad58e135e2ca5771ed6e4e7b1f05fa3a64e0dfb9cc643b7a800a8435"
-dependencies = [
- "alloy-primitives",
- "auto_impl",
- "bitflags 2.4.2",
- "bitvec",
- "c-kzg",
- "cfg-if 1.0.0",
- "derive_more",
- "enumn",
- "hashbrown 0.14.3",
- "hex",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "2.1.0"
-source = "git+https://github.com/bluealloy/revm#13ce01318b0c707b46430c405fb261243d281cd2"
+checksum = "2a4d7d3e793e907dc0797a9d3b43abfdf5226d133855214db9bd27d4cee33ebd"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -5173,9 +5152,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -5185,7 +5164,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.6.1",
+ "serde_with_macros 3.7.0",
  "time",
 ]
 
@@ -5203,9 +5182,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling 0.20.8",
  "proc-macro2",
@@ -5469,11 +5448,11 @@ checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.1",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -5504,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 url = "2.2"
 
 reth-primitives = { git = "https://github.com/paradigmxyz/reth" }
-revm-precompile = { git = "https://github.com/bluealloy/revm" }
+revm-precompile = "^5.0.0"
 c-kzg = "0.4.2"
 
 [patch.crates-io]

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -500,7 +500,7 @@ impl BlobDataConfig {
 
                 // rows have chunk_idx set from 0 (metadata) -> MAX_AGG_SNARKS.
                 rlc_config.enforce_zero(&mut region, &rows[0].chunk_idx)?;
-                let mut zero = {
+                let zero = {
                     let zero = rlc_config.load_private(
                         &mut region,
                         &Fr::zero(),

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -243,6 +243,7 @@ impl BlobDataConfig {
             .collect()
         });
 
+        assert!(meta.degree() <= 5);
         config
     }
 
@@ -741,11 +742,6 @@ impl BlobDataConfig {
                     challenge_digest_limb3.cell(),
                     challenge_digest_crt.truncation.limbs[2].cell(),
                 )?;
-                log::debug!(
-                    "blob crts: {}, export.blob_fields: {}",
-                    blob_crts.len(),
-                    export.blob_fields.len()
-                );
                 for (blob_crt, blob_field) in blob_crts.iter().zip_eq(export.blob_fields.iter()) {
                     let limb1 = rlc_config.inner_product(
                         &mut region,

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -216,7 +216,6 @@ impl BlobDataConfig {
             .collect()
         });
 
-
         // lookup for digest RLC to the hash section.
         meta.lookup_any("BlobDataConfig (hash section)", |meta| {
             let is_data = meta.query_selector(config.data_selector);

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -48,6 +48,8 @@ pub struct BlobDataConfig {
     data_selector: Selector,
     /// Boolean to let us know we are in the hash section.
     hash_selector: Selector,
+    u8_table: U8Table,
+    chunk_idx_range_table: RangeTable<MAX_AGG_SNARKS>,
 }
 
 pub struct AssignedBlobDataExport {
@@ -74,6 +76,8 @@ impl BlobDataConfig {
         keccak_table: &KeccakTable,
     ) -> Self {
         let config = Self {
+            u8_table,
+            chunk_idx_range_table: range_table,
             byte: meta.advice_column(),
             accumulator: meta.advice_column(),
             is_boundary: meta.advice_column(),
@@ -248,6 +252,10 @@ impl BlobDataConfig {
         batch: &BatchHash,
         barycentric_assignments: &[CRTInteger<Fr>],
     ) -> Result<AssignedBlobDataExport, Error> {
+        // load tables
+        self.u8_table.load(layouter)?;
+        self.chunk_idx_range_table.load(layouter)?;
+
         let assigned_rows = layouter.assign_region(
             || "BlobData rows",
             |mut region| {

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -188,13 +188,14 @@ impl BlobDataConfig {
             let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
             let cond = is_data * is_boundary;
             [
+                1.expr(),                                                // q_enable
                 1.expr(),                                                // is final
-                meta.query_advice(config.accumulator, Rotation::cur()),  // input len
                 meta.query_advice(config.preimage_rlc, Rotation::cur()), // input RLC
+                meta.query_advice(config.accumulator, Rotation::cur()),  // input len
                 meta.query_advice(config.digest_rlc, Rotation::cur()),   // output RLC
             ]
             .into_iter()
-            .zip(keccak_table.table_exprs(meta))
+            .zip_eq(keccak_table.table_exprs(meta))
             .map(|(value, table)| (cond.expr() * value, table))
             .collect()
         });
@@ -230,13 +231,14 @@ impl BlobDataConfig {
             let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
             let cond = is_hash * is_boundary;
             [
+                1.expr(),                                                // q_enable
                 1.expr(),                                                // is final
-                32.expr() * (MAX_AGG_SNARKS + 1).expr(),                 // input len
                 meta.query_advice(config.preimage_rlc, Rotation::cur()), // input rlc
+                32.expr() * (MAX_AGG_SNARKS + 1).expr(),                 // input len
                 meta.query_advice(config.digest_rlc, Rotation::cur()),   // output rlc
             ]
             .into_iter()
-            .zip(keccak_table.table_exprs(meta))
+            .zip_eq(keccak_table.table_exprs(meta))
             .map(|(value, table)| (cond.expr() * value, table))
             .collect()
         });
@@ -259,7 +261,7 @@ impl BlobDataConfig {
         let assigned_rows = layouter.assign_region(
             || "BlobData rows",
             |mut region| {
-                let rows = batch.to_blob_data().to_rows(challenge_value.keccak_input());
+                let rows = batch.to_blob_data().to_rows(challenge_value);
                 assert_eq!(rows.len(), N_ROWS_BLOB_DATA_CONFIG);
 
                 // enable data selector

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -400,14 +400,20 @@ impl Circuit<Fr> for AggregationCircuit {
                         },
                     );
 
-                    Ok(config.barycentric.assign2(
+                    let barycentric = config.barycentric.assign2(
                         &mut ctx,
                         self.batch_hash.blob.coefficients,
                         self.batch_hash.blob.challenge_digest,
                         self.batch_hash.blob.evaluation,
-                    ))
+                    );
+
+                    config.barycentric.scalar.range.finalize(&mut ctx);
+                    ctx.print_stats(&["barycentric evaluation"]);
+
+                    Ok(barycentric)
                 },
             )?;
+
             let barycentric_assignments = &be.barycentric_assignments;
             let challenge_le = &be.z_le;
             let evaluation_le = &be.y_le;
@@ -415,7 +421,6 @@ impl Circuit<Fr> for AggregationCircuit {
             let blob_data_exports = config.blob_data_config.assign(
                 &mut layouter,
                 challenges,
-                rlc_config_offset,
                 &config.rlc_config,
                 &self.batch_hash,
                 barycentric_assignments,

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -156,16 +156,16 @@ impl Circuit<Fr> for AggregationCircuit {
 
         let timer = start_timer!(|| "aggregation");
 
+        // load lookup table in range config
+        config
+            .range()
+            .load_lookup_table(&mut layouter)
+            .expect("load range lookup table");
         // ==============================================
         // Step 1: snark aggregation circuit
         // ==============================================
         #[cfg(not(feature = "disable_proof_aggregation"))]
         let (accumulator_instances, snark_inputs) = {
-            config
-                .range()
-                .load_lookup_table(&mut layouter)
-                .expect("load range lookup table");
-
             let mut first_pass = halo2_base::SKIP_FIRST_PASS;
 
             let (accumulator_instances, snark_inputs) = layouter.assign_region(

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -487,14 +487,15 @@ impl CircuitExt<Fr> for AggregationCircuit {
 
     fn selectors(config: &Self::Config) -> Vec<Selector> {
         // - advice columns from flex gate
-        // - selector from RLC gate
+        // - selectors from RLC gate
         config.0.flex_gate().basic_gates[0]
             .iter()
             .map(|gate| gate.q_enable)
             .chain(
                 [
                     config.0.rlc_config.selector,
-                    config.0.rlc_config.enable_challenge,
+                    config.0.rlc_config.enable_challenge1,
+                    config.0.rlc_config.enable_challenge2,
                 ]
                 .iter()
                 .cloned(),

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -164,6 +164,7 @@ impl Circuit<Fr> for AggregationCircuit {
         // ==============================================
         // Step 1: snark aggregation circuit
         // ==============================================
+
         #[cfg(not(feature = "disable_proof_aggregation"))]
         let (accumulator_instances, snark_inputs) = {
             let mut first_pass = halo2_base::SKIP_FIRST_PASS;

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -9,7 +9,7 @@ use halo2_proofs::{
 };
 use itertools::Itertools;
 use rand::Rng;
-use std::{env, fs::File};
+use std::{env, fs::File, rc::Rc};
 
 #[cfg(not(feature = "disable_proof_aggregation"))]
 use snark_verifier::loader::halo2::halo2_ecc::halo2_base;
@@ -164,17 +164,48 @@ impl Circuit<Fr> for AggregationCircuit {
         // ==============================================
         // Step 1: snark aggregation circuit
         // ==============================================
+        #[cfg(feature = "disable_proof_generation")]
+        let barycentric = layouter.assign_region(
+            || "barycentric evaluation",
+            |region| {
+                if is_first_pass {
+                    is_first_pass = false;
+                    return Ok(BarycentricEvaluationCells::default());
+                }
+
+                let mut ctx = Context::new(
+                    region,
+                    ContextParams {
+                        max_rows: config.flex_gate().max_rows,
+                        num_context_ids: 1,
+                        fixed_columns: config.flex_gate().constants.clone(),
+                    },
+                );
+
+                let barycentric = config.barycentric.assign2(
+                    &mut ctx,
+                    self.batch_hash.blob.coefficients,
+                    self.batch_hash.blob.challenge_digest,
+                    self.batch_hash.blob.evaluation,
+                );
+
+                config.barycentric.scalar.range.finalize(&mut ctx);
+                ctx.print_stats(&["barycentric evaluation"]);
+
+                Ok(barycentric)
+            },
+        )?;
 
         #[cfg(not(feature = "disable_proof_aggregation"))]
-        let (accumulator_instances, snark_inputs) = {
+        let (accumulator_instances, snark_inputs, barycentric) = {
             let mut first_pass = halo2_base::SKIP_FIRST_PASS;
 
-            let (accumulator_instances, snark_inputs) = layouter.assign_region(
+            let (accumulator_instances, snark_inputs, barycentric) = layouter.assign_region(
                 || "aggregation",
-                |region| -> Result<(Vec<AssignedValue<Fr>>, Vec<AssignedValue<Fr>>), Error> {
+                |region| {
                     if first_pass {
                         first_pass = false;
-                        return Ok((vec![], vec![]));
+                        return Ok((vec![], vec![], BarycentricEvaluationCells::default()));
                     }
 
                     // stores accumulators for all snarks, including the padded ones
@@ -223,16 +254,26 @@ impl Circuit<Fr> for AggregationCircuit {
                             .flat_map(|instance_column| instance_column.iter().skip(ACC_LEN)),
                     );
 
-                    config.range().finalize(&mut loader.ctx_mut());
+                    loader.ctx_mut().print_stats(&["snark aggregation"]);
 
-                    loader.ctx_mut().print_stats(&["Range"]);
+                    let mut ctx = Rc::into_inner(loader).unwrap().into_ctx();
+                    let barycentric = config.barycentric.assign2(
+                        &mut ctx,
+                        self.batch_hash.blob.coefficients,
+                        self.batch_hash.blob.challenge_digest,
+                        self.batch_hash.blob.evaluation,
+                    );
 
-                    Ok((accumulator_instances, snark_inputs))
+                    ctx.print_stats(&["barycentric"]);
+
+                    config.range().finalize(&mut ctx);
+
+                    Ok((accumulator_instances, snark_inputs, barycentric))
                 },
             )?;
 
             assert_eq!(snark_inputs.len(), MAX_AGG_SNARKS * DIGEST_LEN);
-            (accumulator_instances, snark_inputs)
+            (accumulator_instances, snark_inputs, barycentric)
         };
         end_timer!(timer);
         // ==============================================
@@ -383,41 +424,9 @@ impl Circuit<Fr> for AggregationCircuit {
 
         // blob data config
         {
-            let mut is_first_pass = true;
-            let be = layouter.assign_region(
-                || "blob data and barycentric evaluation",
-                |region| {
-                    if is_first_pass {
-                        is_first_pass = false;
-                        return Ok(BarycentricEvaluationCells::default());
-                    }
-
-                    let mut ctx = Context::new(
-                        region,
-                        ContextParams {
-                            max_rows: config.flex_gate().max_rows,
-                            num_context_ids: 1,
-                            fixed_columns: config.flex_gate().constants.clone(),
-                        },
-                    );
-
-                    let barycentric = config.barycentric.assign2(
-                        &mut ctx,
-                        self.batch_hash.blob.coefficients,
-                        self.batch_hash.blob.challenge_digest,
-                        self.batch_hash.blob.evaluation,
-                    );
-
-                    config.barycentric.scalar.range.finalize(&mut ctx);
-                    ctx.print_stats(&["barycentric evaluation"]);
-
-                    Ok(barycentric)
-                },
-            )?;
-
-            let barycentric_assignments = &be.barycentric_assignments;
-            let challenge_le = &be.z_le;
-            let evaluation_le = &be.y_le;
+            let barycentric_assignments = &barycentric.barycentric_assignments;
+            let challenge_le = &barycentric.z_le;
+            let evaluation_le = &barycentric.y_le;
 
             let blob_data_exports = config.blob_data_config.assign(
                 &mut layouter,

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -197,7 +197,7 @@ impl RlcConfig {
         res
     }
 
-    pub(crate) fn read_challenge(
+    pub(crate) fn read_challenge1(
         &self,
         region: &mut Region<Fr>,
         challenge_value: Challenges<Value<Fr>>,
@@ -205,12 +205,30 @@ impl RlcConfig {
     ) -> Result<AssignedCell<Fr, Fr>, Error> {
         let challenge_value = challenge_value.keccak_input();
         let challenge_cell = region.assign_advice(
-            || "assign challenge",
+            || "assign challenge1",
             self.phase_2_column,
             *offset,
             || challenge_value,
         )?;
-        self.enable_challenge.enable(region, *offset)?;
+        self.enable_challenge1.enable(region, *offset)?;
+        *offset += 1;
+        Ok(challenge_cell)
+    }
+
+    pub(crate) fn read_challenge2(
+        &self,
+        region: &mut Region<Fr>,
+        challenge_value: Challenges<Value<Fr>>,
+        offset: &mut usize,
+    ) -> Result<AssignedCell<Fr, Fr>, Error> {
+        let challenge_value = challenge_value.evm_word();
+        let challenge_cell = region.assign_advice(
+            || "assign challenge2",
+            self.phase_2_column,
+            *offset,
+            || challenge_value,
+        )?;
+        self.enable_challenge2.enable(region, *offset)?;
         *offset += 1;
         Ok(challenge_cell)
     }

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -268,7 +268,7 @@ impl RlcConfig {
 
         a.copy_advice(|| "a", region, self.phase_2_column, *offset)?;
         let one = region.assign_advice(
-            || "c",
+            || "b",
             self.phase_2_column,
             *offset + 1,
             || Value::known(Fr::one()),

--- a/aggregator/src/barycentric.rs
+++ b/aggregator/src/barycentric.rs
@@ -22,8 +22,10 @@ use crate::{
     constants::{BITS, LIMBS},
 };
 
+/*
 mod scalar_field_element;
 use scalar_field_element::ScalarFieldElement;
+*/
 
 pub static ROOTS_OF_UNITY: LazyLock<[Scalar; BLOB_WIDTH]> = LazyLock::new(|| {
     // https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
@@ -142,7 +144,7 @@ impl BarycentricEvaluationConfig {
             .load_private(ctx, Value::known(fe_to_biguint(&evaluation_scalar).into()));
         let powers_of_256 =
             std::iter::successors(Some(Fr::one()), |coeff| Some(Fr::from(256) * coeff))
-                .take(32)
+                .take(11)
                 .map(QuantumCell::Constant)
                 .collect::<Vec<_>>();
         let challenge_limb1 = self.scalar.range().gate.inner_product(
@@ -157,14 +159,14 @@ impl BarycentricEvaluationConfig {
             challenge_le[11..22]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[11..22].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         let challenge_limb3 = self.scalar.range().gate.inner_product(
             ctx,
             challenge_le[22..32]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[22..32].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         self.scalar.range().gate.assert_equal(
             ctx,
@@ -193,14 +195,14 @@ impl BarycentricEvaluationConfig {
             evaluation_le[11..22]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[11..22].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         let evaluation_limb3 = self.scalar.range().gate.inner_product(
             ctx,
             evaluation_le[22..32]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[22..32].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         self.scalar.range().gate.assert_equal(
             ctx,
@@ -224,29 +226,31 @@ impl BarycentricEvaluationConfig {
         blob.iter()
             .zip_eq(ROOTS_OF_UNITY.map(|x| self.scalar.load_constant(ctx, fe_to_biguint(&x))))
             .for_each(|(blob_i, root_i_crt)| {
-                let blob_i_le = blob_i
-                    .to_le_bytes()
-                    .iter()
-                    .map(|&x| QuantumCell::Witness(Value::known(Fr::from(x as u64))))
-                    .collect::<Vec<_>>();
+                let blob_i_le = self.scalar.range().gate.assign_witnesses(
+                    ctx,
+                    blob_i
+                        .to_le_bytes()
+                        .iter()
+                        .map(|&x| Value::known(Fr::from(x as u64))),
+                );
                 let blob_i_scalar = Scalar::from_raw(blob_i.0);
                 let blob_i_crt = self
                     .scalar
                     .load_private(ctx, Value::known(fe_to_biguint(&blob_i_scalar).into()));
                 let limb1 = self.scalar.range().gate.inner_product(
                     ctx,
-                    blob_i_le[0..11].to_vec(),
+                    blob_i_le[0..11].iter().map(|&x| QuantumCell::Existing(x)),
                     powers_of_256[0..11].to_vec(),
                 );
                 let limb2 = self.scalar.range().gate.inner_product(
                     ctx,
-                    blob_i_le[11..22].to_vec(),
-                    powers_of_256[11..22].to_vec(),
+                    blob_i_le[11..22].iter().map(|&x| QuantumCell::Existing(x)),
+                    powers_of_256[0..11].to_vec(),
                 );
                 let limb3 = self.scalar.range().gate.inner_product(
                     ctx,
-                    blob_i_le[22..32].to_vec(),
-                    powers_of_256[22..32].to_vec(),
+                    blob_i_le[22..32].iter().map(|&x| QuantumCell::Existing(x)),
+                    powers_of_256[0..11].to_vec(),
                 );
                 self.scalar.range().gate.assert_equal(
                     ctx,
@@ -265,7 +269,7 @@ impl BarycentricEvaluationConfig {
                 );
                 self.scalar.range().gate.assert_equal(
                     ctx,
-                    blob_i_le[31].clone(),
+                    QuantumCell::Existing(blob_i_le[31]),
                     QuantumCell::Constant(Fr::zero()),
                 );
 
@@ -312,6 +316,7 @@ impl BarycentricEvaluationConfig {
         }
     }
 
+    /*
     pub fn assign(
         &self,
         ctx: &mut Context<Fr>,
@@ -351,6 +356,7 @@ impl BarycentricEvaluationConfig {
             blob,
         }
     }
+    */
 }
 
 pub fn interpolate(z: Scalar, coefficients: [Scalar; BLOB_WIDTH]) -> Scalar {

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -509,7 +509,7 @@ impl BlobData {
             .chain(std::iter::once(BlobDataRow {
                 preimage_rlc: blob_preimage_rlc,
                 digest_rlc: blob_digest_rlc,
-                accumulator: 32 + (MAX_AGG_SNARKS + 1) as u64,
+                accumulator: 32 * (MAX_AGG_SNARKS + 1) as u64,
                 is_boundary: true,
                 ..Default::default()
             }))

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -139,8 +139,8 @@ impl BatchHash {
                 .withdraw_root
                 .as_bytes(),
             batch_data_hash.as_slice(),
-            // TODO: add z
-            // TODO: add y
+            blob.z.to_be_bytes().as_ref(),
+            blob.evaluation.to_be_bytes().as_ref(),
         ]
         .concat();
         let public_input_hash = keccak256(preimage);

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -475,7 +475,7 @@ impl BlobData {
 
         // blob
         let blob_preimage = std::iter::empty()
-            .chain(metadata_bytes.iter())
+            .chain(metadata_digest.iter())
             .chain(chunk_digests.iter().flatten())
             .cloned()
             .collect::<Vec<u8>>();

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -332,6 +332,8 @@ impl BlobDataRow<Fr> {
     fn padding_row() -> Self {
         Self {
             is_padding: true,
+            preimage_rlc: Value::known(Fr::zero()),
+            digest_rlc: Value::known(Fr::zero()),
             ..Default::default()
         }
     }
@@ -399,7 +401,7 @@ impl BlobData {
                     accumulator,
                     preimage_rlc,
                     digest_rlc,
-                    is_boundary: i == 61,
+                    is_boundary: i == bytes.len() - 1,
                     ..Default::default()
                 },
             )
@@ -485,10 +487,12 @@ impl BlobData {
         std::iter::empty()
             .chain(std::iter::once(BlobDataRow {
                 digest_rlc: metadata_digest_rlc,
+                preimage_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .chain(chunk_digest_rlcs.iter().map(|&digest_rlc| BlobDataRow {
                 digest_rlc,
+                preimage_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .chain(std::iter::once(BlobDataRow {
@@ -500,16 +504,22 @@ impl BlobData {
             }))
             .chain(metadata_digest.iter().map(|&byte| BlobDataRow {
                 byte,
+                preimage_rlc: Value::known(Fr::zero()),
+                digest_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .chain(chunk_digests.iter().flat_map(|digest| {
                 digest.iter().map(|&byte| BlobDataRow {
                     byte,
+                    preimage_rlc: Value::known(Fr::zero()),
+                    digest_rlc: Value::known(Fr::zero()),
                     ..Default::default()
                 })
             }))
             .chain(blob_digest.iter().map(|&byte| BlobDataRow {
                 byte,
+                preimage_rlc: Value::known(Fr::zero()),
+                digest_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .collect()

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -56,6 +56,7 @@ impl Blob {
 
 #[derive(Clone, Debug)]
 pub struct BlobAssignments {
+    pub z: U256,
     pub challenge_digest: U256,
     pub evaluation: U256,
     pub coefficients: [U256; BLOB_WIDTH],
@@ -66,8 +67,15 @@ impl From<&Blob> for BlobAssignments {
         let coefficients = blob.coefficients();
         let coefficients_scalar = coefficients.map(|coeff| Scalar::from_raw(coeff.0));
         let challenge_digest = blob.challenge_point();
+        let bls_modulus = U256::from_str_radix(
+            "52435875175126190479447740508185965837690552500527637822603658699938581184513",
+            10,
+        )
+        .unwrap();
+        let (_, z) = challenge_digest.div_mod(bls_modulus);
 
         Self {
+            z,
             challenge_digest,
             evaluation: U256::from_little_endian(
                 &interpolate(Scalar::from_raw(challenge_digest.0), coefficients_scalar).to_bytes(),
@@ -80,6 +88,7 @@ impl From<&Blob> for BlobAssignments {
 impl Default for BlobAssignments {
     fn default() -> Self {
         Self {
+            z: U256::default(),
             challenge_digest: U256::default(),
             evaluation: U256::default(),
             coefficients: [U256::default(); BLOB_WIDTH],

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -15,7 +15,6 @@ impl Blob {
         Self(
             chunk_hashes
                 .iter()
-                .filter(|chunk_hash| !chunk_hash.is_padding)
                 .map(|chunk_hash| chunk_hash.tx_bytes.clone())
                 .collect(),
         )
@@ -37,7 +36,7 @@ impl Blob {
             .chain(chunk_tx_bytes_hashes)
             .collect();
 
-        keccak256(input).into()
+        U256::from_big_endian(&keccak256(input))
     }
 
     fn metadata_bytes(&self) -> impl Iterator<Item = u8> + '_ {

--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -30,6 +30,7 @@ pub(crate) const PREV_STATE_ROOT_INDEX: usize = 8;
 pub(crate) const POST_STATE_ROOT_INDEX: usize = 40;
 pub(crate) const WITHDRAW_ROOT_INDEX: usize = 72;
 pub(crate) const CHUNK_DATA_HASH_INDEX: usize = 104;
+pub(crate) const CHUNK_TX_DATA_HASH_INDEX: usize = 136;
 
 // ================================
 // indices for batch pi hash table

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -41,8 +41,8 @@ use crate::{
         assert_conditional_equal, assert_equal, assert_exist, get_indices, get_max_keccak_updates,
         parse_hash_digest_cells, parse_hash_preimage_cells, parse_pi_hash_rlc_cells,
     },
-    AggregationConfig, RlcConfig, BITS, CHUNK_DATA_HASH_INDEX, LIMBS, POST_STATE_ROOT_INDEX,
-    PREV_STATE_ROOT_INDEX, WITHDRAW_ROOT_INDEX,
+    AggregationConfig, RlcConfig, BITS, CHUNK_DATA_HASH_INDEX, CHUNK_TX_DATA_HASH_INDEX, LIMBS,
+    POST_STATE_ROOT_INDEX, PREV_STATE_ROOT_INDEX, WITHDRAW_ROOT_INDEX,
 };
 
 /// Subroutine for the witness generations.
@@ -239,9 +239,9 @@ pub(crate) fn assign_batch_hashes(
         y: batch_pi_input[BATCH_Y_OFFSET..BATCH_Y_OFFSET + 32].to_vec(),
         chunk_tx_data_hashes: (0..MAX_AGG_SNARKS)
             .map(|i| {
-                extracted_hash_cells.hash_input_cells
-                    [INPUT_LEN_PER_ROUND * (2 + 2 * i)..INPUT_LEN_PER_ROUND * (2 + 2 * (i + 1))]
-                    .to_vec()
+                let chunk_pi_input = &extracted_hash_cells.hash_input_cells
+                    [INPUT_LEN_PER_ROUND * (2 + 2 * i)..INPUT_LEN_PER_ROUND * (2 + 2 * (i + 1))];
+                chunk_pi_input[CHUNK_TX_DATA_HASH_INDEX..CHUNK_TX_DATA_HASH_INDEX + 32].to_vec()
             })
             .collect(),
     };

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -968,7 +968,7 @@ pub(crate) fn conditional_constraints(
                 // 8. batch data hash is correct w.r.t. its RLCs
                 // batchDataHash = keccak(chunk[0].dataHash || ... || chunk[k-1].dataHash)
                 let challenge_cell =
-                    rlc_config.read_challenge(&mut region, challenges, &mut offset)?;
+                    rlc_config.read_challenge1(&mut region, challenges, &mut offset)?;
 
                 let flags = chunk_is_valid_cells
                     .iter()

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -556,11 +556,6 @@ pub(crate) fn conditional_constraints(
         .assign_region(
             || "rlc conditional constraints",
             |mut region| -> Result<(), halo2_proofs::plonk::Error> {
-                // if first_pass {
-                //     first_pass = false;
-                //     return Ok(0);
-                // }
-
                 rlc_config.init(&mut region)?;
                 let mut offset = 0;
                 // ====================================================

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -558,10 +558,10 @@ pub(crate) fn conditional_constraints(
         .assign_region(
             || "rlc conditional constraints",
             |mut region| -> Result<usize, halo2_proofs::plonk::Error> {
-                if first_pass {
-                    first_pass = false;
-                    return Ok(0);
-                }
+                // if first_pass {
+                //     first_pass = false;
+                //     return Ok(0);
+                // }
 
                 rlc_config.init(&mut region)?;
                 let mut offset = 0;


### PR DESCRIPTION
### Description

`revm-precompile` v5.1.0 relies on `c-kzg#1.0.0` while `reth-primitives` relies on `c-kzg#0.4.2`. Therefore we downgrade the `revm-precompile` to an older version `v0.5.0` to solve the multiple version conflict.

