### PR TITLE
big arrays replaced by vec and passed by ref

### DIFF
--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -197,7 +197,7 @@ impl BlobDataConfig {
 
         // lookup metadata and chunk data digests in keccak table.
         meta.lookup_any(
-            "BlobDataConfig (metadata/chunk_data digests in keccak table)",
+            "BlobDataConfig (metadata/chunk_data/challenge digests in keccak table)",
             |meta| {
                 let is_data = meta.query_selector(config.data_selector);
                 let is_hash = meta.query_selector(config.hash_selector);
@@ -256,7 +256,7 @@ impl BlobDataConfig {
 
         // lookup challenge digest in keccak table.
         meta.lookup_any(
-            "BlobDataConfig (challenge digest in keccak table)",
+            "BlobDataConfig (metadata/chunk_data/challenge digests in keccak table)",
             |meta| {
                 let is_hash = meta.query_selector(config.hash_selector);
                 let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -188,7 +188,7 @@ impl Circuit<Fr> for AggregationCircuit {
 
                     let barycentric = config.barycentric.assign(
                         &mut ctx,
-                        self.batch_hash.blob.coefficients,
+                        &self.batch_hash.blob.coefficients,
                         self.batch_hash.blob.challenge_digest,
                         self.batch_hash.blob.evaluation,
                     );
@@ -268,7 +268,7 @@ impl Circuit<Fr> for AggregationCircuit {
                     let mut ctx = Rc::into_inner(loader).unwrap().into_ctx();
                     let barycentric = config.barycentric.assign(
                         &mut ctx,
-                        self.batch_hash.blob.coefficients,
+                        &self.batch_hash.blob.coefficients,
                         self.batch_hash.blob.challenge_digest,
                         self.batch_hash.blob.evaluation,
                     );

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -511,7 +511,7 @@ impl From<&BlobData> for BlobAssignments {
         let evaluation = U256::from_little_endian(
             &interpolate(
                 Scalar::from_raw(challenge_digest.0),
-                coefficients_as_scalars,
+                &coefficients_as_scalars,
             )
             .to_bytes(),
         );

--- a/aggregator/src/tests/blob.rs
+++ b/aggregator/src/tests/blob.rs
@@ -117,7 +117,7 @@ impl Circuit<Fr> for BlobCircuit {
                 let blob = BlobAssignments::from(&self.data);
                 Ok(config.barycentric.assign(
                     &mut ctx,
-                    blob.coefficients,
+                    &blob.coefficients,
                     blob.challenge_digest,
                     blob.evaluation,
                 ))
@@ -208,8 +208,8 @@ fn generic_blob_data() -> BlobData {
         vec![100; 300],
         vec![100, 23, 34, 24, 10],
         vec![200; 20],
-        vec![200; 20],
         vec![],
+        vec![200; 20],
     ])
 }
 
@@ -240,11 +240,3 @@ fn inconsistent_chunk_bytes() {
     blob_data.chunk_data[0].push(128);
     assert!(check_circuit(blob_data).is_err());
 }
-
-// This is not possible to check right now becuase of the assignment code.
-// #[test]
-// fn too_many_chunk_bytes() {
-//     let mut blob_data = generic_blob_data();
-//     blob_data.chunk_bytes[0].extend(vec![100; BLOB_WIDTH * 31]);
-//     assert!(check_circuit(blob_data).is_err());
-// }


### PR DESCRIPTION
Refactor:

- Convert `ROOTS_OF_UNITY` to a vector instead of array
- Pass blob polynomial coefficients as reference to the barycentric `assign` and `interpolate` functions
- Rename lookup to keccak table, for no confusion in debugging failure