### PR TITLE
Fix bugs in integration test

### DIFF
--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -500,7 +500,7 @@ impl BlobDataConfig {
 
                 // rows have chunk_idx set from 0 (metadata) -> MAX_AGG_SNARKS.
                 rlc_config.enforce_zero(&mut region, &rows[0].chunk_idx)?;
-                let mut zero = {
+                let zero = {
                     let zero = rlc_config.load_private(
                         &mut region,
                         &Fr::zero(),

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -243,6 +243,7 @@ impl BlobDataConfig {
             .collect()
         });
 
+        assert!(meta.degree() <= 5);
         config
     }
 
@@ -741,11 +742,6 @@ impl BlobDataConfig {
                     challenge_digest_limb3.cell(),
                     challenge_digest_crt.truncation.limbs[2].cell(),
                 )?;
-                log::debug!(
-                    "blob crts: {}, export.blob_fields: {}",
-                    blob_crts.len(),
-                    export.blob_fields.len()
-                );
                 for (blob_crt, blob_field) in blob_crts.iter().zip_eq(export.blob_fields.iter()) {
                     let limb1 = rlc_config.inner_product(
                         &mut region,

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -216,7 +216,6 @@ impl BlobDataConfig {
             .collect()
         });
 
-
         // lookup for digest RLC to the hash section.
         meta.lookup_any("BlobDataConfig (hash section)", |meta| {
             let is_data = meta.query_selector(config.data_selector);

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -48,6 +48,8 @@ pub struct BlobDataConfig {
     data_selector: Selector,
     /// Boolean to let us know we are in the hash section.
     hash_selector: Selector,
+    u8_table: U8Table,
+    chunk_idx_range_table: RangeTable<MAX_AGG_SNARKS>,
 }
 
 pub struct AssignedBlobDataExport {
@@ -74,6 +76,8 @@ impl BlobDataConfig {
         keccak_table: &KeccakTable,
     ) -> Self {
         let config = Self {
+            u8_table,
+            chunk_idx_range_table: range_table,
             byte: meta.advice_column(),
             accumulator: meta.advice_column(),
             is_boundary: meta.advice_column(),
@@ -248,6 +252,10 @@ impl BlobDataConfig {
         batch: &BatchHash,
         barycentric_assignments: &[CRTInteger<Fr>],
     ) -> Result<AssignedBlobDataExport, Error> {
+        // load tables
+        self.u8_table.load(layouter)?;
+        self.chunk_idx_range_table.load(layouter)?;
+
         let assigned_rows = layouter.assign_region(
             || "BlobData rows",
             |mut region| {

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -188,13 +188,14 @@ impl BlobDataConfig {
             let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
             let cond = is_data * is_boundary;
             [
+                1.expr(),                                                // q_enable
                 1.expr(),                                                // is final
-                meta.query_advice(config.accumulator, Rotation::cur()),  // input len
                 meta.query_advice(config.preimage_rlc, Rotation::cur()), // input RLC
+                meta.query_advice(config.accumulator, Rotation::cur()),  // input len
                 meta.query_advice(config.digest_rlc, Rotation::cur()),   // output RLC
             ]
             .into_iter()
-            .zip(keccak_table.table_exprs(meta))
+            .zip_eq(keccak_table.table_exprs(meta))
             .map(|(value, table)| (cond.expr() * value, table))
             .collect()
         });
@@ -230,13 +231,14 @@ impl BlobDataConfig {
             let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
             let cond = is_hash * is_boundary;
             [
+                1.expr(),                                                // q_enable
                 1.expr(),                                                // is final
-                32.expr() * (MAX_AGG_SNARKS + 1).expr(),                 // input len
                 meta.query_advice(config.preimage_rlc, Rotation::cur()), // input rlc
+                32.expr() * (MAX_AGG_SNARKS + 1).expr(),                 // input len
                 meta.query_advice(config.digest_rlc, Rotation::cur()),   // output rlc
             ]
             .into_iter()
-            .zip(keccak_table.table_exprs(meta))
+            .zip_eq(keccak_table.table_exprs(meta))
             .map(|(value, table)| (cond.expr() * value, table))
             .collect()
         });
@@ -259,7 +261,7 @@ impl BlobDataConfig {
         let assigned_rows = layouter.assign_region(
             || "BlobData rows",
             |mut region| {
-                let rows = batch.to_blob_data().to_rows(challenge_value.keccak_input());
+                let rows = batch.to_blob_data().to_rows(challenge_value);
                 assert_eq!(rows.len(), N_ROWS_BLOB_DATA_CONFIG);
 
                 // enable data selector

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -400,14 +400,20 @@ impl Circuit<Fr> for AggregationCircuit {
                         },
                     );
 
-                    Ok(config.barycentric.assign2(
+                    let barycentric = config.barycentric.assign2(
                         &mut ctx,
                         self.batch_hash.blob.coefficients,
                         self.batch_hash.blob.challenge_digest,
                         self.batch_hash.blob.evaluation,
-                    ))
+                    );
+
+                    config.barycentric.scalar.range.finalize(&mut ctx);
+                    ctx.print_stats(&["barycentric evaluation"]);
+
+                    Ok(barycentric)
                 },
             )?;
+
             let barycentric_assignments = &be.barycentric_assignments;
             let challenge_le = &be.z_le;
             let evaluation_le = &be.y_le;
@@ -415,7 +421,6 @@ impl Circuit<Fr> for AggregationCircuit {
             let blob_data_exports = config.blob_data_config.assign(
                 &mut layouter,
                 challenges,
-                rlc_config_offset,
                 &config.rlc_config,
                 &self.batch_hash,
                 barycentric_assignments,

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -156,16 +156,16 @@ impl Circuit<Fr> for AggregationCircuit {
 
         let timer = start_timer!(|| "aggregation");
 
+        // load lookup table in range config
+        config
+            .range()
+            .load_lookup_table(&mut layouter)
+            .expect("load range lookup table");
         // ==============================================
         // Step 1: snark aggregation circuit
         // ==============================================
         #[cfg(not(feature = "disable_proof_aggregation"))]
         let (accumulator_instances, snark_inputs) = {
-            config
-                .range()
-                .load_lookup_table(&mut layouter)
-                .expect("load range lookup table");
-
             let mut first_pass = halo2_base::SKIP_FIRST_PASS;
 
             let (accumulator_instances, snark_inputs) = layouter.assign_region(

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -487,14 +487,15 @@ impl CircuitExt<Fr> for AggregationCircuit {
 
     fn selectors(config: &Self::Config) -> Vec<Selector> {
         // - advice columns from flex gate
-        // - selector from RLC gate
+        // - selectors from RLC gate
         config.0.flex_gate().basic_gates[0]
             .iter()
             .map(|gate| gate.q_enable)
             .chain(
                 [
                     config.0.rlc_config.selector,
-                    config.0.rlc_config.enable_challenge,
+                    config.0.rlc_config.enable_challenge1,
+                    config.0.rlc_config.enable_challenge2,
                 ]
                 .iter()
                 .cloned(),

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -164,6 +164,7 @@ impl Circuit<Fr> for AggregationCircuit {
         // ==============================================
         // Step 1: snark aggregation circuit
         // ==============================================
+
         #[cfg(not(feature = "disable_proof_aggregation"))]
         let (accumulator_instances, snark_inputs) = {
             let mut first_pass = halo2_base::SKIP_FIRST_PASS;

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -9,7 +9,7 @@ use halo2_proofs::{
 };
 use itertools::Itertools;
 use rand::Rng;
-use std::{env, fs::File};
+use std::{env, fs::File, rc::Rc};
 
 #[cfg(not(feature = "disable_proof_aggregation"))]
 use snark_verifier::loader::halo2::halo2_ecc::halo2_base;
@@ -164,17 +164,48 @@ impl Circuit<Fr> for AggregationCircuit {
         // ==============================================
         // Step 1: snark aggregation circuit
         // ==============================================
+        #[cfg(feature = "disable_proof_generation")]
+        let barycentric = layouter.assign_region(
+            || "barycentric evaluation",
+            |region| {
+                if is_first_pass {
+                    is_first_pass = false;
+                    return Ok(BarycentricEvaluationCells::default());
+                }
+
+                let mut ctx = Context::new(
+                    region,
+                    ContextParams {
+                        max_rows: config.flex_gate().max_rows,
+                        num_context_ids: 1,
+                        fixed_columns: config.flex_gate().constants.clone(),
+                    },
+                );
+
+                let barycentric = config.barycentric.assign2(
+                    &mut ctx,
+                    self.batch_hash.blob.coefficients,
+                    self.batch_hash.blob.challenge_digest,
+                    self.batch_hash.blob.evaluation,
+                );
+
+                config.barycentric.scalar.range.finalize(&mut ctx);
+                ctx.print_stats(&["barycentric evaluation"]);
+
+                Ok(barycentric)
+            },
+        )?;
 
         #[cfg(not(feature = "disable_proof_aggregation"))]
-        let (accumulator_instances, snark_inputs) = {
+        let (accumulator_instances, snark_inputs, barycentric) = {
             let mut first_pass = halo2_base::SKIP_FIRST_PASS;
 
-            let (accumulator_instances, snark_inputs) = layouter.assign_region(
+            let (accumulator_instances, snark_inputs, barycentric) = layouter.assign_region(
                 || "aggregation",
-                |region| -> Result<(Vec<AssignedValue<Fr>>, Vec<AssignedValue<Fr>>), Error> {
+                |region| {
                     if first_pass {
                         first_pass = false;
-                        return Ok((vec![], vec![]));
+                        return Ok((vec![], vec![], BarycentricEvaluationCells::default()));
                     }
 
                     // stores accumulators for all snarks, including the padded ones
@@ -223,16 +254,26 @@ impl Circuit<Fr> for AggregationCircuit {
                             .flat_map(|instance_column| instance_column.iter().skip(ACC_LEN)),
                     );
 
-                    config.range().finalize(&mut loader.ctx_mut());
+                    loader.ctx_mut().print_stats(&["snark aggregation"]);
 
-                    loader.ctx_mut().print_stats(&["Range"]);
+                    let mut ctx = Rc::into_inner(loader).unwrap().into_ctx();
+                    let barycentric = config.barycentric.assign2(
+                        &mut ctx,
+                        self.batch_hash.blob.coefficients,
+                        self.batch_hash.blob.challenge_digest,
+                        self.batch_hash.blob.evaluation,
+                    );
 
-                    Ok((accumulator_instances, snark_inputs))
+                    ctx.print_stats(&["barycentric"]);
+
+                    config.range().finalize(&mut ctx);
+
+                    Ok((accumulator_instances, snark_inputs, barycentric))
                 },
             )?;
 
             assert_eq!(snark_inputs.len(), MAX_AGG_SNARKS * DIGEST_LEN);
-            (accumulator_instances, snark_inputs)
+            (accumulator_instances, snark_inputs, barycentric)
         };
         end_timer!(timer);
         // ==============================================
@@ -383,41 +424,9 @@ impl Circuit<Fr> for AggregationCircuit {
 
         // blob data config
         {
-            let mut is_first_pass = true;
-            let be = layouter.assign_region(
-                || "blob data and barycentric evaluation",
-                |region| {
-                    if is_first_pass {
-                        is_first_pass = false;
-                        return Ok(BarycentricEvaluationCells::default());
-                    }
-
-                    let mut ctx = Context::new(
-                        region,
-                        ContextParams {
-                            max_rows: config.flex_gate().max_rows,
-                            num_context_ids: 1,
-                            fixed_columns: config.flex_gate().constants.clone(),
-                        },
-                    );
-
-                    let barycentric = config.barycentric.assign2(
-                        &mut ctx,
-                        self.batch_hash.blob.coefficients,
-                        self.batch_hash.blob.challenge_digest,
-                        self.batch_hash.blob.evaluation,
-                    );
-
-                    config.barycentric.scalar.range.finalize(&mut ctx);
-                    ctx.print_stats(&["barycentric evaluation"]);
-
-                    Ok(barycentric)
-                },
-            )?;
-
-            let barycentric_assignments = &be.barycentric_assignments;
-            let challenge_le = &be.z_le;
-            let evaluation_le = &be.y_le;
+            let barycentric_assignments = &barycentric.barycentric_assignments;
+            let challenge_le = &barycentric.z_le;
+            let evaluation_le = &barycentric.y_le;
 
             let blob_data_exports = config.blob_data_config.assign(
                 &mut layouter,

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -197,7 +197,7 @@ impl RlcConfig {
         res
     }
 
-    pub(crate) fn read_challenge(
+    pub(crate) fn read_challenge1(
         &self,
         region: &mut Region<Fr>,
         challenge_value: Challenges<Value<Fr>>,
@@ -205,12 +205,30 @@ impl RlcConfig {
     ) -> Result<AssignedCell<Fr, Fr>, Error> {
         let challenge_value = challenge_value.keccak_input();
         let challenge_cell = region.assign_advice(
-            || "assign challenge",
+            || "assign challenge1",
             self.phase_2_column,
             *offset,
             || challenge_value,
         )?;
-        self.enable_challenge.enable(region, *offset)?;
+        self.enable_challenge1.enable(region, *offset)?;
+        *offset += 1;
+        Ok(challenge_cell)
+    }
+
+    pub(crate) fn read_challenge2(
+        &self,
+        region: &mut Region<Fr>,
+        challenge_value: Challenges<Value<Fr>>,
+        offset: &mut usize,
+    ) -> Result<AssignedCell<Fr, Fr>, Error> {
+        let challenge_value = challenge_value.evm_word();
+        let challenge_cell = region.assign_advice(
+            || "assign challenge2",
+            self.phase_2_column,
+            *offset,
+            || challenge_value,
+        )?;
+        self.enable_challenge2.enable(region, *offset)?;
         *offset += 1;
         Ok(challenge_cell)
     }

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -268,7 +268,7 @@ impl RlcConfig {
 
         a.copy_advice(|| "a", region, self.phase_2_column, *offset)?;
         let one = region.assign_advice(
-            || "c",
+            || "b",
             self.phase_2_column,
             *offset + 1,
             || Value::known(Fr::one()),

--- a/aggregator/src/barycentric.rs
+++ b/aggregator/src/barycentric.rs
@@ -22,8 +22,10 @@ use crate::{
     constants::{BITS, LIMBS},
 };
 
+/*
 mod scalar_field_element;
 use scalar_field_element::ScalarFieldElement;
+*/
 
 pub static ROOTS_OF_UNITY: LazyLock<[Scalar; BLOB_WIDTH]> = LazyLock::new(|| {
     // https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants
@@ -142,7 +144,7 @@ impl BarycentricEvaluationConfig {
             .load_private(ctx, Value::known(fe_to_biguint(&evaluation_scalar).into()));
         let powers_of_256 =
             std::iter::successors(Some(Fr::one()), |coeff| Some(Fr::from(256) * coeff))
-                .take(32)
+                .take(11)
                 .map(QuantumCell::Constant)
                 .collect::<Vec<_>>();
         let challenge_limb1 = self.scalar.range().gate.inner_product(
@@ -157,14 +159,14 @@ impl BarycentricEvaluationConfig {
             challenge_le[11..22]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[11..22].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         let challenge_limb3 = self.scalar.range().gate.inner_product(
             ctx,
             challenge_le[22..32]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[22..32].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         self.scalar.range().gate.assert_equal(
             ctx,
@@ -193,14 +195,14 @@ impl BarycentricEvaluationConfig {
             evaluation_le[11..22]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[11..22].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         let evaluation_limb3 = self.scalar.range().gate.inner_product(
             ctx,
             evaluation_le[22..32]
                 .iter()
                 .map(|&x| QuantumCell::Existing(x)),
-            powers_of_256[22..32].to_vec(),
+            powers_of_256[0..11].to_vec(),
         );
         self.scalar.range().gate.assert_equal(
             ctx,
@@ -224,29 +226,31 @@ impl BarycentricEvaluationConfig {
         blob.iter()
             .zip_eq(ROOTS_OF_UNITY.map(|x| self.scalar.load_constant(ctx, fe_to_biguint(&x))))
             .for_each(|(blob_i, root_i_crt)| {
-                let blob_i_le = blob_i
-                    .to_le_bytes()
-                    .iter()
-                    .map(|&x| QuantumCell::Witness(Value::known(Fr::from(x as u64))))
-                    .collect::<Vec<_>>();
+                let blob_i_le = self.scalar.range().gate.assign_witnesses(
+                    ctx,
+                    blob_i
+                        .to_le_bytes()
+                        .iter()
+                        .map(|&x| Value::known(Fr::from(x as u64))),
+                );
                 let blob_i_scalar = Scalar::from_raw(blob_i.0);
                 let blob_i_crt = self
                     .scalar
                     .load_private(ctx, Value::known(fe_to_biguint(&blob_i_scalar).into()));
                 let limb1 = self.scalar.range().gate.inner_product(
                     ctx,
-                    blob_i_le[0..11].to_vec(),
+                    blob_i_le[0..11].iter().map(|&x| QuantumCell::Existing(x)),
                     powers_of_256[0..11].to_vec(),
                 );
                 let limb2 = self.scalar.range().gate.inner_product(
                     ctx,
-                    blob_i_le[11..22].to_vec(),
-                    powers_of_256[11..22].to_vec(),
+                    blob_i_le[11..22].iter().map(|&x| QuantumCell::Existing(x)),
+                    powers_of_256[0..11].to_vec(),
                 );
                 let limb3 = self.scalar.range().gate.inner_product(
                     ctx,
-                    blob_i_le[22..32].to_vec(),
-                    powers_of_256[22..32].to_vec(),
+                    blob_i_le[22..32].iter().map(|&x| QuantumCell::Existing(x)),
+                    powers_of_256[0..11].to_vec(),
                 );
                 self.scalar.range().gate.assert_equal(
                     ctx,
@@ -265,7 +269,7 @@ impl BarycentricEvaluationConfig {
                 );
                 self.scalar.range().gate.assert_equal(
                     ctx,
-                    blob_i_le[31].clone(),
+                    QuantumCell::Existing(blob_i_le[31]),
                     QuantumCell::Constant(Fr::zero()),
                 );
 
@@ -312,6 +316,7 @@ impl BarycentricEvaluationConfig {
         }
     }
 
+    /*
     pub fn assign(
         &self,
         ctx: &mut Context<Fr>,
@@ -351,6 +356,7 @@ impl BarycentricEvaluationConfig {
             blob,
         }
     }
+    */
 }
 
 pub fn interpolate(z: Scalar, coefficients: [Scalar; BLOB_WIDTH]) -> Scalar {

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -509,7 +509,7 @@ impl BlobData {
             .chain(std::iter::once(BlobDataRow {
                 preimage_rlc: blob_preimage_rlc,
                 digest_rlc: blob_digest_rlc,
-                accumulator: 32 + (MAX_AGG_SNARKS + 1) as u64,
+                accumulator: 32 * (MAX_AGG_SNARKS + 1) as u64,
                 is_boundary: true,
                 ..Default::default()
             }))

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -139,8 +139,8 @@ impl BatchHash {
                 .withdraw_root
                 .as_bytes(),
             batch_data_hash.as_slice(),
-            // TODO: add z
-            // TODO: add y
+            blob.z.to_be_bytes().as_ref(),
+            blob.evaluation.to_be_bytes().as_ref(),
         ]
         .concat();
         let public_input_hash = keccak256(preimage);

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -475,7 +475,7 @@ impl BlobData {
 
         // blob
         let blob_preimage = std::iter::empty()
-            .chain(metadata_bytes.iter())
+            .chain(metadata_digest.iter())
             .chain(chunk_digests.iter().flatten())
             .cloned()
             .collect::<Vec<u8>>();

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -332,6 +332,8 @@ impl BlobDataRow<Fr> {
     fn padding_row() -> Self {
         Self {
             is_padding: true,
+            preimage_rlc: Value::known(Fr::zero()),
+            digest_rlc: Value::known(Fr::zero()),
             ..Default::default()
         }
     }
@@ -399,7 +401,7 @@ impl BlobData {
                     accumulator,
                     preimage_rlc,
                     digest_rlc,
-                    is_boundary: i == 61,
+                    is_boundary: i == bytes.len() - 1,
                     ..Default::default()
                 },
             )
@@ -485,10 +487,12 @@ impl BlobData {
         std::iter::empty()
             .chain(std::iter::once(BlobDataRow {
                 digest_rlc: metadata_digest_rlc,
+                preimage_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .chain(chunk_digest_rlcs.iter().map(|&digest_rlc| BlobDataRow {
                 digest_rlc,
+                preimage_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .chain(std::iter::once(BlobDataRow {
@@ -500,16 +504,22 @@ impl BlobData {
             }))
             .chain(metadata_digest.iter().map(|&byte| BlobDataRow {
                 byte,
+                preimage_rlc: Value::known(Fr::zero()),
+                digest_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .chain(chunk_digests.iter().flat_map(|digest| {
                 digest.iter().map(|&byte| BlobDataRow {
                     byte,
+                    preimage_rlc: Value::known(Fr::zero()),
+                    digest_rlc: Value::known(Fr::zero()),
                     ..Default::default()
                 })
             }))
             .chain(blob_digest.iter().map(|&byte| BlobDataRow {
                 byte,
+                preimage_rlc: Value::known(Fr::zero()),
+                digest_rlc: Value::known(Fr::zero()),
                 ..Default::default()
             }))
             .collect()

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -56,6 +56,7 @@ impl Blob {
 
 #[derive(Clone, Debug)]
 pub struct BlobAssignments {
+    pub z: U256,
     pub challenge_digest: U256,
     pub evaluation: U256,
     pub coefficients: [U256; BLOB_WIDTH],
@@ -66,8 +67,15 @@ impl From<&Blob> for BlobAssignments {
         let coefficients = blob.coefficients();
         let coefficients_scalar = coefficients.map(|coeff| Scalar::from_raw(coeff.0));
         let challenge_digest = blob.challenge_point();
+        let bls_modulus = U256::from_str_radix(
+            "52435875175126190479447740508185965837690552500527637822603658699938581184513",
+            10,
+        )
+        .unwrap();
+        let (_, z) = challenge_digest.div_mod(bls_modulus);
 
         Self {
+            z,
             challenge_digest,
             evaluation: U256::from_little_endian(
                 &interpolate(Scalar::from_raw(challenge_digest.0), coefficients_scalar).to_bytes(),
@@ -80,6 +88,7 @@ impl From<&Blob> for BlobAssignments {
 impl Default for BlobAssignments {
     fn default() -> Self {
         Self {
+            z: U256::default(),
             challenge_digest: U256::default(),
             evaluation: U256::default(),
             coefficients: [U256::default(); BLOB_WIDTH],

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -15,7 +15,6 @@ impl Blob {
         Self(
             chunk_hashes
                 .iter()
-                .filter(|chunk_hash| !chunk_hash.is_padding)
                 .map(|chunk_hash| chunk_hash.tx_bytes.clone())
                 .collect(),
         )
@@ -37,7 +36,7 @@ impl Blob {
             .chain(chunk_tx_bytes_hashes)
             .collect();
 
-        keccak256(input).into()
+        U256::from_big_endian(&keccak256(input))
     }
 
     fn metadata_bytes(&self) -> impl Iterator<Item = u8> + '_ {

--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -30,6 +30,7 @@ pub(crate) const PREV_STATE_ROOT_INDEX: usize = 8;
 pub(crate) const POST_STATE_ROOT_INDEX: usize = 40;
 pub(crate) const WITHDRAW_ROOT_INDEX: usize = 72;
 pub(crate) const CHUNK_DATA_HASH_INDEX: usize = 104;
+pub(crate) const CHUNK_TX_DATA_HASH_INDEX: usize = 136;
 
 // ================================
 // indices for batch pi hash table

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -41,8 +41,8 @@ use crate::{
         assert_conditional_equal, assert_equal, assert_exist, get_indices, get_max_keccak_updates,
         parse_hash_digest_cells, parse_hash_preimage_cells, parse_pi_hash_rlc_cells,
     },
-    AggregationConfig, RlcConfig, BITS, CHUNK_DATA_HASH_INDEX, LIMBS, POST_STATE_ROOT_INDEX,
-    PREV_STATE_ROOT_INDEX, WITHDRAW_ROOT_INDEX,
+    AggregationConfig, RlcConfig, BITS, CHUNK_DATA_HASH_INDEX, CHUNK_TX_DATA_HASH_INDEX, LIMBS,
+    POST_STATE_ROOT_INDEX, PREV_STATE_ROOT_INDEX, WITHDRAW_ROOT_INDEX,
 };
 
 /// Subroutine for the witness generations.
@@ -239,9 +239,9 @@ pub(crate) fn assign_batch_hashes(
         y: batch_pi_input[BATCH_Y_OFFSET..BATCH_Y_OFFSET + 32].to_vec(),
         chunk_tx_data_hashes: (0..MAX_AGG_SNARKS)
             .map(|i| {
-                extracted_hash_cells.hash_input_cells
-                    [INPUT_LEN_PER_ROUND * (2 + 2 * i)..INPUT_LEN_PER_ROUND * (2 + 2 * (i + 1))]
-                    .to_vec()
+                let chunk_pi_input = &extracted_hash_cells.hash_input_cells
+                    [INPUT_LEN_PER_ROUND * (2 + 2 * i)..INPUT_LEN_PER_ROUND * (2 + 2 * (i + 1))];
+                chunk_pi_input[CHUNK_TX_DATA_HASH_INDEX..CHUNK_TX_DATA_HASH_INDEX + 32].to_vec()
             })
             .collect(),
     };

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -968,7 +968,7 @@ pub(crate) fn conditional_constraints(
                 // 8. batch data hash is correct w.r.t. its RLCs
                 // batchDataHash = keccak(chunk[0].dataHash || ... || chunk[k-1].dataHash)
                 let challenge_cell =
-                    rlc_config.read_challenge(&mut region, challenges, &mut offset)?;
+                    rlc_config.read_challenge1(&mut region, challenges, &mut offset)?;
 
                 let flags = chunk_is_valid_cells
                     .iter()

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -556,11 +556,6 @@ pub(crate) fn conditional_constraints(
         .assign_region(
             || "rlc conditional constraints",
             |mut region| -> Result<(), halo2_proofs::plonk::Error> {
-                // if first_pass {
-                //     first_pass = false;
-                //     return Ok(0);
-                // }
-
                 rlc_config.init(&mut region)?;
                 let mut offset = 0;
                 // ====================================================

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -558,10 +558,10 @@ pub(crate) fn conditional_constraints(
         .assign_region(
             || "rlc conditional constraints",
             |mut region| -> Result<usize, halo2_proofs::plonk::Error> {
-                if first_pass {
-                    first_pass = false;
-                    return Ok(0);
-                }
+                // if first_pass {
+                //     first_pass = false;
+                //     return Ok(0);
+                // }
 
                 rlc_config.init(&mut region)?;
                 let mut offset = 0;


### PR DESCRIPTION
### Description

This PR will fix three issues (then the integration test `cargo test  --release --lib test_aggregation_circuit` shall pass):
- [x] `preimage_rlc / digest_rlc` is not set right for padding data rows and hash rows in `BlobDataConfig`;
- [x]  `ColumnNotInPermutation` errors;
- [x] BlobData region shares `RlcConfig` rows with snark aggregation-related region.


