### PR TITLE
Check that chunk_idx increases on boundaries

### DIFF
--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -126,6 +126,16 @@ impl BlobDataConfig {
             },
         );
 
+        meta.lookup(
+            "chunk_idx for non-padding, data rows in [1..MAX_AGG_SNARKS]",
+            |meta| {
+                let is_data = meta.query_selector(config.data_selector);
+                let is_padding = meta.query_advice(config.is_padding, Rotation::cur());
+                let chunk_idx = meta.query_advice(config.chunk_idx, Rotation::cur());
+                vec![(is_data * (1.expr() - is_padding) * (chunk_idx - 1.expr()), config.chunk_idx_range_table.into())]
+            },
+        );
+
         meta.create_gate("BlobDataConfig (transition when boundary)", |meta| {
             let is_data = meta.query_selector(config.data_selector);
             let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -121,7 +121,8 @@ impl BlobDataConfig {
                 let cond = is_not_hash * is_boundary * (1.expr() - is_padding_next);
                 let chunk_idx_curr = meta.query_advice(config.chunk_idx, Rotation::cur());
                 let chunk_idx_next = meta.query_advice(config.chunk_idx, Rotation::next());
-                vec![(cond * (chunk_idx_next - chunk_idx_curr), range_table.into())]
+                // chunk_idx increases by at least 1 and at most MAX_AGG_SNARKS when condition is met.
+                vec![(cond * (chunk_idx_next - chunk_idx_curr - 1.expr()), config.chunk_idx_range_table.into())]
             },
         );
 


### PR DESCRIPTION
From https://github.com/scroll-tech/zkevm-circuits/pull/1167#issue-2202449609:
> The only unit test that is failing currently is: "all empty except last chunk", i.e. We have 15 valid chunks, 14 are empty and the 15th chunk has some data. The reason why this is failing is because the chunk_idx for the first non-empty chunk is 15. But the range table used in BlobDataConfig is initialised as: RangeTable<MAX_AGG_SNARKS> hence the maximum value in the range table is 14. So we encounter a lookup failure
This range table also includes 0, which allows an attacker to set chunk_idx' == chunk_idx at a chunk boundary, thereby never increasing the chunk idx at this row. This is an issue. We want to constrain:

>(chunk_idx' - chunk_idx) in [1, MAX_AGG_SNARKS]

>One solution is to exclude 0 from this range table (change RangeTable<MAX> to RangeTable<EXCLUDE_ZERO, MAX>), but this won't work as on the rows where the lookup condition is not met, 0 wouldn't lie in the range table.
Another solution is to simply use RangeTable<{ MAX_AGG_SNARKS + 1 }> and add an additional constraint that on is_boundary, we do not allow chunk_idx' == chunk_idx.

Fix both of these by checking that chunk_idx.cur() - chunk_idx.next() - 1 is in the range table, rather than just chunk_idx.cur() - chunk_idx.next() is in the range table.