### PR TITLE
Add more tests for BlobData struct

### DIFF
--- a/aggregator/src/aggregation.rs
+++ b/aggregator/src/aggregation.rs
@@ -11,6 +11,7 @@ mod rlc;
 
 pub(crate) use barycentric::{
     interpolate, AssignedBarycentricEvaluationConfig, BarycentricEvaluationConfig, BLS_MODULUS,
+    ROOTS_OF_UNITY,
 };
 pub(crate) use blob_data::BlobDataConfig;
 pub use circuit::AggregationCircuit;

--- a/aggregator/src/aggregation.rs
+++ b/aggregator/src/aggregation.rs
@@ -11,7 +11,6 @@ mod rlc;
 
 pub(crate) use barycentric::{
     interpolate, AssignedBarycentricEvaluationConfig, BarycentricEvaluationConfig, BLS_MODULUS,
-    ROOTS_OF_UNITY,
 };
 pub(crate) use blob_data::BlobDataConfig;
 pub use circuit::AggregationCircuit;

--- a/aggregator/src/aggregation/barycentric.rs
+++ b/aggregator/src/aggregation/barycentric.rs
@@ -18,9 +18,12 @@ use num_bigint::{BigInt, Sign};
 use std::{iter::successors, sync::LazyLock};
 
 use crate::{
-    blob::{BLOB_WIDTH, LOG_BLOB_WIDTH},
+    blob::BLOB_WIDTH,
     constants::{BITS, LIMBS},
 };
+
+/// Base 2 logarithm of BLOB_WIDTH.
+const LOG_BLOB_WIDTH: usize = 12;
 
 pub static BLS_MODULUS: LazyLock<U256> = LazyLock::new(|| {
     U256::from_str_radix(Scalar::MODULUS, 16).expect("BLS_MODULUS from bls crate")
@@ -346,7 +349,21 @@ pub fn interpolate(z: Scalar, coefficients: &[Scalar; BLOB_WIDTH]) -> Scalar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeSet;
+    use crate::blob::BlobData;
+    use c_kzg::{Blob as RethBlob, KzgProof, KzgSettings};
+    use once_cell::sync::Lazy;
+    use std::{collections::BTreeSet, sync::Arc};
+
+    /// KZG trusted setup
+    pub static MAINNET_KZG_TRUSTED_SETUP: Lazy<Arc<KzgSettings>> = Lazy::new(|| {
+        Arc::new(
+            c_kzg::KzgSettings::load_trusted_setup(
+                &revm_primitives::kzg::G1_POINTS.0,
+                &revm_primitives::kzg::G2_POINTS.0,
+            )
+            .expect("failed to load trusted setup"),
+        )
+    });
 
     #[test]
     fn log_blob_width() {
@@ -377,5 +394,67 @@ mod tests {
             ROOTS_OF_UNITY.iter().collect::<BTreeSet<_>>().len(),
             BLOB_WIDTH
         );
+    }
+
+    #[test]
+    fn interpolate_matches_reth_implementation() {
+        let blob = BlobData::from(&vec![
+            vec![30; 56],
+            vec![200; 100],
+            vec![0; 340],
+            vec![10; 23],
+        ]);
+
+        for z in 0..10 {
+            let z = Scalar::from(u64::try_from(13241234 + z).unwrap());
+            assert_eq!(
+                reth_point_evaluation(z, &blob.get_coefficients().map(|c| Scalar::from_raw(c.0))),
+                interpolate(z, &blob.get_coefficients().map(|c| Scalar::from_raw(c.0)))
+            );
+        }
+    }
+
+    fn reth_point_evaluation(z: Scalar, coefficients: &[Scalar]) -> Scalar {
+        assert_eq!(coefficients.len(), BLOB_WIDTH);
+        let blob = RethBlob::from_bytes(
+            &coefficients
+                .iter()
+                .cloned()
+                .flat_map(to_be_bytes)
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        let (_proof, y) =
+            KzgProof::compute_kzg_proof(&blob, &to_be_bytes(z).into(), &MAINNET_KZG_TRUSTED_SETUP)
+                .unwrap();
+        from_canonical_be_bytes(*y)
+    }
+
+    #[test]
+    fn reth_kzg_implementation() {
+        // check that we are calling the reth implementation correctly
+        for z in 0..10 {
+            let z = Scalar::from(u64::try_from(z).unwrap());
+            assert_eq!(reth_point_evaluation(z, &*ROOTS_OF_UNITY), z)
+        }
+    }
+
+    fn to_be_bytes(x: Scalar) -> [u8; 32] {
+        let mut bytes = x.to_bytes();
+        bytes.reverse();
+        bytes
+    }
+
+    fn from_canonical_be_bytes(bytes: [u8; 32]) -> Scalar {
+        let mut bytes = bytes;
+        bytes.reverse();
+        Scalar::from_bytes(&bytes).expect("non-canonical bytes")
+    }
+
+    #[test]
+    fn test_be_bytes() {
+        let mut be_bytes_one = [0; 32];
+        be_bytes_one[31] = 1;
+        assert_eq!(to_be_bytes(Scalar::one()), be_bytes_one);
     }
 }

--- a/aggregator/src/aggregation/barycentric.rs
+++ b/aggregator/src/aggregation/barycentric.rs
@@ -435,7 +435,7 @@ mod tests {
         // check that we are calling the reth implementation correctly
         for z in 0..10 {
             let z = Scalar::from(u64::try_from(z).unwrap());
-            assert_eq!(reth_point_evaluation(z, &*ROOTS_OF_UNITY), z)
+            assert_eq!(reth_point_evaluation(z, &ROOTS_OF_UNITY), z)
         }
     }
 

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -10,7 +10,7 @@ use halo2_proofs::{
     halo2curves::{bls12_381::Scalar, bn256::Fr},
 };
 use itertools::Itertools;
-use std::iter::repeat;
+use std::iter::{once, repeat};
 use zkevm_circuits::util::Challenges;
 
 /// The number of coefficients (BLS12-381 scalars) to represent the blob polynomial in evaluation
@@ -303,9 +303,9 @@ impl BlobData {
             let digest_rlc = digest.iter().fold(Value::known(Fr::zero()), |acc, &x| {
                 acc * challenge.evm_word() + Value::known(Fr::from(x as u64))
             });
-            std::iter::repeat(Value::known(Fr::zero()))
+            repeat(Value::known(Fr::zero()))
                 .take(N_ROWS_METADATA - 1)
-                .chain(std::iter::once(digest_rlc))
+                .chain(once(digest_rlc))
         };
 
         // preimage_rlc is the running RLC over bytes in the "metadata" section.
@@ -373,7 +373,7 @@ impl BlobData {
                     },
                 )
             })
-            .chain(std::iter::repeat(BlobDataRow::padding_row()))
+            .chain(repeat(BlobDataRow::padding_row()))
             .take(N_ROWS_DATA)
             .collect()
     }
@@ -422,7 +422,7 @@ impl BlobData {
         // - metadata digest bytes
         // - chunks[i].chunk_data_digest bytes for each chunk
         // - challenge digest bytes
-        std::iter::once(BlobDataRow {
+        once(BlobDataRow {
             digest_rlc: metadata_digest_rlc,
             preimage_rlc: Value::known(Fr::zero()),
             // this is_padding assignment does not matter as we have already crossed the "chunk
@@ -444,7 +444,7 @@ impl BlobData {
                     ..Default::default()
                 }),
         )
-        .chain(std::iter::once(BlobDataRow {
+        .chain(once(BlobDataRow {
             preimage_rlc: challenge_digest_preimage_rlc,
             digest_rlc: challenge_digest_rlc,
             accumulator: 32 * (MAX_AGG_SNARKS + 1) as u64,
@@ -605,23 +605,23 @@ mod tests {
             ),
             (
                 "max number of chunks only last one non-empty not full blob",
-                std::iter::repeat(vec![])
+                repeat(vec![])
                     .take(MAX_AGG_SNARKS - 1)
-                    .chain(std::iter::once(vec![132; N_ROWS_DATA - 1111]))
+                    .chain(once(vec![132; N_ROWS_DATA - 1111]))
                     .collect(),
             ),
             (
                 "max number of chunks only last one non-empty full blob",
-                std::iter::repeat(vec![])
+                repeat(vec![])
                     .take(MAX_AGG_SNARKS - 1)
-                    .chain(std::iter::once(vec![132; N_ROWS_DATA]))
+                    .chain(once(vec![132; N_ROWS_DATA]))
                     .collect(),
             ),
             (
                 "max number of chunks but last is empty",
-                std::iter::repeat(vec![111; 100])
+                repeat(vec![111; 100])
                     .take(MAX_AGG_SNARKS - 1)
-                    .chain(std::iter::once(vec![]))
+                    .chain(once(vec![]))
                     .collect(),
             ),
         ]


### PR DESCRIPTION
Re-enable point precompile tests and add a test checking that the data bytes are packed in into blob coefficients in big-endian order.