### PR TITLE
Refactor | Clippy

### DIFF
--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -348,11 +348,9 @@ impl Block {
         self.copy_events.push(event);
         // Each byte needs 2 rows
         // TODO: magic num
-        if self.copy_counter > 500_000 {
-            if cfg!(feature = "strict-ccc") {
-                log::error!("copy event len overflow {}", self.copy_counter);
-                panic!("copy event len overflow");
-            }
+        if cfg!(feature = "strict-ccc") && self.copy_counter > 500_000 {
+            log::error!("copy event len overflow {}", self.copy_counter);
+            panic!("copy event len overflow");
         }
     }
     fn copy_event_total_len(&self) -> usize {

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -175,11 +175,9 @@ impl<'a> CircuitInputStateRef<'a> {
             max_rws
         };
         let rwc = self.block_ctx.rwc.0;
-        if rwc > effective_limit {
-            if cfg!(feature = "strict-ccc") {
-                log::error!("rwc > max_rws, rwc={}, max_rws={}", rwc, max_rws);
-                return Err(Error::InternalError("rws not enough"));
-            }
+        if cfg!(feature = "strict-ccc") && rwc > effective_limit {
+            log::error!("rwc > max_rws, rwc={}, max_rws={}", rwc, max_rws);
+            return Err(Error::InternalError("rws not enough"));
         };
         Ok(())
     }

--- a/bus-mapping/src/evm/opcodes/sload.rs
+++ b/bus-mapping/src/evm/opcodes/sload.rs
@@ -60,7 +60,11 @@ impl Opcode for Sload {
         let value_from_statedb = *state.sdb.get_storage(&contract_addr, &key).1;
 
         #[cfg(feature = "enable-stack")]
-        assert_eq!(value_from_statedb, geth_steps[1].stack.last()?, "inconsistent sload: step proof {value_from_step:?}, result {:?} in contract {contract_addr:?}, key {key:?}", geth_steps[1].stack.last()?);
+        assert_eq!(
+            value_from_statedb,
+            geth_steps[1].stack.last()?,
+            "inconsistent sload: step proof {value_from_statedb:?}, result {:?} in contract {contract_addr:?}, key {key:?}", geth_steps[1].stack.last()?,
+        );
 
         let value = value_from_statedb;
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -332,14 +332,9 @@ impl<F: Field> SubCircuit<F> for EvmCircuit<F> {
     ) -> Result<(), Error> {
         let block = self.block.as_ref().unwrap();
 
-        let max_blob_bytes = 4096 * 31 - 62;
-        let max_pow_limit = Some(max_blob_bytes);
-
         config.load_fixed_table(layouter, self.fixed_table_tags.clone())?;
         config.load_byte_table(layouter)?;
-        config
-            .pow_of_rand_table
-            .assign(layouter, challenges, max_pow_limit)?;
+        config.pow_of_rand_table.assign(layouter, challenges)?;
         let export = config.execution.assign_block(layouter, block, challenges)?;
         self.exports.borrow_mut().replace(export);
         Ok(())

--- a/zkevm-circuits/src/pi_circuit/dev.rs
+++ b/zkevm-circuits/src/pi_circuit/dev.rs
@@ -136,18 +136,9 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_INNER_
             &challenges,
         )?;
 
-        let tx_max_challenge_pow = self
-            .0
-            .public_data
-            .transactions
-            .iter()
-            .filter(|&tx| tx.is_chunk_l2_tx())
-            .map(|tx| tx.rlp_signed.len())
-            .max();
-
         config
             .pow_of_rand_table
-            .assign(&mut layouter, &challenges, tx_max_challenge_pow)?;
+            .assign(&mut layouter, &challenges)?;
 
         self.0.import_tx_values(tx_value_cells);
         self.0.synthesize_sub(&config, &challenges, &mut layouter)?;

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -3058,7 +3058,7 @@ impl PowOfRandTable {
         let r = challenges.keccak_input();
 
         let max_rows = if cfg!(feature = "test") {
-            4096
+            2048
         } else {
             4094 * 31
         };

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -17,7 +17,7 @@ use crate::{
 use bus_mapping::{
     circuit_input_builder::{
         BigModExp, CopyDataType, CopyEvent, CopyStep, EcAddOp, EcMulOp, EcPairingOp, ExpEvent,
-        PrecompileEcParams, N_BYTES_PER_PAIR, N_PAIRING_PER_OP,
+        PrecompileEcParams,
     },
     precompile::PrecompileCalls,
 };
@@ -3054,22 +3054,15 @@ impl PowOfRandTable {
         &self,
         layouter: &mut impl Layouter<F>,
         challenges: &Challenges<Value<F>>,
-        max_pow_limit: Option<usize>,
     ) -> Result<(), Error> {
         let r = challenges.keccak_input();
-
-        // Determine the maximum pow
-        let mut curr_max_pow = N_PAIRING_PER_OP * N_BYTES_PER_PAIR;
-        if max_pow_limit.is_some() {
-            curr_max_pow = curr_max_pow.max(max_pow_limit.unwrap() + 1);
-        }
 
         layouter.assign_region(
             || "power of randomness table",
             |mut region| {
                 let pows_of_rand =
                     std::iter::successors(Some(Value::known(F::one())), |&v| Some(v * r))
-                        .take(curr_max_pow);
+                        .take(4194 * 31);
 
                 for (idx, pow_of_rand) in pows_of_rand.enumerate() {
                     region.assign_fixed(

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -3057,7 +3057,9 @@ impl PowOfRandTable {
     ) -> Result<(), Error> {
         let r = challenges.keccak_input();
 
-        let max_rows = if cfg!(feature = "test") {
+        let max_rows = if cfg!(feature = "scroll") && cfg!(feature = "test") {
+            4000
+        } else if cfg!(feature = "test") {
             2048
         } else {
             4094 * 31

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -3057,12 +3057,18 @@ impl PowOfRandTable {
     ) -> Result<(), Error> {
         let r = challenges.keccak_input();
 
+        let max_rows = if cfg!(feature = "test") {
+            4096
+        } else {
+            4094 * 31
+        };
+
         layouter.assign_region(
             || "power of randomness table",
             |mut region| {
                 let pows_of_rand =
                     std::iter::successors(Some(Value::known(F::one())), |&v| Some(v * r))
-                        .take(4194 * 31);
+                        .take(max_rows);
 
                 for (idx, pow_of_rand) in pows_of_rand.enumerate() {
                     region.assign_fixed(

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -3942,7 +3942,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
                 }
             })
             .sum::<usize>();
-        let blob_usage: f32 = chunk_txbytes_len as f32 / CHUNK_TXBYTES_BLOB_LIMIT.clone() as f32;
+        let blob_usage: f32 = chunk_txbytes_len as f32 / CHUNK_TXBYTES_BLOB_LIMIT as f32;
 
         // Calculate tx circuit dynamic section usage
         let sum_calldata_len = block.txs.iter().map(|tx| tx.call_data.len()).sum::<usize>();
@@ -3976,7 +3976,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
             (sum_calldata_len + sum_access_list_len) as f32 / max_dynamic_data as f32;
 
         // Get the highest usage fraction out of all capacities
-        let highest_usage = (vec![blob_usage, dynamic_usage])
+        let highest_usage = ([blob_usage, dynamic_usage])
             .iter()
             .cloned()
             .fold(0_f32, f32::max);

--- a/zkevm-circuits/src/tx_circuit/dev.rs
+++ b/zkevm-circuits/src/tx_circuit/dev.rs
@@ -238,22 +238,10 @@ impl<F: Field> Circuit<F> for TxCircuitTester<F> {
             &challenges,
         )?;
 
-        // The chunk bytes of all txs are accumulated by rlp_signed length
-        // To accomplish this, PowOfRandTable must provide appropriate rows according to the max
-        // rlp_signed len for lookup
-        let tx_max_challenge_pow = self
-            .tx_circuit
-            .txs
-            .iter()
-            .chain(padding_txs.iter())
-            .map(|tx| tx.rlp_signed.len())
-            .max();
-
-        config.tx_config.pow_of_rand_table.assign(
-            &mut layouter,
-            &challenges,
-            tx_max_challenge_pow,
-        )?;
+        config
+            .tx_config
+            .pow_of_rand_table
+            .assign(&mut layouter, &challenges)?;
         config.tx_config.rlp_table.dev_load(
             &mut layouter,
             self.tx_circuit


### PR DESCRIPTION
- We no longer need an optional `max_pow_limit` for the `PowOfRandTable` as we know the upper bound.
- Fix clippy warnings (unrelated files)