### PR TITLE
Refactoring and naming changes

### DIFF
--- a/aggregator/src/aggregation.rs
+++ b/aggregator/src/aggregation.rs
@@ -11,7 +11,6 @@ mod rlc;
 
 pub(crate) use barycentric::{
     interpolate, AssignedBarycentricEvaluationConfig, BarycentricEvaluationConfig, BLS_MODULUS,
-    ROOTS_OF_UNITY,
 };
 pub(crate) use blob_data::BlobDataConfig;
 pub use circuit::AggregationCircuit;

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -197,7 +197,7 @@ impl BlobDataConfig {
 
         // lookup metadata and chunk data digests in keccak table.
         meta.lookup_any(
-            "BlobDataConfig (chunk data digests in keccak table)",
+            "BlobDataConfig (metadata/chunk_data digests in keccak table)",
             |meta| {
                 let is_data = meta.query_selector(config.data_selector);
                 let is_hash = meta.query_selector(config.hash_selector);
@@ -713,15 +713,7 @@ impl BlobDataConfig {
                     )?;
 
                     // constrain chunk size specified here against decoded in metadata.
-                    let chunk_size_specified = rlc_config.select(
-                        &mut region,
-                        &zero,
-                        &row.accumulator,
-                        &is_empty,
-                        &mut rlc_config_offset,
-                    )?;
-                    region
-                        .constrain_equal(chunk_size_specified.cell(), chunk_size_decoded.cell())?;
+                    region.constrain_equal(row.accumulator.cell(), chunk_size_decoded.cell())?;
 
                     chunk_digest_evm_rlcs.push(&row.digest_rlc);
                 }

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -455,7 +455,7 @@ impl Circuit<Fr> for AggregationCircuit {
                     for (chunk_data_digest, expected_chunk_data_digest) in blob_data_exports
                         .chunk_data_digests
                         .iter()
-                        .zip_eq(assigned_batch_hash.blob.chunk_data_digests.iter())
+                        .zip_eq(assigned_batch_hash.blob.chunk_tx_data_digests.iter())
                     {
                         for (c, ec) in chunk_data_digest
                             .iter()

--- a/aggregator/src/constants.rs
+++ b/aggregator/src/constants.rs
@@ -24,7 +24,7 @@ pub(crate) const LOG_DEGREE: u32 = 19;
 // - post_state_root    32 bytes
 // - withdraw_root      32 bytes
 // - chunk_data_hash    32 bytes
-// - chunk_data_digest  32 bytes
+// - chunk_tx_data_hash 32 bytes
 
 pub(crate) const PREV_STATE_ROOT_INDEX: usize = 8;
 pub(crate) const POST_STATE_ROOT_INDEX: usize = 40;

--- a/aggregator/src/core.rs
+++ b/aggregator/src/core.rs
@@ -162,7 +162,7 @@ pub(crate) struct ExtractedHashCells {
 pub(crate) struct ExpectedBlobCells {
     pub(crate) z: Vec<AssignedCell<Fr, Fr>>,
     pub(crate) y: Vec<AssignedCell<Fr, Fr>>,
-    pub(crate) chunk_data_digests: Vec<Vec<AssignedCell<Fr, Fr>>>,
+    pub(crate) chunk_tx_data_digests: Vec<Vec<AssignedCell<Fr, Fr>>>,
 }
 
 pub(crate) struct AssignedBatchHash {
@@ -238,7 +238,7 @@ pub(crate) fn assign_batch_hashes(
     let expected_blob_cells = ExpectedBlobCells {
         z: batch_pi_input[BATCH_Z_OFFSET..BATCH_Z_OFFSET + 32].to_vec(),
         y: batch_pi_input[BATCH_Y_OFFSET..BATCH_Y_OFFSET + 32].to_vec(),
-        chunk_data_digests: (0..MAX_AGG_SNARKS)
+        chunk_tx_data_digests: (0..MAX_AGG_SNARKS)
             .map(|i| {
                 let chunk_pi_input = &extracted_hash_cells.hash_input_cells
                     [INPUT_LEN_PER_ROUND * (2 + 2 * i)..INPUT_LEN_PER_ROUND * (2 + 2 * (i + 1))];


### PR DESCRIPTION
Includes minor changes based on review comments from PR #1167 

- no need of `select` in copy constraint for "chunk size specified"
- revert change in naming for `chunk_tx_bytes_digest`
- assertion fix in `blob.rs` for sum of chunk sizes
- naming change in lookup to keccak table from blob data config (include "metadata")
- clippy fix