### PR TITLE
Feat/Blob 4844 PICircuit Chunk TxBytes Condense

### DIFF
--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -23,7 +23,6 @@ use crate::{
 use halo2_proofs::plonk::FirstPhase as SecondPhase;
 #[cfg(not(feature = "onephase"))]
 use halo2_proofs::plonk::SecondPhase;
-use std::ops::Mul;
 
 use crate::{
     evm_circuit::{util::constraint_builder::BaseConstraintBuilder, EvmCircuitExports},

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -203,10 +203,7 @@ impl PublicData {
     /// chunk
     fn chunk_txbytes(&self) -> Vec<u8> {
         let mut result: Vec<u8> = vec![];
-        let chunk_txs_iter = self
-            .transactions
-            .iter()
-            .filter(|&tx| tx.is_chunk_l2_tx());
+        let chunk_txs_iter = self.transactions.iter().filter(|&tx| tx.is_chunk_l2_tx());
 
         for tx in chunk_txs_iter {
             result.extend_from_slice(&tx.rlp_signed);
@@ -309,8 +306,7 @@ impl PublicData {
     }
 
     fn pi_bytes_start_offset(&self) -> usize {
-        self.q_chunk_txbytes_end_offset()
-            + 1 // new row.
+        self.q_chunk_txbytes_end_offset() + 1 // new row.
     }
 
     fn pi_bytes_end_offset(&self) -> usize {
@@ -1151,8 +1147,8 @@ impl<F: Field> PiCircuitConfig<F> {
         };
 
         region.constrain_equal(
-            tx_value_cells[public_data.max_txs * TX_LEN].cell(), 
-            chunk_txbytes_hash_rlc_cell.cell()
+            tx_value_cells[public_data.max_txs * TX_LEN].cell(),
+            chunk_txbytes_hash_rlc_cell.cell(),
         )?;
 
         Ok((offset + 1, chunk_txbytes_hash_rlc_cell))

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -499,6 +499,7 @@ impl<F: Field> SubCircuitConfig<F> for PiCircuitConfig<F> {
         meta.enable_equality(block_table.value); // copy block to rpi
         meta.enable_equality(block_table.index);
         meta.enable_equality(tx_table.value); // copy tx hashes to rpi
+        meta.enable_equality(tx_table.chunk_txbytes_hash_rlc); // copy chunk_txbytes_hash
         meta.enable_equality(cum_num_txs);
         meta.enable_equality(pi);
 

--- a/zkevm-circuits/src/pi_circuit/dev.rs
+++ b/zkevm-circuits/src/pi_circuit/dev.rs
@@ -91,7 +91,6 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_INNER_
         let keccak_table = KeccakTable::construct(meta);
         let challenges = Challenges::construct(meta);
         let challenge_exprs = challenges.exprs(meta);
-        let pow_of_rand_table = PowOfRandTable::construct(meta, &challenge_exprs);
         (
             PiCircuitConfig::new(
                 meta,
@@ -99,7 +98,6 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_INNER_
                     block_table,
                     keccak_table,
                     tx_table,
-                    pow_of_rand_table,
                     challenges: challenge_exprs,
                 },
             ),
@@ -135,19 +133,6 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_INNER_
             vec![&data_bytes, &chunk_txbytes, &pi_bytes],
             &challenges,
         )?;
-
-        let tx_max_challenge_pow = self
-            .0
-            .public_data
-            .transactions
-            .iter()
-            .filter(|&tx| tx.is_chunk_l2_tx())
-            .map(|tx| tx.rlp_signed.len())
-            .max();
-
-        config
-            .pow_of_rand_table
-            .assign(&mut layouter, &challenges, tx_max_challenge_pow)?;
 
         self.0.import_tx_values(tx_value_cells);
         self.0.synthesize_sub(&config, &challenges, &mut layouter)?;

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -249,7 +249,6 @@ impl SubCircuitConfig<Fr> for SuperCircuitConfig<Fr> {
                 block_table: block_table.clone(),
                 keccak_table: keccak_table.clone(),
                 tx_table: tx_table.clone(),
-                pow_of_rand_table,
                 challenges: challenges_expr.clone(),
             },
         );

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -414,14 +414,6 @@ impl TxTable {
             meta.query_advice(self.value, Rotation::next()), // offset 22: TxType
         ]
     }
-    /// Return l2 PICircuit exprs
-    pub fn l2_pi_exprs<F: Field>(&self, meta: &mut VirtualCells<F>) -> Vec<Expression<F>> {
-        vec![
-            meta.query_fixed(self.q_enable, Rotation::cur()),
-            meta.query_advice(self.value, Rotation::cur()), // offset 20: TxHashRLC
-            meta.query_advice(self.value, Rotation::prev()), // offset 19: TxHashLength
-        ]
-    }
 }
 
 impl<F: Field> LookupTable<F> for TxTable {

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -2595,7 +2595,7 @@ impl<F: Field> TxCircuitConfig<F> {
             access_list_size(&tx.access_list);
 
         // Only bytes from L2 txs are accumulated for chunk bytes hash
-        let is_chunk_bytes = (tx.tx_type != TxType::L1Msg) && !tx.caller_address.is_zero();
+        let is_chunk_bytes = tx.is_chunk_l2_tx();
 
         let hash_len = if is_chunk_bytes {
             tx.rlp_signed.len()
@@ -3594,7 +3594,7 @@ impl<F: Field> TxCircuit<F> {
         let chunk_hash_bytes = self
             .txs
             .iter()
-            .filter(|&tx| (tx.tx_type != TxType::L1Msg) && !tx.caller_address.is_zero())
+            .filter(|&tx| tx.is_chunk_l2_tx())
             .flat_map(|tx| tx.rlp_signed.clone())
             .collect::<Vec<u8>>();
         inputs.extend_from_slice(&[chunk_hash_bytes]);
@@ -3737,7 +3737,7 @@ impl<F: Field> TxCircuit<F> {
                 let mut chunk_bytes: Vec<u8> = vec![];
                 for i in 0..sigs.len() {
                     let tx = get_tx(i);
-                    if (tx.tx_type != TxType::L1Msg) && !tx.caller_address.is_zero() {
+                    if tx.is_chunk_l2_tx() {
                         chunk_bytes.extend_from_slice(&tx.rlp_signed);
                     }
                 }

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -229,7 +229,6 @@ pub struct TxCircuitConfig<F: Field> {
     // used for calculating hash of all chunk bytes
     chunk_txbytes_rlc: Column<Advice>,
     chunk_txbytes_len_acc: Column<Advice>,
-    chunk_txbytes_hash: Column<Advice>,
     pow_of_rand: Column<Advice>,
 
     _marker: PhantomData<F>,
@@ -357,13 +356,11 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         let is_chunk_bytes = meta.advice_column();
         let chunk_bytes_len = meta.advice_column();
         let chunk_txbytes_rlc = meta.advice_column_in(SecondPhase);
-        let chunk_txbytes_hash = meta.advice_column_in(SecondPhase);
         let chunk_txbytes_len_acc = meta.advice_column();
         let pow_of_rand = meta.advice_column_in(SecondPhase);
 
         meta.enable_equality(chunk_bytes_len);
         meta.enable_equality(chunk_txbytes_rlc);
-        meta.enable_equality(chunk_txbytes_hash);
         meta.enable_equality(chunk_txbytes_len_acc);
         meta.enable_equality(pow_of_rand);
 
@@ -991,7 +988,6 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
             sks_acc,
             chunk_txbytes_rlc,
             chunk_txbytes_len_acc,
-            chunk_txbytes_hash,
         );
 
         meta.create_gate("tx_gas_cost == 0 for L1 msg", |meta| {
@@ -1940,7 +1936,6 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
             chunk_bytes_len,
             chunk_txbytes_rlc,
             chunk_txbytes_len_acc,
-            chunk_txbytes_hash,
             pow_of_rand,
             _marker: PhantomData,
             num_txs,
@@ -1984,7 +1979,6 @@ impl<F: Field> TxCircuitConfig<F> {
         sks_acc: Column<Advice>,
         chunk_txbytes_rlc: Column<Advice>,
         chunk_txbytes_len_acc: Column<Advice>,
-        chunk_txbytes_hash: Column<Advice>,
     ) {
         macro_rules! is_tx_type {
             ($var:ident, $type_variant:ident) => {
@@ -2533,7 +2527,7 @@ impl<F: Field> TxCircuitConfig<F> {
                 1.expr(),                                                   // is_final
                 meta.query_advice(chunk_txbytes_rlc, Rotation::prev()),     // input_rlc
                 meta.query_advice(chunk_txbytes_len_acc, Rotation::prev()), // input_len
-                meta.query_advice(chunk_txbytes_hash, Rotation::prev()),    // output_rlc
+                meta.query_advice(tx_table.chunk_txbytes_hash_rlc, Rotation::prev()),    // output_rlc
             ]
             .into_iter()
             .zip(keccak_table.table_exprs(meta))
@@ -2966,8 +2960,8 @@ impl<F: Field> TxCircuitConfig<F> {
                 || chunk_txbytes_len,
             )?;
             txbytes_hash_assignment = Some(region.assign_advice(
-                || "chunk_txbytes_hash",
-                self.chunk_txbytes_hash,
+                || "tx_table.chunk_txbytes_hash_rlc",
+                self.tx_table.chunk_txbytes_hash_rlc,
                 *offset,
                 || chunk_txbytes_hash,
             )?);

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -1836,9 +1836,12 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         meta.lookup_any("Correct pow_of_rand for HashLen", |meta| {
             let enable = and::expr(vec![
                 meta.query_fixed(q_enable, Rotation::cur()),
-                // A valid chunk txbytes tx is determined by: (tx.tx_type != TxType::L1Msg) && !tx.caller_address.is_zero()
+                // A valid chunk txbytes tx is determined by: (tx.tx_type != TxType::L1Msg) &&
+                // !tx.caller_address.is_zero()
                 not::expr(meta.query_advice(is_l1_msg, Rotation::cur())),
-                not::expr(value_is_zero.expr(Rotation(-((HASH_RLC_OFFSET - CALLER_ADDRESS_OFFSET) as i32)))(meta)),
+                not::expr(value_is_zero.expr(Rotation(
+                    -((HASH_RLC_OFFSET - CALLER_ADDRESS_OFFSET) as i32),
+                ))(meta)),
                 is_hash_rlc(meta),
             ]);
 
@@ -2527,11 +2530,11 @@ impl<F: Field> TxCircuitConfig<F> {
             ]);
 
             vec![
-                1.expr(),                                                   // q_enable
-                1.expr(),                                                   // is_final
-                meta.query_advice(chunk_txbytes_rlc, Rotation::prev()),     // input_rlc
-                meta.query_advice(chunk_txbytes_len_acc, Rotation::prev()), // input_len
-                meta.query_advice(tx_table.chunk_txbytes_hash_rlc, Rotation::prev()),    // output_rlc
+                1.expr(),                                                             // q_enable
+                1.expr(),                                                             // is_final
+                meta.query_advice(chunk_txbytes_rlc, Rotation::prev()),               // input_rlc
+                meta.query_advice(chunk_txbytes_len_acc, Rotation::prev()),           // input_len
+                meta.query_advice(tx_table.chunk_txbytes_hash_rlc, Rotation::prev()), // output_rlc
             ]
             .into_iter()
             .zip(keccak_table.table_exprs(meta))

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -372,6 +372,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         meta.enable_equality(chunk_txbytes_rlc);
         meta.enable_equality(chunk_txbytes_len_acc);
         meta.enable_equality(pow_of_rand);
+        meta.enable_equality(tx_table.chunk_txbytes_hash_rlc);
 
         // TODO: add lookup to SignVerify table for sv_address
         let sv_address = meta.advice_column();

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -3904,7 +3904,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
     type Config = TxCircuitConfig<F>;
 
     fn unusable_rows() -> usize {
-        9
+        10
     }
 
     fn new_from_block(block: &witness::Block<F>) -> Self {


### PR DESCRIPTION
### Description

Simplifies the `chunk_txbytes` section within `PICircuit` and condenses the section into one row with a copy constraint from `TxCircuit` where the correctness of l2 tx bytes accumulation and final keccak hash is actually ascertained.
- Remove pow_of_rand from `PICircuit`.
- Remove accumulation scheme for chunk txbytes in `PICircuit`.
- Add `chunk_txbytes_hash_rlc` column to `TxTable` for copy constraint.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
