### PR TITLE
[FIX] Calculating for required rows of sha256 circuit

### DIFF
--- a/zkevm-circuits/src/sha256_circuit.rs
+++ b/zkevm-circuits/src/sha256_circuit.rs
@@ -66,20 +66,20 @@ pub struct SHA256Circuit<F: Field>(Vec<SHA256>, usize, std::marker::PhantomData<
 
 const TABLE16_BLOCK_ROWS: usize = 2114;
 const BLOCK_SIZE_IN_BYTES: usize = BLOCK_SIZE * 4;
-const LENGTH_BYTES: usize = 9; // the additional bytes (a 0x80 byte with 64-bit int)
-                               // must be set at the end of padded bytes
+const MIN_PADDING_BYTES: usize = 9; // the additional bytes (a 0x80 byte)
+                                    // and 8-byte length
 
 impl<F: Field> SHA256Circuit<F> {
     fn expected_rows(&self) -> usize {
         self.0
             .iter()
             .map(|evnt| {
-                (evnt.input.len() + LENGTH_BYTES + BLOCK_SIZE_IN_BYTES - 1) / BLOCK_SIZE_IN_BYTES
+                (evnt.input.len() + MIN_PADDING_BYTES + BLOCK_SIZE_IN_BYTES - 1)
+                    / BLOCK_SIZE_IN_BYTES
             })
             .reduce(|acc, v| acc + v)
             .unwrap_or_default()
             * TABLE16_BLOCK_ROWS
-            + 20 // we have an additional region for initialization
     }
 
     fn with_row_limit(self, row_limit: usize) -> Self {

--- a/zkevm-circuits/src/sha256_circuit.rs
+++ b/zkevm-circuits/src/sha256_circuit.rs
@@ -71,10 +71,19 @@ impl<F: Field> SHA256Circuit<F> {
     fn expected_rows(&self) -> usize {
         self.0
             .iter()
-            .map(|evnt| (evnt.input.len()) + 9 / BLOCK_SIZE_IN_BYTES + 1)
+            .map(|evnt| {
+                let blks = (evnt.input.len() + BLOCK_SIZE_IN_BYTES - 1) / BLOCK_SIZE_IN_BYTES;
+                let paddings = blks * BLOCK_SIZE_IN_BYTES - evnt.input.len();
+                if paddings < 9 {
+                    blks + 1
+                } else {
+                    blks
+                }
+            })
             .reduce(|acc, v| acc + v)
             .unwrap_or_default()
             * TABLE16_BLOCK_ROWS
+            + 20 // we have an additional region for initialization
     }
 
     fn with_row_limit(self, row_limit: usize) -> Self {

--- a/zkevm-circuits/src/sha256_circuit.rs
+++ b/zkevm-circuits/src/sha256_circuit.rs
@@ -66,7 +66,7 @@ pub struct SHA256Circuit<F: Field>(Vec<SHA256>, usize, std::marker::PhantomData<
 
 const TABLE16_BLOCK_ROWS: usize = 2114;
 const BLOCK_SIZE_IN_BYTES: usize = BLOCK_SIZE * 4;
-const LENGTH_BYTES: usize = 9; // the additional bytes (a 0 byte with 64-bit int)
+const LENGTH_BYTES: usize = 9; // the additional bytes (a 0x80 byte with 64-bit int)
                                // must be set at the end of padded bytes
 
 impl<F: Field> SHA256Circuit<F> {

--- a/zkevm-circuits/src/sha256_circuit.rs
+++ b/zkevm-circuits/src/sha256_circuit.rs
@@ -66,19 +66,15 @@ pub struct SHA256Circuit<F: Field>(Vec<SHA256>, usize, std::marker::PhantomData<
 
 const TABLE16_BLOCK_ROWS: usize = 2114;
 const BLOCK_SIZE_IN_BYTES: usize = BLOCK_SIZE * 4;
+const LENGTH_BYTES: usize = 9; // the additional bytes (a 0 byte with 64-bit int)
+                               // must be set at the end of padded bytes
 
 impl<F: Field> SHA256Circuit<F> {
     fn expected_rows(&self) -> usize {
         self.0
             .iter()
             .map(|evnt| {
-                let blks = (evnt.input.len() + BLOCK_SIZE_IN_BYTES - 1) / BLOCK_SIZE_IN_BYTES;
-                let paddings = blks * BLOCK_SIZE_IN_BYTES - evnt.input.len();
-                if paddings < 9 {
-                    blks + 1
-                } else {
-                    blks
-                }
+                (evnt.input.len() + LENGTH_BYTES + BLOCK_SIZE_IN_BYTES - 1) / BLOCK_SIZE_IN_BYTES
             })
             .reduce(|acc, v| acc + v)
             .unwrap_or_default()


### PR DESCRIPTION
The origianl code is problematic. The correct way should be:

For each sha256 hashing:
+ Padding the contents above to be aligned at 64 bytes border
+ Check the actually padding size in bytes, if it is less than 9 (a 0x80 bytes plus with 64 bit integer which indicate the input size), the content must be padded with one more block
+ Calculate the required sha256 blocks, each one would handle 512bit (64 bytes) content
+ Each block would cost fixed number of circuit rows (currently is 2114)
+ Add an initliazation region, which cost 16 rows, and some additional rows for accommodate rotations and constants, totally 20  

(note: for SHA256 protocol, we need pad a '1' bit after the context then padding it to the border of byte, and followed by the int64 length mark, so for byte-aligned context we just pad an addition byte of `0x80`)