### PR TITLE
[Fix] Issue from codeaudition of sha256 circuit

### DIFF
--- a/zkevm-circuits/src/sha256_circuit/README.md
+++ b/zkevm-circuits/src/sha256_circuit/README.md
@@ -55,6 +55,10 @@ The circuit contains fixed layouts of input and output regions, i.e. an input re
 
 ### Defination in regions:
 
+  The 256-bit state to start a new compression is stored in 16 cells extracted from the digest region (see below), each cell for a 16-bit part and is called a "dense state" in table16. Such a dense state is assigned into an initialization region of table16 and export a "working state" for the following compression step. The working state also contain another dense state inside it. The caller to this initialization entry of table16, that is, the sha256 circuit, has a response to constarint the input dense state with the output one.
+  
+  Also, for the first compression step, circuit also constarint the dense state inside of the working state with the constants of the "Initiazation Vector" of sha256.
+
   Each input region captures a 512-bit block and copies the 16 x 32-bit integers (in the form of a pair of assigned cells for their lo and hi 16-bit parts) inside of the `message schedule` region of table16. The region consists of 66 rows: 64 rows for 64 bytes representing the 512-bit block and 2 extra rows at the beginning. For the `s_final_block`, `byte_counter`, `s_padding` and `bytes_rlc` cols, the cells in last row (enabled by `s_last` selector) are connected by equality constraints to the first row of next input region for the subsequent 512-bit block. Additionally the `s_final_block` cells is also connected with the corresponding digest reion. 
   
   The second row at the top of the region determines how the `byte_counter`, `s_padding` and `bytes_rlc` cols begin: if the inherited `s_final_block` cell (at the first row at the top of the region) is 1, these cols will start with an initial value (i.e., 0); else they will start with the "inherited" value of the previous 512-bit block. 

--- a/zkevm-circuits/src/sha256_circuit/README.md
+++ b/zkevm-circuits/src/sha256_circuit/README.md
@@ -8,7 +8,7 @@ This circuit use a forking of [table16](https://zcash.github.io/halo2/design/gad
 The witness in table16 is then exported to an extra region so that the RLC of input and digest can be calculated and form the lookup table for the SHA256 precompile in zkevm-circuit. To achieve this, we have introduced several cols and assigned them to two regions: `input` and `digest`. The following table illustrates:
 
 input region (example for input 'abc'):
-|          |      s_final     | s_u16     | counter   | bytes_rlc | trans_byte | copied_data | s_output|  padding        |padding_size|
+|          | s_final_block | s_u16     | byte_counter| bytes_rlc | trans_byte | copied_data | s_output|  s_padding      |helper |
 |----------|------------------|-----------|-----------|-----------|------------|-------------|---------|-----------------|------------|
 |(inherit) |     *1*          |           |  *42*     |*inherit_rlc*|          |             |         |       *1*       |            |
 |s_begin   |     1            |           |     0     |     0     |            |             |         |       0         |            |
@@ -18,19 +18,19 @@ input region (example for input 'abc'):
 |s_enable  |     1            |    0      |     3     | 0x61062063|   b'0x80'  |             |         |       1         |            |
 |....      |
 |s_enable  |     1            |    1      |     3     | 0x61062063|   b'0x00   |  *0x0018*   |         |       1         |    0       |
-|s_last    |     1            |    0      |     3     | 0x61062063|   b'0x18   |             |         |       1         |    24      |
+|s_final   |     1            |    0      |     3     | 0x61062063|   b'0x18   |             |         |       1         |    24      |
 
 
 digest region (example for the hash of 'abc'):
-|          |      s_final     | s_u16     | counter   | bytes_rlc | trans_byte | copied_data | s_output|  padding  |
-|----------|------------------|-----------|-----------|-----------|------------|-------------|---------|-----------|
+|          | s_final_block | s_u16     | byte_counter| bytes_rlc | trans_byte | copied_data | s_output|s_padding  |helper |
+|----------|------------------|-----------|-----------|-----------|------------|-------------|---------|-----------|-----------|
 |          |     *1*          |           |           | **0**     |            |             |         |    **0**  |
 |s_enable  |      1           |    1      |           |  0xba     |   b'0xba'  | *0xba78*    |  0x6a09 |    0      |
 |s_enable  |      1           |    0      |           | 0xba078   |   b'0x78   | *0x6a09*    |         |
 |....      |
 |s_enable  |      1           |    1      |           |           |   b'0x15   | *0x15ad*    |  0xcd19 |    0      |
 |s_enable  |      1           |    0      |           | hash_rlc  |   b'0xad   | *0xcd19*    |         |    **0**  |
-|          |                  |           |*input_counter*|*hash_rlc*|         | *input_rlc* |    1    |           |
+|s_final    |                  |           |*input_counter*|*hash_rlc*|         |          |    1    |           | *input_rlc* |
 
 Note: 
 + *Italic* indicate the cell is equality constrainted whie **bold** indicate the cell is constarinted with constant
@@ -40,23 +40,30 @@ Note:
 
 + `copied_data` col is used to copy the cells with `u16` values from `table16`.
 + `trans_byte` expands each `u16` value copied from `table16` into two bytes across two adjacent rows, with the help of the selector `s_u16`
-+ `padding` col marks whether the byte in current row is padding or input byte.
++ `s_padding` col marks whether the byte in current row is padding or input byte.
 + `bytes_rlc` accumulates bytes in `trans_byte` col to its RLC expression only if the byte in current row is not padding. Otherwise, it continues the value from the previous row if the current row is marked as padding.
-+ `counter` counts the total input bytes if byte in current row is not padding, Otherwise it continues the value from previous row if the current row is marked as padding.
-+ `s_final` is a boolean advice col that identifies in each row of an input region, marking wether the current block is the last block
-+ `padding_size` calculates the accumulation of the last 8 bytes in input region and obtains the bit counts recorded in the tail of the padding, which is specified by SHA2.
++ `byte_counter` counts the total input bytes if byte in current row is not padding, Otherwise it continues the value from previous row if the current row is marked as padding.
++ `s_final_block` is a boolean advice col that identifies in each row of an input region, marking wether the current block is the last block
++ `helper` col has mutiple usage. In input region it calculate the acculumation of the last 8 bytes and represent the bit counts in the last row (if current block is the final one); in output region it copied the rlc of input bytes in the final row.
+
+The circuit contains fixed layouts of input and output regions, i.e. an input region is followed by a output region, handling one sha256 block (512 bits or 64 bytes), and the whole circuit would handle the fixed count of blocks. So it is possible to put fixed selector cols in the circuit:
++ `s_begin` is used to indicate the first row in both input and output region.
++ `s_enable` is used to indicate each row in regions the common gates must be actived
++ `s_final` is used to indicate the last row in both input and output region.
++ `s_assigned_u16` is used to indicate there is a copied u16 word in the cell of `copied_data` col.
++ `s_padding_size` and `s_common_bytes` is a pair of fixed selector to mark the the last 8 bytes in every input region. `s_padding_size` select the last 8 bytes while `s_common_bytes` select the other. They help to accumulate the last 8 bytes in input region and obtains the bit counts recorded in the tail of the padding, which is specified by SHA2.
 
 ### Defination in regions:
 
-  Each input region captures a 512-bit block and copies the 16 x 32-bit integers (in the form of a pair of assigned cells for their lo and hi 16-bit parts) inside of the `message schedule` region of table16. The region consists of 66 rows: 64 rows for 64 bytes representing the 512-bit block and 2 extra rows at the beginning. For the `s_final`, `counter`, `padding` and `bytes_rlc` cols, the cells in last row (enabled by `s_last` selector) are connected by equality constraints to the first row of next input region for the subsequent 512-bit block. Additionally the `s_final` cells is also connected with the corresponding digest reion. 
+  Each input region captures a 512-bit block and copies the 16 x 32-bit integers (in the form of a pair of assigned cells for their lo and hi 16-bit parts) inside of the `message schedule` region of table16. The region consists of 66 rows: 64 rows for 64 bytes representing the 512-bit block and 2 extra rows at the beginning. For the `s_final_block`, `byte_counter`, `s_padding` and `bytes_rlc` cols, the cells in last row (enabled by `s_last` selector) are connected by equality constraints to the first row of next input region for the subsequent 512-bit block. Additionally the `s_final_block` cells is also connected with the corresponding digest reion. 
   
-  The second row at the top of the region determines how the `counter`, `padding` and `bytes_rlc` cols begin: if the inherited `s_final` cell (at the first row at the top of the region) is 1, these cols will start with an initial value (i.e., 0); else they will start with the "inherited" value of the previous 512-bit block. 
+  The second row at the top of the region determines how the `byte_counter`, `s_padding` and `bytes_rlc` cols begin: if the inherited `s_final_block` cell (at the first row at the top of the region) is 1, these cols will start with an initial value (i.e., 0); else they will start with the "inherited" value of the previous 512-bit block. 
 
-  Note that it is free to specify `s_final` in each block as either 0 or 1. If `s_final` is set to 1, the last row must satisfy the "final" constraint, that is the cell in `counter` col has to equal the calculated bit size in `padding_size` cell.
+  Note that it is free to specify `s_final_block` in each block as either 0 or 1. If `s_final_block` is set to 1, the last row must satisfy the "final" constraint, that is the cell in `byte_counter` col has to equal the calculated bit size in `s_padding_size` cell.
 
-  There is exactly one digest region corresponding to each input region. This region captures the 256-bit digest of the 512-bit block and copies it from the `digest` region of table16. The region consists of 34 rows: 32 rows for bytes of digests, 1 extra row at the beginning, and 1 row at the bottom. The `s_final` is inherited from the input region, and the first row for `counter`, `padding` and `bytes_rlc` cols are specified with 0 by constraints to a constant. The last row for digest bytes is also constarint the `padding` cell as 0, which also ensure there is no padding row existed in digest region.
+  There is exactly one digest region corresponding to each input region. This region captures the 256-bit digest of the 512-bit block and copies it from the `digest` region of table16. The region consists of 34 rows: 32 rows for bytes of digests, 1 extra row at the beginning, and 1 row at the bottom. The `s_final_block` is inherited from the input region, and the first row for `byte_counter`, `s_padding` and `bytes_rlc` cols are specified with 0 by constraints to a constant. The last row for digest bytes is also constarint the `s_padding` cell as 0, which also ensure there is no padding row existed in digest region.
 
-  Like input region, digest region calculated the RLC of digest bytes. The final row in digest copied `s_final` and `counter` value inheirted from input region into the corresponding cols; `bytes_rlc` of the cell in previous cell (i.e. the RLC of digest); and the RLC of input into `copied_data` col. This row represents a row in SHA256 table used for looking up from evm circuit.
+  Like input region, digest region calculated the RLC of digest bytes. The final row in digest copied `s_final_block` and `byte_counter` value inheirted from input region into the corresponding cols; `bytes_rlc` of the cell in previous cell (i.e. the RLC of digest); and the RLC of input into `helper` col. This row represents a row in SHA256 table used for looking up from evm circuit.
 
 ## Performance
 

--- a/zkevm-circuits/src/sha256_circuit/circuit.rs
+++ b/zkevm-circuits/src/sha256_circuit/circuit.rs
@@ -62,6 +62,7 @@ pub trait SHA256Table {
 pub struct CircuitConfig {
     table16: Table16Config,
     byte_range: TableColumn,
+    c_data: Column<Fixed>,
 
     copied_data: Column<Advice>,
     trans_byte: Column<Advice>,
@@ -287,9 +288,11 @@ impl CircuitConfig {
         let s_enable = meta.selector();
         let s_assigned_u16 = meta.selector();
 
+        let c_data = meta.fixed_column();
         let byte_range = meta.lookup_table_column();
         let table16 = Table16Chip::configure(meta);
 
+        meta.enable_constant(c_data);
         meta.enable_equality(helper);
         meta.enable_equality(copied_data);
         meta.enable_equality(bytes_rlc);
@@ -300,6 +303,7 @@ impl CircuitConfig {
         let ret = Self {
             table16,
             byte_range,
+            c_data,
             copied_data,
             trans_byte,
             bytes_rlc,
@@ -647,6 +651,11 @@ impl CircuitConfig {
         )
     }
 
+    const IV16: [u16; 16] = [
+        0x6a09, 0xe667, 0xbb67, 0xae85, 0x3c6e, 0xf372, 0xa54f, 0xf53a, 0x510e, 0x527f, 0x9b05,
+        0x688c, 0x1f83, 0xd9ab, 0x5be0, 0xcd19,
+    ];
+
     #[allow(clippy::type_complexity)]
     fn assign_output_region(
         &self,
@@ -656,10 +665,6 @@ impl CircuitConfig {
         input_block: &BlockInheritments,
         is_final: bool,
     ) -> Result<[(AssignedBits<Fr, 16>, AssignedBits<Fr, 16>); 8], Error> {
-        const IV16: [u16; 16] = [
-            0x6a09, 0xe667, 0xbb67, 0xae85, 0x3c6e, 0xf372, 0xa54f, 0xf53a, 0x510e, 0x527f, 0x9b05,
-            0x688c, 0x1f83, 0xd9ab, 0x5be0, 0xcd19,
-        ];
 
         let output_cells = layouter.assign_region(
             || "sha256 digest",
@@ -693,7 +698,7 @@ impl CircuitConfig {
                 // assign message state
                 let (export_cells, byte_cells) = self.assign_message_block(
                     &mut region,
-                    state.iter().flat_map(|(lo, hi)| [hi, lo]).zip_eq(IV16),
+                    state.iter().flat_map(|(lo, hi)| [hi, lo]).zip_eq(Self::IV16),
                     header_offset,
                     is_final,
                 )?;
@@ -705,7 +710,7 @@ impl CircuitConfig {
                         || "set s_output for init_iv",
                         self.s_output,
                         row,
-                        || Value::known(Fr::from(IV16[i / 2] as u64)),
+                        || Value::known(Fr::from(Self::IV16[i / 2] as u64)),
                     )?;
                     region.assign_advice(
                         || "byte counter",
@@ -852,6 +857,45 @@ impl Hasher {
 
         let table16_chip = Table16Chip::construct::<Fr>(chip.table16.clone());
         let state = table16_chip.initialization_vector(layouter)?;
+        // init the 16 iv cells and binding them to initialize state
+        layouter.assign_region(
+            || "sha256 state initialized by iv bind",
+            |mut region|{
+                let extract_dense = {
+                    let (a, b, c, d, e, f, g, h) = match state.clone() {
+                        Table16State::Compress(s) => s.decompose(),
+                        _ => unreachable!(),
+                    };
+                    [
+                        a.into_dense(),
+                        b.into_dense(),
+                        c.into_dense(),
+                        d,
+                        e.into_dense(),
+                        f.into_dense(),
+                        g.into_dense(),
+                        h,
+                    ]                        
+                };
+                for (i, den_s) in extract_dense.into_iter().enumerate() {
+                    let (cell_s_lo, cell_s_hi) = den_s.decompose();
+                    let row_i = i*2;
+                    // notice the iv is organized as (hi, lo)
+                    let (iv_hi, iv_lo) = (CircuitConfig::IV16[row_i], CircuitConfig::IV16[row_i+1]);
+                    let (cell_iv_lo, cell_iv_hi) = (
+                        region.assign_fixed(||"iv_hi", chip.c_data, row_i, 
+                        ||Value::known(Fr::from(iv_lo as u64)))?,
+                        region.assign_fixed(||"iv_hi", chip.c_data, row_i+1,
+                        ||Value::known(Fr::from(iv_hi as u64)))?,
+                    );
+                    region.constrain_equal(cell_s_lo.cell(), cell_iv_lo.cell())?;
+                    region.constrain_equal(cell_s_hi.cell(), cell_iv_hi.cell())?;
+                }
+
+                Ok(())
+            }
+        )?;
+
         let hasher_state = chip.initialize_block_head(layouter)?;
         Ok(Self {
             chip,
@@ -1123,7 +1167,6 @@ mod tests {
                 hashes_rlc: meta.advice_column(),
                 is_effect: meta.advice_column(),
             };
-            meta.enable_constant(dev_table.s_enable);
 
             let chng = Expression::Constant(Fr::from(0x1000u64));
             Self::Config::configure(meta, dev_table, chng)


### PR DESCRIPTION
This PR has fixed two issue raised from the code audition of sha256 circuit:

+ "2. Discrepancies between circuit descriptions and circuit implementations‬", the part related with sha256 circuit

+ "3. The Table16 circuit does not bind the input state to the decomposed‬ ‭internal state variables"‬, we have made a patch outside of table16 (i.e. in the sha256 circuit, which wrapped table16). so we do not need to upgrade the dependency of `halo2-gadgets`