### PR TITLE
include selectors from blob data config

### DIFF
--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -48,9 +48,9 @@ pub struct BlobDataConfig {
     /// only at the rows where we actually do the Keccak lookup.
     digest_rlc: Column<Advice>,
     /// Boolean to let us know we are in the data section.
-    data_selector: Selector,
+    pub data_selector: Selector,
     /// Boolean to let us know we are in the hash section.
-    hash_selector: Selector,
+    pub hash_selector: Selector,
     /// Fixed table that consists of [0, 256).
     u8_table: U8Table,
     /// Fixed table that consists of [0, MAX_AGG_SNARKS).

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -519,6 +519,8 @@ impl CircuitExt<Fr> for AggregationCircuit {
                     config.0.rlc_config.selector,
                     config.0.rlc_config.enable_challenge1,
                     config.0.rlc_config.enable_challenge2,
+                    config.0.blob_data_config.data_selector,
+                    config.0.blob_data_config.hash_selector,
                 ]
                 .iter()
                 .cloned(),


### PR DESCRIPTION
`BlobDataConfig` has 2 new selectors `data_selector` and `hash_selector` which need to be included in the `selectors` method in `AggregationCircuit`.