### PR TITLE
rlc keccak vs evm

### DIFF
--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -487,14 +487,15 @@ impl CircuitExt<Fr> for AggregationCircuit {
 
     fn selectors(config: &Self::Config) -> Vec<Selector> {
         // - advice columns from flex gate
-        // - selector from RLC gate
+        // - selectors from RLC gate
         config.0.flex_gate().basic_gates[0]
             .iter()
             .map(|gate| gate.q_enable)
             .chain(
                 [
                     config.0.rlc_config.selector,
-                    config.0.rlc_config.enable_challenge,
+                    config.0.rlc_config.enable_challenge1,
+                    config.0.rlc_config.enable_challenge2,
                 ]
                 .iter()
                 .cloned(),

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -197,7 +197,7 @@ impl RlcConfig {
         res
     }
 
-    pub(crate) fn read_challenge(
+    pub(crate) fn read_challenge1(
         &self,
         region: &mut Region<Fr>,
         challenge_value: Challenges<Value<Fr>>,
@@ -205,12 +205,30 @@ impl RlcConfig {
     ) -> Result<AssignedCell<Fr, Fr>, Error> {
         let challenge_value = challenge_value.keccak_input();
         let challenge_cell = region.assign_advice(
-            || "assign challenge",
+            || "assign challenge1",
             self.phase_2_column,
             *offset,
             || challenge_value,
         )?;
-        self.enable_challenge.enable(region, *offset)?;
+        self.enable_challenge1.enable(region, *offset)?;
+        *offset += 1;
+        Ok(challenge_cell)
+    }
+
+    pub(crate) fn read_challenge2(
+        &self,
+        region: &mut Region<Fr>,
+        challenge_value: Challenges<Value<Fr>>,
+        offset: &mut usize,
+    ) -> Result<AssignedCell<Fr, Fr>, Error> {
+        let challenge_value = challenge_value.evm_word();
+        let challenge_cell = region.assign_advice(
+            || "assign challenge2",
+            self.phase_2_column,
+            *offset,
+            || challenge_value,
+        )?;
+        self.enable_challenge2.enable(region, *offset)?;
         *offset += 1;
         Ok(challenge_cell)
     }

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -968,7 +968,7 @@ pub(crate) fn conditional_constraints(
                 // 8. batch data hash is correct w.r.t. its RLCs
                 // batchDataHash = keccak(chunk[0].dataHash || ... || chunk[k-1].dataHash)
                 let challenge_cell =
-                    rlc_config.read_challenge(&mut region, challenges, &mut offset)?;
+                    rlc_config.read_challenge1(&mut region, challenges, &mut offset)?;
 
                 let flags = chunk_is_valid_cells
                     .iter()


### PR DESCRIPTION
preimage uses keccak input (randomness), but digest RLCs are evm word (randomness).

The PR fixes the part of copy constraints within blob data config to address this.