### PR TITLE
Feat/Blob 4844 Chunk-level Patch

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -332,17 +332,14 @@ impl<F: Field> SubCircuit<F> for EvmCircuit<F> {
     ) -> Result<(), Error> {
         let block = self.block.as_ref().unwrap();
 
-        let tx_max_challenge_pow: Option<usize> = if block.txs.len() > 0 {
-            Some(block.txs.iter().map(|tx| tx.rlp_signed.len()).max().unwrap())
-        } else {
-            None
-        };
+        let max_blob_bytes = 4096 * 31 - 62;
+        let max_pow_limit = Some(max_blob_bytes);
 
         config.load_fixed_table(layouter, self.fixed_table_tags.clone())?;
         config.load_byte_table(layouter)?;
         config
             .pow_of_rand_table
-            .assign(layouter, challenges, tx_max_challenge_pow)?;
+            .assign(layouter, challenges, max_pow_limit)?;
         let export = config.execution.assign_block(layouter, block, challenges)?;
         self.exports.borrow_mut().replace(export);
         Ok(())

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -332,11 +332,17 @@ impl<F: Field> SubCircuit<F> for EvmCircuit<F> {
     ) -> Result<(), Error> {
         let block = self.block.as_ref().unwrap();
 
+        let tx_max_challenge_pow: Option<usize> = if block.txs.len() > 0 {
+            Some(block.txs.iter().map(|tx| tx.rlp_signed.len()).max().unwrap())
+        } else {
+            None
+        };
+
         config.load_fixed_table(layouter, self.fixed_table_tags.clone())?;
         config.load_byte_table(layouter)?;
         config
             .pow_of_rand_table
-            .assign(layouter, challenges, None)?;
+            .assign(layouter, challenges, tx_max_challenge_pow)?;
         let export = config.execution.assign_block(layouter, block, challenges)?;
         self.exports.borrow_mut().replace(export);
         Ok(())

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1214,7 +1214,7 @@ impl<F: Field> PiCircuitConfig<F> {
     /// TxCircuit, which is an RLC summary of rlp_signed (including tx_type byte) of a L2 tx.
     /// This is to ensure the fixed length of an otherwise variable length section.
     ///
-    /// The rip_length_acc field, subsequently, accumulates the length of the rlp_signed data for
+    /// The rpi_length_acc field, subsequently, accumulates the length of the rlp_signed data for
     /// each tx and the RLC multiplier at each row is the power of rand corresponding to the
     /// differential length.
     ///

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -602,7 +602,7 @@ impl<F: Field> SubCircuitConfig<F> for PiCircuitConfig<F> {
                         );
                     }
                 );
-                
+
                 cb.gate(meta.query_fixed(q_chunk_txbytes, Rotation::cur()))
             },
         );

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -592,6 +592,17 @@ impl<F: Field> SubCircuitConfig<F> for PiCircuitConfig<F> {
                     ),
                 );
 
+                cb.condition(
+                    is_rpi_padding,
+                    |cb| {
+                        cb.require_equal(
+                            "rpi_length_cc' = rpi_length_acc for padding rows",
+                            meta.query_advice(rpi_length_acc, Rotation::prev()),
+                            meta.query_advice(rpi_length_acc, Rotation::cur()),
+                        );
+                    }
+                );
+                
                 cb.gate(meta.query_fixed(q_chunk_txbytes, Rotation::cur()))
             },
         );


### PR DESCRIPTION
### Description

This patch includes the following fixes:
- Correct assignment of `pow_of_rand` table from `evm_circuit`.
- Correct documentation typo
- Add `rpi_length_acc` consistency constraint for padding rows within `chunk_txbytes` section.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
