### PR TITLE
soundness fix: hash selector

### DIFF
--- a/aggregator/src/tests/blob.rs
+++ b/aggregator/src/tests/blob.rs
@@ -2,7 +2,7 @@ use crate::{
     aggregation::{
         AssignedBarycentricEvaluationConfig, BarycentricEvaluationConfig, BlobDataConfig, RlcConfig,
     },
-    blob::{BlobAssignments, BlobData},
+    blob::{BlobAssignments, BlobData, N_ROWS_DATA},
     param::ConfigParams,
     MAX_AGG_SNARKS,
 };
@@ -167,6 +167,8 @@ fn check_circuit(data: BlobData) -> Result<(), Vec<VerifyFailure>> {
 
 #[test]
 fn blob_circuit_completeness() {
+    // single chunk in batch, but the chunk has a size of N_ROWS_DATA
+    let full_blob = vec![vec![123; N_ROWS_DATA]];
     let all_empty_chunks: Vec<Vec<u8>> = vec![vec![]; MAX_AGG_SNARKS];
     let one_chunk = vec![vec![2, 3, 4, 100, 1]];
     let two_chunks = vec![vec![100; 1000], vec![2, 3, 4, 100, 1]];
@@ -188,6 +190,7 @@ fn blob_circuit_completeness() {
         .collect::<Vec<_>>();
 
     for blob in [
+        full_blob,
         one_chunk,
         two_chunks,
         max_chunks,


### PR DESCRIPTION
### Soundness Bug

The `hash_selector` was enabled for both the "digest rlc" and "digest bytes" sections. This means that the lookup to the hash section could be maliciously satisfied by setting `digest_rlc` in the "chunk data" section to be an arbitrary value and also setting the same arbitrary value in one of the "digest bytes" rows. Since we only check the `byte` column from the "digest bytes" section, effectively this becomes a soundness bug as `accumulator` and `chunk_idx` can be set to satisfy the "chunk data" section (while setting an arbitrary value for `digest_rlc` and satisfying the lookup).

### Fix

The fix is to enable the `hash_selector` _only_ for the "digest rlc" section. We already have constraints on the `chunk_idx` column for this section, there is now no way to maliciously satisfy the lookup to the `hash_selector`

### Misc updates

Also includes:
- minor refactoring (naming change) where `blob_preimage` is changed to `challenge_digest_preimage`
- we add a unit test case for blob data config where _every_ row in "chunk data" section is filled, i.e. a batch that fully fills the blob data config. This is to check that `is_boundary=true` on the last row of this section can be handled successfully by the custom gates in blob data config.