### PR TITLE
bump reth-primitives and revm-precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "reth-primitives",
- "revm-precompile 4.1.0 (git+https://github.com/bluealloy/revm)",
+ "revm-precompile 5.1.0 (git+https://github.com/bluealloy/revm)",
  "serde",
  "serde_json",
  "snark-verifier",
@@ -106,20 +106,20 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "thiserror",
+ "serde",
 ]
 
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-serde",
  "serde",
 ]
 
@@ -171,11 +171,12 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-engine-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
+ "alloy-serde",
  "jsonrpsee-types",
  "serde",
  "thiserror",
@@ -184,10 +185,11 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -195,15 +197,26 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=76c70fb#76c70fb9d44ace661bbf33408c2527e3874c964e"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde",
  "itertools 0.12.1",
  "jsonrpsee-types",
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=410850b#410850b305a28297483d819b669b04ba31796359"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -553,9 +566,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 dependencies = [
  "serde",
 ]
@@ -740,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a4bc5367b6284358d2a6a6a1dc2d92ec4b86034561c3b9d3341909752fd848"
+checksum = "3130f3d8717cc02e668a896af24984d5d5d4e8bf12e278e982e0f1bd88a0f9af"
 dependencies = [
  "blst",
  "cc",
@@ -1698,6 +1711,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "enr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "hex",
+ "k256 0.13.3",
+ "log",
+ "rand",
+ "rlp",
+ "secp256k1 0.27.0",
+ "sha3 0.10.8",
+ "zeroize",
+]
+
+[[package]]
 name = "enumn"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,7 +2023,7 @@ dependencies = [
  "auto_impl",
  "base64 0.21.7",
  "bytes",
- "enr",
+ "enr 0.8.1",
  "ethers-core",
  "futures-channel",
  "futures-core",
@@ -3228,7 +3259,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall",
 ]
@@ -4157,7 +4188,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -4389,8 +4420,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#30d79a98aabcc6385beb6548f7cce9ebd85347ca"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -4399,8 +4430,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#30d79a98aabcc6385beb6548f7cce9ebd85347ca"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -4410,8 +4441,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#30d79a98aabcc6385beb6548f7cce9ebd85347ca"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -4423,8 +4454,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#30d79a98aabcc6385beb6548f7cce9ebd85347ca"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -4437,6 +4468,7 @@ dependencies = [
  "c-kzg",
  "cfg-if 1.0.0",
  "derive_more",
+ "enr 0.10.0",
  "itertools 0.12.1",
  "modular-bitfield",
  "nybbles",
@@ -4445,12 +4477,13 @@ dependencies = [
  "reth-codecs",
  "reth-ethereum-forks",
  "reth-rpc-types",
- "revm 6.1.0",
- "revm-primitives 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm 7.2.0",
+ "revm-primitives 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "roaring",
  "secp256k1 0.27.0",
  "serde",
  "serde_json",
+ "serde_with 3.6.1",
  "sha2",
  "strum 0.26.1",
  "tempfile",
@@ -4460,9 +4493,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/paradigmxyz/reth#200978436296d4e2b731fe262b79f16039c17dd4"
+version = "0.2.0-beta.3"
+source = "git+https://github.com/paradigmxyz/reth#30d79a98aabcc6385beb6548f7cce9ebd85347ca"
 dependencies = [
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-engine-types",
@@ -4496,25 +4530,26 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "6.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d35316fc02d99e42831356c71e882f5d385c77b78f64a44ae82f2f9a4b8b72f"
+checksum = "24fd3ed4b62dc61c647552d8b781811ae25ec74d23309055077e4dfb392444d2"
 dependencies = [
  "auto_impl",
  "cfg-if 1.0.0",
+ "dyn-clone",
  "revm-interpreter",
- "revm-precompile 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-precompile 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-interpreter"
-version = "3.1.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa10c2dc1e8f4934bdc763a2c09371bcec29e50c22e55e3eb325ee0cba09064"
+checksum = "9f0a1818f8c876b0d71a0714217c34da7df8a42c0462750768779d55680e4554"
 dependencies = [
- "revm-primitives 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -4536,15 +4571,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "4.1.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db828d49d329560a70809d9d1fa0c74695edb49f50c5332db3eb24483076deac"
+checksum = "7a9645a70f1df1e5bd7fa8718b9ba486fac9c3f0467aa6b58e7f590d5f6fd0f7"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
  "k256 0.13.3",
  "once_cell",
- "revm-primitives 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ripemd",
  "secp256k1 0.28.2",
  "sha2",
@@ -4553,14 +4588,14 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "4.1.0"
-source = "git+https://github.com/bluealloy/revm#13ce01318b0c707b46430c405fb261243d281cd2"
+version = "5.1.0"
+source = "git+https://github.com/bluealloy/revm#09df19cc089b6fc796aa252bdc12133334256d9d"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
  "k256 0.13.3",
  "once_cell",
- "revm-primitives 2.1.0 (git+https://github.com/bluealloy/revm)",
+ "revm-primitives 3.1.0 (git+https://github.com/bluealloy/revm)",
  "ripemd",
  "secp256k1 0.28.2",
  "sha2",
@@ -4587,17 +4622,18 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "2.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecd125aad58e135e2ca5771ed6e4e7b1f05fa3a64e0dfb9cc643b7a800a8435"
+checksum = "323ad597cf75ac9cb1d161be29fcc3562426f0278a1d04741697fca556e1ceea"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "bitvec",
  "c-kzg",
  "cfg-if 1.0.0",
  "derive_more",
+ "dyn-clone",
  "enumn",
  "hashbrown 0.14.3",
  "hex",
@@ -4607,12 +4643,12 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "2.1.0"
-source = "git+https://github.com/bluealloy/revm#13ce01318b0c707b46430c405fb261243d281cd2"
+version = "3.1.0"
+source = "git+https://github.com/bluealloy/revm#09df19cc089b6fc796aa252bdc12133334256d9d"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "bitvec",
  "c-kzg",
  "cfg-if 1.0.0",
@@ -4807,7 +4843,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5010,6 +5046,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
+ "rand",
  "secp256k1-sys 0.9.2",
 ]
 


### PR DESCRIPTION
### Description

Update Cargo.lock to bump `reth-primitives` and `revm-precompile`.