### PR TITLE
feat(bus-mapping): add sanity check for jumpi

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -40,6 +40,7 @@ mod extcodecopy;
 mod extcodehash;
 mod extcodesize;
 mod gasprice;
+mod jumpi;
 mod logs;
 mod mload;
 mod mstore;
@@ -78,7 +79,7 @@ mod memory_expansion_test;
 #[cfg(feature = "test")]
 pub use callop::tests::PrecompileCallArgs;
 
-use self::{pushn::PushN, sha3::Sha3};
+use self::{jumpi::Jumpi, pushn::PushN, sha3::Sha3};
 
 use address::Address;
 use arithmetic::ArithmeticOpcode;
@@ -234,7 +235,7 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
         OpcodeId::SLOAD => Sload::gen_associated_ops,
         OpcodeId::SSTORE => Sstore::gen_associated_ops,
         OpcodeId::JUMP => StackPopOnlyOpcode::<1>::gen_associated_ops,
-        OpcodeId::JUMPI => StackPopOnlyOpcode::<2>::gen_associated_ops,
+        OpcodeId::JUMPI => Jumpi::gen_associated_ops,
         OpcodeId::PC => Pc::gen_associated_ops,
         OpcodeId::MSIZE => Msize::gen_associated_ops,
         OpcodeId::GAS => Gas::gen_associated_ops,

--- a/bus-mapping/src/evm/opcodes/jumpi.rs
+++ b/bus-mapping/src/evm/opcodes/jumpi.rs
@@ -1,0 +1,49 @@
+use super::Opcode;
+use crate::{
+    circuit_input_builder::{CircuitInputStateRef, ExecStep},
+    Error,
+};
+use eth_types::GethExecStep;
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Jumpi;
+
+impl Opcode for Jumpi {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        let geth_step = &geth_steps[0];
+        let mut exec_step = state.new_step(geth_step)?;
+
+        let pc = state.stack_pop(&mut exec_step)?;
+        let condition = state.stack_pop(&mut exec_step)?;
+
+        if let Some(next_step) = geth_steps.get(1) {
+            if condition == 0.into() {
+                assert_eq!(
+                    next_step.pc.0,
+                    geth_step.pc.0 + 1,
+                    "jumpi should not jump: current step {:?} next step {:?}",
+                    geth_step,
+                    next_step
+                );
+            } else {
+                assert_eq!(
+                    next_step.pc.0 as u64,
+                    pc.low_u64(),
+                    "jumpi should jump: current step {:?} next step {:?}",
+                    geth_step,
+                    next_step
+                );
+            }
+        }
+
+        #[cfg(feature = "enable-stack")]
+        for (i, v) in [pc, condition].into_iter().enumerate() {
+            assert_eq!(v, geth_step.stack.nth_last(i)?);
+        }
+
+        Ok(vec![exec_step])
+    }
+}


### PR DESCRIPTION
We removed step.storage and step.stack recently.  Previously we could write some sanity check inside SLOAD opcode, comparing step.storage and step.stack and the storage value inside local statedb, to detect inconsistent statedb between Rust(CCC) and Golang(EVM traces).   

Without step.storage and step.stack, we have to design another sanity check to detect any ccc divergence.  This time i think JUMPI would be good.  If we constrain every jump to be consistent, then i think the execution almost will be correct.