### PR TITLE
Refactor and Optimise

### DIFF
--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -174,7 +174,7 @@ impl BlobDataConfig {
                     * (1.expr() - is_padding_next.expr())
                     * (preimage_rlc_next - byte_next.expr()),
                 // the boundary count increments, i.e.
-                // - boundary_count_curr == boundary_count_prev + 1
+                // boundary_count_curr == boundary_count_prev + 1
                 cond.expr() * (boundary_count_curr - boundary_count_prev - 1.expr()),
             ]
         });

--- a/aggregator/src/aggregation/rlc.rs
+++ b/aggregator/src/aggregation/rlc.rs
@@ -2,3 +2,4 @@ mod config;
 mod gates;
 
 pub(crate) use config::RlcConfig;
+pub(crate) use gates::POWS_OF_256;

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -7,60 +7,97 @@ use halo2_proofs::{
 };
 use zkevm_circuits::util::Challenges;
 
-use crate::{constants::LOG_DEGREE, util::assert_equal};
+use crate::{constants::LOG_DEGREE, util::assert_equal, MAX_AGG_SNARKS};
 
 use super::RlcConfig;
 
+const FIXED_OFFSET_32: usize = MAX_AGG_SNARKS + 1;
+const FIXED_OFFSET_168: usize = FIXED_OFFSET_32 + 1;
+const FIXED_OFFSET_200: usize = FIXED_OFFSET_168 + 1;
+const FIXED_OFFSET_2_POW_32: usize = FIXED_OFFSET_200 + 1;
+const FIXED_OFFSET_256: usize = FIXED_OFFSET_2_POW_32 + 1;
+const FIXED_OFFSET_EMPTY_KECCAK: usize = FIXED_OFFSET_256 + POWS_OF_256;
+
+pub(crate) const POWS_OF_256: usize = 10;
+
 impl RlcConfig {
     /// initialize the chip with fixed cells
+    ///
+    /// The layout for fixed cells is:
+    ///
+    /// | Offset                 | Fixed value          |
+    /// |------------------------|----------------------|
+    /// | 0                      | 0                    |
+    /// | 1                      | 1                    |
+    /// | i ...                  | i ...                |
+    /// | MAX_AGG_SNARKS         | MAX_AGG_SNARKS       |
+    /// | MAX_AGG_SNARKS + 1     | 32                   |
+    /// | MAX_AGG_SNARKS + 2     | 168                  |
+    /// | MAX_AGG_SNARKS + 3     | 200                  |
+    /// | MAX_AGG_SNARKS + 4     | 2 ^ 32               |
+    /// | MAX_AGG_SNARKS + 5     | 256                  |
+    /// | MAX_AGG_SNARKS + 6     | 256 ^ 2              |
+    /// | MAX_AGG_SNARKS + 7     | 256 ^ 3              |
+    /// | MAX_AGG_SNARKS + j ... | 256 ^ (j - 4)        |
+    /// | MAX_AGG_SNARKS + 14    | 256 ^ 10             |
+    /// | MAX_AGG_SNARKS + 15    | EMPTY_KECCAK[0]      |
+    /// | MAX_AGG_SNARKS + 16    | EMPTY_KECCAK[1]      |
+    /// | MAX_AGG_SNARKS + k ... | EMPTY_KECCAK[k - 15] |
+    /// | MAX_AGG_SNARKS + 46    | EMPTY_KECCAK[31]     |
+    /// |------------------------|----------------------|
     pub(crate) fn init(&self, region: &mut Region<Fr>) -> Result<(), Error> {
-        region.assign_fixed(|| "const zero", self.fixed, 0, || Value::known(Fr::zero()))?;
-        region.assign_fixed(|| "const one", self.fixed, 1, || Value::known(Fr::one()))?;
-        region.assign_fixed(|| "const two", self.fixed, 2, || Value::known(Fr::from(2)))?;
-        region.assign_fixed(|| "const five", self.fixed, 3, || Value::known(Fr::from(5)))?;
-        region.assign_fixed(|| "const nine", self.fixed, 4, || Value::known(Fr::from(9)))?;
-        region.assign_fixed(|| "const 13", self.fixed, 5, || Value::known(Fr::from(13)))?;
-        region.assign_fixed(|| "const 32", self.fixed, 6, || Value::known(Fr::from(32)))?;
-        region.assign_fixed(
-            || "const 136",
-            self.fixed,
-            7,
-            || Value::known(Fr::from(136)),
-        )?;
-        region.assign_fixed(
-            || "const 2^32",
-            self.fixed,
-            8,
-            || Value::known(Fr::from(1 << 32)),
-        )?;
-        region.assign_fixed(
-            || "const 256",
-            self.fixed,
-            9,
-            || Value::known(Fr::from(256)),
-        )?;
-        region.assign_fixed(
-            || "const 168",
-            self.fixed,
-            10,
-            || Value::known(Fr::from(168)),
-        )?;
-        region.assign_fixed(
-            || "const 200",
-            self.fixed,
-            11,
-            || Value::known(Fr::from(200)),
-        )?;
+        let mut offset = 0;
 
-        let empty_keccak = keccak256([]);
-        for (i, &byte) in empty_keccak.iter().enumerate() {
+        // [0, ..., MAX_AGG_SNARKS]
+        for const_val in 0..=MAX_AGG_SNARKS {
             region.assign_fixed(
-                || "const empty_keccak[i]",
+                || format!("const at offset={offset}"),
                 self.fixed,
-                12 + i,
+                offset,
+                || Value::known(Fr::from(const_val as u64)),
+            )?;
+            offset += 1;
+        }
+        assert_eq!(offset, FIXED_OFFSET_32);
+
+        // [32, 168, 200, 1 << 32]
+        for const_val in [32, 168, 200, 1 << 32] {
+            region.assign_fixed(
+                || format!("const at offset={offset}"),
+                self.fixed,
+                offset,
+                || Value::known(Fr::from(const_val)),
+            )?;
+            offset += 1;
+        }
+        assert_eq!(offset, FIXED_OFFSET_256);
+
+        // [256, ..., 256 ^ i, ..., 256 ^ 10]
+        for const_val in std::iter::successors(Some(Fr::from(256)), |n| Some(n * Fr::from(256)))
+            .take(POWS_OF_256)
+        {
+            region.assign_fixed(
+                || format!("const at offset={offset}"),
+                self.fixed,
+                offset,
+                || Value::known(const_val),
+            )?;
+            offset += 1;
+        }
+        assert_eq!(offset, FIXED_OFFSET_EMPTY_KECCAK);
+
+        // [EMPTY_KECCAK[0], ..., EMPTY_KECCAK[31]]
+        let empty_keccak = keccak256([]);
+        for &byte in empty_keccak.iter() {
+            region.assign_fixed(
+                || format!("const at offset={offset}"),
+                self.fixed,
+                offset,
                 || Value::known(Fr::from(byte as u64)),
             )?;
+            offset += 1;
         }
+        assert_eq!(offset, FIXED_OFFSET_EMPTY_KECCAK + 32);
 
         Ok(())
     }
@@ -96,7 +133,7 @@ impl RlcConfig {
     pub(crate) fn five_cell(&self, region_index: RegionIndex) -> Cell {
         Cell {
             region_index,
-            row_offset: 3,
+            row_offset: 5,
             column: self.fixed.into(),
         }
     }
@@ -105,7 +142,7 @@ impl RlcConfig {
     pub(crate) fn nine_cell(&self, region_index: RegionIndex) -> Cell {
         Cell {
             region_index,
-            row_offset: 4,
+            row_offset: 9,
             column: self.fixed.into(),
         }
     }
@@ -114,7 +151,21 @@ impl RlcConfig {
     pub(crate) fn thirteen_cell(&self, region_index: RegionIndex) -> Cell {
         Cell {
             region_index,
-            row_offset: 5,
+            row_offset: 13,
+            column: self.fixed.into(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn fixed_up_to_max_agg_snarks_cell(
+        &self,
+        region_index: RegionIndex,
+        index: usize,
+    ) -> Cell {
+        assert!(index <= MAX_AGG_SNARKS, "only up to MAX_AGG_SNARKS");
+        Cell {
+            region_index,
+            row_offset: index,
             column: self.fixed.into(),
         }
     }
@@ -123,33 +174,7 @@ impl RlcConfig {
     pub(crate) fn thirty_two_cell(&self, region_index: RegionIndex) -> Cell {
         Cell {
             region_index,
-            row_offset: 6,
-            column: self.fixed.into(),
-        }
-    }
-    // #[inline]
-    // pub(crate) fn one_hundred_and_thirty_six_cell(&self, region_index: RegionIndex) -> Cell {
-    //     Cell {
-    //         region_index,
-    //         row_offset: 7,
-    //         column: self.fixed.into(),
-    //     }
-    // }
-
-    #[inline]
-    pub(crate) fn two_to_thirty_two_cell(&self, region_index: RegionIndex) -> Cell {
-        Cell {
-            region_index,
-            row_offset: 8,
-            column: self.fixed.into(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn two_hundred_and_fifty_size_cell(&self, region_index: RegionIndex) -> Cell {
-        Cell {
-            region_index,
-            row_offset: 9,
+            row_offset: FIXED_OFFSET_32,
             column: self.fixed.into(),
         }
     }
@@ -158,7 +183,7 @@ impl RlcConfig {
     pub(crate) fn one_hundred_and_sixty_eight_cell(&self, region_index: RegionIndex) -> Cell {
         Cell {
             region_index,
-            row_offset: 10,
+            row_offset: FIXED_OFFSET_168,
             column: self.fixed.into(),
         }
     }
@@ -167,16 +192,44 @@ impl RlcConfig {
     pub(crate) fn two_hundred_cell(&self, region_index: RegionIndex) -> Cell {
         Cell {
             region_index,
-            row_offset: 11,
+            row_offset: FIXED_OFFSET_200,
+            column: self.fixed.into(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn two_to_thirty_two_cell(&self, region_index: RegionIndex) -> Cell {
+        Cell {
+            region_index,
+            row_offset: FIXED_OFFSET_2_POW_32,
+            column: self.fixed.into(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn pow_of_two_hundred_and_fifty_six_cell(
+        &self,
+        region_index: RegionIndex,
+        exponent: usize,
+    ) -> Cell {
+        assert!(exponent > 0, "for exponent == 0, fetch the one cell");
+        assert!(
+            exponent <= POWS_OF_256,
+            "only up to 256 ^ 10 in fixed column"
+        );
+        Cell {
+            region_index,
+            row_offset: FIXED_OFFSET_256 + exponent - 1,
             column: self.fixed.into(),
         }
     }
 
     #[inline]
     pub(crate) fn empty_keccak_cell_i(&self, region_index: RegionIndex, index: usize) -> Cell {
+        assert!(index <= 31, "keccak digest only has 32 bytes");
         Cell {
             region_index,
-            row_offset: 12 + index,
+            row_offset: FIXED_OFFSET_EMPTY_KECCAK + index,
             column: self.fixed.into(),
         }
     }
@@ -653,6 +706,7 @@ impl RlcConfig {
         self.is_zero(region, &diff, offset)
     }
 }
+
 #[inline]
 fn byte_to_bits_le(byte: &u8) -> Vec<u8> {
     let mut res = vec![];


### PR DESCRIPTION
The PR includes 2 commits:
- https://github.com/scroll-tech/zkevm-circuits/commit/9093928ad52ad99fccf0bb14350de02b64221e19: make use of the RLC Config's fixed column wherever appropriate
- https://github.com/scroll-tech/zkevm-circuits/commit/65850920318f989e724c665449e34a2fff26de1c: add a `boundary_count` column to `BlobDataConfig` that sums over the "chunk data" section, instead of having to sum using RLC Config (which takes 4 rows per sum)

### No. of rows used in RLC Config
- Before:
```
[DEBUG aggregator::aggregation::blob_data] rlc config offset = 1021132
```
- After https://github.com/scroll-tech/zkevm-circuits/commit/9093928ad52ad99fccf0bb14350de02b64221e19:
```
[DEBUG aggregator::aggregation::blob_data] rlc config offset = 1021051
```
- After https://github.com/scroll-tech/zkevm-circuits/commit/65850920318f989e724c665449e34a2fff26de1c:
```
[DEBUG aggregator::aggregation::blob_data] rlc config offset = 513395
```