### PR TITLE
Separation of `BlobDataConfig` and `BatchDataConfig`

### DIFF
--- a/aggregator/src/aggregation.rs
+++ b/aggregator/src/aggregation.rs
@@ -1,6 +1,8 @@
 /// Config to evaluate blob polynomial at a random challenge.
 mod barycentric;
-/// Config to constrain blob data
+/// Config to constrain batch data (decoded blob data)
+mod batch_data;
+/// Config to constrain blob data (encoded batch data)
 mod blob_data;
 /// Circuit implementation of aggregation circuit.
 mod circuit;
@@ -14,7 +16,10 @@ mod rlc;
 pub(crate) use barycentric::{
     interpolate, AssignedBarycentricEvaluationConfig, BarycentricEvaluationConfig, BLS_MODULUS,
 };
+pub(crate) use batch_data::BatchDataConfig;
 pub(crate) use blob_data::BlobDataConfig;
+pub(crate) use decompression::decoder::DecoderConfig;
+pub(crate) use rlc::RlcConfig;
+
 pub use circuit::AggregationCircuit;
 pub use config::AggregationConfig;
-pub(crate) use rlc::RlcConfig;

--- a/aggregator/src/aggregation/barycentric.rs
+++ b/aggregator/src/aggregation/barycentric.rs
@@ -349,7 +349,7 @@ pub fn interpolate(z: Scalar, coefficients: &[Scalar; BLOB_WIDTH]) -> Scalar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blob::{BlobData, KZG_TRUSTED_SETUP};
+    use crate::blob::{BatchData, KZG_TRUSTED_SETUP};
     use c_kzg::{Blob as RethBlob, KzgProof};
     use std::collections::BTreeSet;
 
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn interpolate_matches_reth_implementation() {
-        let blob = BlobData::from(&vec![
+        let batch = BatchData::from(&vec![
             vec![30; 56],
             vec![200; 100],
             vec![0; 340],
@@ -396,8 +396,8 @@ mod tests {
         for z in 0..10 {
             let z = Scalar::from(u64::try_from(13241234 + z).unwrap());
             assert_eq!(
-                reth_point_evaluation(z, &blob.get_coefficients().map(|c| Scalar::from_raw(c.0))),
-                interpolate(z, &blob.get_coefficients().map(|c| Scalar::from_raw(c.0)))
+                reth_point_evaluation(z, &batch.get_coefficients().map(|c| Scalar::from_raw(c.0))),
+                interpolate(z, &batch.get_coefficients().map(|c| Scalar::from_raw(c.0)))
             );
         }
     }

--- a/aggregator/src/aggregation/batch_data.rs
+++ b/aggregator/src/aggregation/batch_data.rs
@@ -1,0 +1,954 @@
+use ethers_core::utils::keccak256;
+use halo2_ecc::bigint::CRTInteger;
+use halo2_proofs::{
+    circuit::{AssignedCell, Layouter, Region, Value},
+    halo2curves::bn256::Fr,
+    plonk::{Advice, Column, ConstraintSystem, Error, Expression, SecondPhase, Selector},
+    poly::Rotation,
+};
+use itertools::Itertools;
+use zkevm_circuits::{
+    table::{KeccakTable, LookupTable, RangeTable, U8Table},
+    util::{Challenges, Expr},
+};
+
+use crate::{
+    aggregation::rlc::POWS_OF_256,
+    blob::{
+        BatchData, BLOB_WIDTH, N_BYTES_U256, N_ROWS_BATCH_DATA_CONFIG, N_ROWS_DATA,
+        N_ROWS_DIGEST_BYTES, N_ROWS_DIGEST_RLC, N_ROWS_METADATA,
+    },
+    RlcConfig, MAX_AGG_SNARKS,
+};
+
+#[derive(Clone, Debug)]
+pub struct BatchDataConfig {
+    /// The byte value at this row.
+    byte: Column<Advice>,
+    /// The accumulator serves several purposes.
+    /// 1. For the metadata section, the accumulator holds the running linear combination of the
+    ///    chunk size.
+    /// 2. For the chunk data section, the accumulator holds the incremental chunk size, which
+    ///    resets to 1 if we encounter a chunk boundary. The accumulator here is referenced while
+    ///    doing a lookup to the Keccak table that requires the input length.
+    accumulator: Column<Advice>,
+    /// An increasing counter that denotes the chunk ID. The chunk ID is from [1, MAX_AGG_SNARKS].
+    chunk_idx: Column<Advice>,
+    /// A boolean witness that is set only when we encounter the end of a chunk. We enable a lookup
+    /// to the Keccak table when the boundary is met.
+    is_boundary: Column<Advice>,
+    /// A running accumulator of the boundary counts.
+    boundary_count: Column<Advice>,
+    /// A boolean witness to indicate padded rows at the end of the data section.
+    is_padding: Column<Advice>,
+    /// A running accumulator of the RLC of every byte seen so far.
+    bytes_rlc: Column<Advice>,
+    /// Represents the running random linear combination of bytes seen so far, that are a part of
+    /// the preimage to the Keccak hash. It resets whenever we encounter a chunk boundary.
+    preimage_rlc: Column<Advice>,
+    /// Represents the random linear combination of the Keccak digest. This has meaningful values
+    /// only at the rows where we actually do the Keccak lookup.
+    digest_rlc: Column<Advice>,
+    /// Boolean to let us know we are in the chunk data section.
+    pub data_selector: Selector,
+    /// Boolean to let us know we are in the hash section.
+    pub hash_selector: Selector,
+    /// Fixed table that consists of [0, 256).
+    u8_table: U8Table,
+    /// Fixed table that consists of [0, MAX_AGG_SNARKS).
+    chunk_idx_range_table: RangeTable<MAX_AGG_SNARKS>,
+}
+
+pub struct AssignedBatchDataExport {
+    pub num_valid_chunks: AssignedCell<Fr, Fr>,
+    pub versioned_hash: Vec<AssignedCell<Fr, Fr>>,
+    pub chunk_data_digests: Vec<Vec<AssignedCell<Fr, Fr>>>,
+    pub bytes_rlc: AssignedCell<Fr, Fr>,
+}
+
+pub struct AssignedBatchDataConfig {
+    pub byte: AssignedCell<Fr, Fr>,
+    pub accumulator: AssignedCell<Fr, Fr>,
+    pub chunk_idx: AssignedCell<Fr, Fr>,
+    pub is_boundary: AssignedCell<Fr, Fr>,
+    pub boundary_count: AssignedCell<Fr, Fr>,
+    pub is_padding: AssignedCell<Fr, Fr>,
+    pub bytes_rlc: AssignedCell<Fr, Fr>,
+    pub preimage_rlc: AssignedCell<Fr, Fr>,
+    pub digest_rlc: AssignedCell<Fr, Fr>,
+}
+
+impl BatchDataConfig {
+    pub fn configure(
+        meta: &mut ConstraintSystem<Fr>,
+        challenge: Challenges<Expression<Fr>>,
+        u8_table: U8Table,
+        range_table: RangeTable<MAX_AGG_SNARKS>,
+        keccak_table: &KeccakTable,
+    ) -> Self {
+        let config = Self {
+            u8_table,
+            chunk_idx_range_table: range_table,
+            byte: meta.advice_column(),
+            accumulator: meta.advice_column(),
+            is_boundary: meta.advice_column(),
+            boundary_count: meta.advice_column(),
+            chunk_idx: meta.advice_column(),
+            is_padding: meta.advice_column(),
+            bytes_rlc: meta.advice_column_in(SecondPhase),
+            preimage_rlc: meta.advice_column_in(SecondPhase),
+            digest_rlc: meta.advice_column_in(SecondPhase),
+            data_selector: meta.complex_selector(),
+            hash_selector: meta.complex_selector(),
+        };
+
+        // TODO: reduce the number of permutation columns
+        meta.enable_equality(config.byte);
+        meta.enable_equality(config.accumulator);
+        meta.enable_equality(config.is_boundary);
+        meta.enable_equality(config.boundary_count);
+        meta.enable_equality(config.is_padding);
+        meta.enable_equality(config.chunk_idx);
+        meta.enable_equality(config.preimage_rlc);
+        meta.enable_equality(config.digest_rlc);
+
+        let r = challenge.keccak_input();
+
+        meta.lookup("BatchDataConfig (0 < byte < 256)", |meta| {
+            let byte_value = meta.query_advice(config.byte, Rotation::cur());
+            vec![(byte_value, u8_table.into())]
+        });
+
+        meta.lookup(
+            "BatchDataConfig (chunk idx transition on boundary)",
+            |meta| {
+                let is_hash = meta.query_selector(config.hash_selector);
+                let is_not_hash = 1.expr() - is_hash;
+                let is_padding_next = meta.query_advice(config.is_padding, Rotation::next());
+                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
+                // if we are in the data section, encounter a boundary and the next row is not a
+                // padding row.
+                let cond = is_not_hash * is_boundary * (1.expr() - is_padding_next);
+                let chunk_idx_curr = meta.query_advice(config.chunk_idx, Rotation::cur());
+                let chunk_idx_next = meta.query_advice(config.chunk_idx, Rotation::next());
+                // chunk_idx increases by at least 1 and at most MAX_AGG_SNARKS when condition is
+                // met.
+                vec![(
+                    cond * (chunk_idx_next - chunk_idx_curr - 1.expr()),
+                    config.chunk_idx_range_table.into(),
+                )]
+            },
+        );
+
+        meta.lookup(
+            "BatchDataConfig (chunk_idx for non-padding, data rows in [1..MAX_AGG_SNARKS])",
+            |meta| {
+                let is_data = meta.query_selector(config.data_selector);
+                let is_padding = meta.query_advice(config.is_padding, Rotation::cur());
+                let chunk_idx = meta.query_advice(config.chunk_idx, Rotation::cur());
+                vec![(
+                    is_data * (1.expr() - is_padding) * (chunk_idx - 1.expr()),
+                    config.chunk_idx_range_table.into(),
+                )]
+            },
+        );
+
+        meta.create_gate("BatchDataConfig (boolean columns)", |meta| {
+            let is_data = meta.query_selector(config.data_selector);
+            let is_hash = meta.query_selector(config.hash_selector);
+
+            // is_data is never 1 when is_hash is 1, so we can add these selectors and still have a
+            // boolean condition.
+            let cond = is_data.clone() + is_hash.clone();
+
+            let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
+            let is_padding = meta.query_advice(config.is_padding, Rotation::cur());
+
+            vec![
+                cond.clone() * is_boundary.clone() * (1.expr() - is_boundary),
+                cond * is_padding.clone() * (1.expr() - is_padding),
+            ]
+        });
+
+        meta.create_gate("BatchDataConfig (transition when boundary)", |meta| {
+            let is_data = meta.query_selector(config.data_selector);
+            let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
+            let is_padding_next = meta.query_advice(config.is_padding, Rotation::next());
+
+            let cond = is_data * is_boundary;
+
+            let len_next = meta.query_advice(config.accumulator, Rotation::next());
+            let preimage_rlc_next = meta.query_advice(config.preimage_rlc, Rotation::next());
+            let byte_next = meta.query_advice(config.byte, Rotation::next());
+
+            let boundary_count_curr = meta.query_advice(config.boundary_count, Rotation::cur());
+            let boundary_count_prev = meta.query_advice(config.boundary_count, Rotation::prev());
+
+            vec![
+                // if boundary followed by padding, length and preimage_rlc is 0.
+                cond.expr() * is_padding_next.expr() * len_next.expr(),
+                cond.expr() * is_padding_next.expr() * preimage_rlc_next.expr(),
+                // if boundary not followed by padding, length resets to 1, preimage_rlc resets to
+                // the byte value.
+                cond.expr() * (1.expr() - is_padding_next.expr()) * (len_next.expr() - 1.expr()),
+                cond.expr()
+                    * (1.expr() - is_padding_next.expr())
+                    * (preimage_rlc_next - byte_next.expr()),
+                // the boundary count increments, i.e.
+                // boundary_count_curr == boundary_count_prev + 1
+                cond.expr() * (boundary_count_curr - boundary_count_prev - 1.expr()),
+            ]
+        });
+
+        meta.create_gate("BatchDataConfig (transition when no boundary)", |meta| {
+            let is_data = meta.query_selector(config.data_selector);
+            let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
+            let is_padding = meta.query_advice(config.is_padding, Rotation::cur());
+
+            // in the data section (not padding) when we traverse the same chunk.
+            let cond = is_data * (1.expr() - is_padding) * (1.expr() - is_boundary);
+
+            let chunk_idx_curr = meta.query_advice(config.chunk_idx, Rotation::cur());
+            let chunk_idx_next = meta.query_advice(config.chunk_idx, Rotation::next());
+            let len_curr = meta.query_advice(config.accumulator, Rotation::cur());
+            let len_next = meta.query_advice(config.accumulator, Rotation::next());
+            let preimage_rlc_curr = meta.query_advice(config.preimage_rlc, Rotation::cur());
+            let preimage_rlc_next = meta.query_advice(config.preimage_rlc, Rotation::next());
+            let byte_next = meta.query_advice(config.byte, Rotation::next());
+            let boundary_count_curr = meta.query_advice(config.boundary_count, Rotation::cur());
+            let boundary_count_prev = meta.query_advice(config.boundary_count, Rotation::prev());
+            let digest_rlc = meta.query_advice(config.digest_rlc, Rotation::cur());
+
+            vec![
+                // chunk idx unchanged.
+                cond.expr() * (chunk_idx_next - chunk_idx_curr),
+                // length is accumulated.
+                cond.expr() * (len_next - len_curr - 1.expr()),
+                // preimage rlc is updated.
+                cond.expr() * (preimage_rlc_curr * r + byte_next - preimage_rlc_next),
+                // boundary count continues.
+                cond.expr() * (boundary_count_curr - boundary_count_prev),
+                // digest_rlc is 0.
+                cond.expr() * digest_rlc,
+            ]
+        });
+
+        meta.create_gate("BatchDataConfig (\"chunk data\" section)", |meta| {
+            let is_data = meta.query_selector(config.data_selector);
+            let is_padding_curr = meta.query_advice(config.is_padding, Rotation::cur());
+            let is_padding_next = meta.query_advice(config.is_padding, Rotation::next());
+            let diff = is_padding_next - is_padding_curr.expr();
+            let byte = meta.query_advice(config.byte, Rotation::cur());
+            let chunk_idx = meta.query_advice(config.chunk_idx, Rotation::cur());
+            let accumulator = meta.query_advice(config.accumulator, Rotation::cur());
+            let preimage_rlc = meta.query_advice(config.preimage_rlc, Rotation::cur());
+            let digest_rlc = meta.query_advice(config.digest_rlc, Rotation::cur());
+            let boundary_count_curr = meta.query_advice(config.boundary_count, Rotation::cur());
+            let boundary_count_prev = meta.query_advice(config.boundary_count, Rotation::prev());
+
+            vec![
+                // byte, accumulator, digest_rlc, preimage_rlc, chunk_idx iare 0 when padding in
+                // the "chunk data" section.
+                is_data.expr() * is_padding_curr.expr() * byte,
+                is_data.expr() * is_padding_curr.expr() * accumulator,
+                is_data.expr() * is_padding_curr.expr() * digest_rlc,
+                is_data.expr() * is_padding_curr.expr() * preimage_rlc,
+                is_data.expr() * is_padding_curr.expr() * chunk_idx,
+                // diff is 0 or 1, i.e. is_padding transitions from 0 -> 1 only once.
+                is_data.expr() * diff.expr() * (1.expr() - diff.expr()),
+                // boundary count continues if padding
+                is_data.expr()
+                    * is_padding_curr.expr()
+                    * (boundary_count_curr - boundary_count_prev),
+            ]
+        });
+
+        // TODO: custom gate for validation of bytes_rlc accumulation
+
+        // lookup metadata and chunk data digests in keccak table.
+        meta.lookup_any(
+            "BatchDataConfig (metadata/chunk_data/challenge digests in keccak table)",
+            |meta| {
+                let is_data = meta.query_selector(config.data_selector);
+                let is_hash = meta.query_selector(config.hash_selector);
+                let is_not_hash = 1.expr() - is_hash;
+                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
+
+                // in the "metadata" or "chunk data" section, wherever is_boundary is set.
+                let cond = is_not_hash * is_boundary;
+
+                let accumulator = meta.query_advice(config.accumulator, Rotation::cur());
+                let preimage_len =
+                    is_data.expr() * accumulator + (1.expr() - is_data) * N_ROWS_METADATA.expr();
+
+                [
+                    1.expr(),                                                // q_enable
+                    1.expr(),                                                // is final
+                    meta.query_advice(config.preimage_rlc, Rotation::cur()), // input RLC
+                    preimage_len,                                            // input len
+                    meta.query_advice(config.digest_rlc, Rotation::cur()),   // output RLC
+                ]
+                .into_iter()
+                .zip_eq(keccak_table.table_exprs(meta))
+                .map(|(value, table)| (cond.expr() * value, table))
+                .collect()
+            },
+        );
+
+        // lookup chunk data digests in the "digest rlc section" of BatchDataConfig.
+        meta.lookup_any(
+            "BatchDataConfig (chunk data digests in BatchDataConfig \"hash section\")",
+            |meta| {
+                let is_data = meta.query_selector(config.data_selector);
+                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
+
+                // in the "chunk data" section when we encounter a chunk boundary
+                let cond = is_data * is_boundary;
+
+                let hash_section_table = vec![
+                    meta.query_selector(config.hash_selector),
+                    meta.query_advice(config.chunk_idx, Rotation::cur()),
+                    meta.query_advice(config.accumulator, Rotation::cur()),
+                    meta.query_advice(config.digest_rlc, Rotation::cur()),
+                ];
+                [
+                    1.expr(),                                               // hash section
+                    meta.query_advice(config.chunk_idx, Rotation::cur()),   // chunk idx
+                    meta.query_advice(config.accumulator, Rotation::cur()), // chunk len
+                    meta.query_advice(config.digest_rlc, Rotation::cur()),  // digest rlc
+                ]
+                .into_iter()
+                .zip(hash_section_table)
+                .map(|(value, table)| (cond.expr() * value, table))
+                .collect()
+            },
+        );
+
+        // lookup challenge digest in keccak table.
+        meta.lookup_any(
+            "BatchDataConfig (metadata/chunk_data/challenge digests in keccak table)",
+            |meta| {
+                let is_hash = meta.query_selector(config.hash_selector);
+                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
+
+                // when is_boundary is set in the "digest RLC" section.
+                // this is also the last row of the "digest RLC" section.
+                let cond = is_hash * is_boundary;
+
+                // - metadata_digest: 32 bytes
+                // - chunk[i].chunk_data_digest: 32 bytes each
+                // - versioned_hash: 32 bytes
+                let preimage_len = 32.expr() * (MAX_AGG_SNARKS + 1 + 1).expr();
+
+                [
+                    1.expr(),                                                // q_enable
+                    1.expr(),                                                // is final
+                    meta.query_advice(config.preimage_rlc, Rotation::cur()), // input rlc
+                    preimage_len,                                            // input len
+                    meta.query_advice(config.digest_rlc, Rotation::cur()),   // output rlc
+                ]
+                .into_iter()
+                .zip_eq(keccak_table.table_exprs(meta))
+                .map(|(value, table)| (cond.expr() * value, table))
+                .collect()
+            },
+        );
+
+        assert!(meta.degree() <= 5);
+
+        config
+    }
+
+    pub fn assign(
+        &self,
+        layouter: &mut impl Layouter<Fr>,
+        challenge_value: Challenges<Value<Fr>>,
+        rlc_config: &RlcConfig,
+        // The chunks_are_padding assigned cells are exports from the conditional constraints in
+        // `core.rs`. Since these are already constrained, we can just use them as is.
+        chunks_are_padding: &[AssignedCell<Fr, Fr>],
+        batch_data: &BatchData,
+        barycentric_assignments: &[CRTInteger<Fr>],
+    ) -> Result<AssignedBatchDataExport, Error> {
+        self.load_range_tables(layouter)?;
+
+        let assigned_rows = layouter.assign_region(
+            || "BatchData rows",
+            |mut region| self.assign_rows(&mut region, challenge_value, batch_data),
+        )?;
+
+        layouter.assign_region(
+            || "BatchData internal checks",
+            |mut region| {
+                self.assign_internal_checks(
+                    &mut region,
+                    challenge_value,
+                    rlc_config,
+                    chunks_are_padding,
+                    barycentric_assignments,
+                    &assigned_rows,
+                )
+            },
+        )
+    }
+
+    pub fn load_range_tables(&self, layouter: &mut impl Layouter<Fr>) -> Result<(), Error> {
+        self.u8_table.load(layouter)?;
+        self.chunk_idx_range_table.load(layouter)
+    }
+
+    pub fn assign_rows(
+        &self,
+        region: &mut Region<Fr>,
+        challenge_value: Challenges<Value<Fr>>,
+        batch_data: &BatchData,
+    ) -> Result<Vec<AssignedBatchDataConfig>, Error> {
+        let rows = batch_data.to_rows(challenge_value);
+        assert_eq!(rows.len(), N_ROWS_BATCH_DATA_CONFIG);
+
+        // enable data selector
+        for offset in N_ROWS_METADATA..N_ROWS_METADATA + N_ROWS_DATA {
+            self.data_selector.enable(region, offset)?;
+        }
+
+        // enable hash selector
+        for offset in
+            N_ROWS_METADATA + N_ROWS_DATA..N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST_RLC
+        {
+            self.hash_selector.enable(region, offset)?;
+        }
+
+        let mut assigned_rows = Vec::with_capacity(N_ROWS_BATCH_DATA_CONFIG);
+        let mut count = 0u64;
+        let mut bytes_rlc_acc = Value::known(Fr::zero());
+        for (i, row) in rows.iter().enumerate() {
+            bytes_rlc_acc = bytes_rlc_acc * challenge_value.keccak_input()
+                + Value::known(Fr::from(row.byte as u64));
+            let byte = region.assign_advice(
+                || "byte",
+                self.byte,
+                i,
+                || Value::known(Fr::from(row.byte as u64)),
+            )?;
+            let accumulator = region.assign_advice(
+                || "accumulator",
+                self.accumulator,
+                i,
+                || Value::known(Fr::from(row.accumulator)),
+            )?;
+            let chunk_idx = region.assign_advice(
+                || "chunk_idx",
+                self.chunk_idx,
+                i,
+                || Value::known(Fr::from(row.chunk_idx)),
+            )?;
+            let is_boundary = region.assign_advice(
+                || "is_boundary",
+                self.is_boundary,
+                i,
+                || Value::known(Fr::from(row.is_boundary as u64)),
+            )?;
+            let bcount = if (N_ROWS_METADATA..N_ROWS_METADATA + N_ROWS_DATA).contains(&i) {
+                count += row.is_boundary as u64;
+                count
+            } else {
+                0
+            };
+            let boundary_count = region.assign_advice(
+                || "boundary_count",
+                self.boundary_count,
+                i,
+                || Value::known(Fr::from(bcount)),
+            )?;
+            let is_padding = region.assign_advice(
+                || "is_padding",
+                self.is_padding,
+                i,
+                || Value::known(Fr::from(row.is_padding as u64)),
+            )?;
+            let preimage_rlc = region.assign_advice(
+                || "preimage_rlc",
+                self.preimage_rlc,
+                i,
+                || row.preimage_rlc,
+            )?;
+            let digest_rlc =
+                region.assign_advice(|| "digest_rlc", self.digest_rlc, i, || row.digest_rlc)?;
+            let bytes_rlc =
+                region.assign_advice(|| "bytes_rlc", self.bytes_rlc, i, || bytes_rlc_acc)?;
+            assigned_rows.push(AssignedBatchDataConfig {
+                byte,
+                accumulator,
+                chunk_idx,
+                is_boundary,
+                boundary_count,
+                is_padding,
+                bytes_rlc,
+                preimage_rlc,
+                digest_rlc,
+            });
+        }
+        Ok(assigned_rows)
+    }
+
+    pub fn assign_internal_checks(
+        &self,
+        region: &mut Region<Fr>,
+        challenge_value: Challenges<Value<Fr>>,
+        rlc_config: &RlcConfig,
+        // The chunks_are_padding assigned cells are exports from the conditional constraints in
+        // `core.rs`. Since these are already constrained, we can just use them as is.
+        chunks_are_padding: &[AssignedCell<Fr, Fr>],
+        barycentric_assignments: &[CRTInteger<Fr>],
+        assigned_rows: &[AssignedBatchDataConfig],
+    ) -> Result<AssignedBatchDataExport, Error> {
+        rlc_config.init(region)?;
+        let mut rlc_config_offset = 0;
+
+        // load some constants that we will use later.
+        let zero = {
+            let zero = rlc_config.load_private(region, &Fr::zero(), &mut rlc_config_offset)?;
+            let zero_cell = rlc_config.zero_cell(zero.cell().region_index);
+            region.constrain_equal(zero.cell(), zero_cell)?;
+            zero
+        };
+        let one = {
+            let one = rlc_config.load_private(region, &Fr::one(), &mut rlc_config_offset)?;
+            let one_cell = rlc_config.one_cell(one.cell().region_index);
+            region.constrain_equal(one.cell(), one_cell)?;
+            one
+        };
+        let fixed_chunk_indices = {
+            let mut fixed_chunk_indices = vec![one.clone()];
+            for i in 2..=MAX_AGG_SNARKS {
+                let i_cell =
+                    rlc_config.load_private(region, &Fr::from(i as u64), &mut rlc_config_offset)?;
+                let i_fixed_cell =
+                    rlc_config.fixed_up_to_max_agg_snarks_cell(i_cell.cell().region_index, i);
+                region.constrain_equal(i_cell.cell(), i_fixed_cell)?;
+                fixed_chunk_indices.push(i_cell);
+            }
+            fixed_chunk_indices
+        };
+        let pows_of_256 = {
+            let mut pows_of_256 = vec![one.clone()];
+            for (exponent, pow_of_256) in (1..=POWS_OF_256).zip_eq(
+                std::iter::successors(Some(Fr::from(256)), |n| Some(n * Fr::from(256)))
+                    .take(POWS_OF_256),
+            ) {
+                let pow_cell =
+                    rlc_config.load_private(region, &pow_of_256, &mut rlc_config_offset)?;
+                let fixed_pow_cell = rlc_config
+                    .pow_of_two_hundred_and_fifty_six_cell(pow_cell.cell().region_index, exponent);
+                region.constrain_equal(pow_cell.cell(), fixed_pow_cell)?;
+                pows_of_256.push(pow_cell);
+            }
+            pows_of_256
+        };
+        let two_fifty_six = pows_of_256[1].clone();
+
+        // read randomness challenges for RLC computations.
+        let r_keccak =
+            rlc_config.read_challenge1(region, challenge_value, &mut rlc_config_offset)?;
+        let r_evm = rlc_config.read_challenge2(region, challenge_value, &mut rlc_config_offset)?;
+        let r32 = {
+            let r2 = rlc_config.mul(region, &r_keccak, &r_keccak, &mut rlc_config_offset)?;
+            let r4 = rlc_config.mul(region, &r2, &r2, &mut rlc_config_offset)?;
+            let r8 = rlc_config.mul(region, &r4, &r4, &mut rlc_config_offset)?;
+            let r16 = rlc_config.mul(region, &r8, &r8, &mut rlc_config_offset)?;
+            rlc_config.mul(region, &r16, &r16, &mut rlc_config_offset)?
+        };
+
+        // load cells representing the keccak digest of empty bytes.
+        let mut empty_digest_cells = Vec::with_capacity(N_BYTES_U256);
+        for (i, &byte) in keccak256([]).iter().enumerate() {
+            let cell =
+                rlc_config.load_private(region, &Fr::from(byte as u64), &mut rlc_config_offset)?;
+            let fixed_cell = rlc_config.empty_keccak_cell_i(cell.cell().region_index, i);
+            region.constrain_equal(cell.cell(), fixed_cell)?;
+            empty_digest_cells.push(cell);
+        }
+        let empty_digest_evm_rlc =
+            rlc_config.rlc(region, &empty_digest_cells, &r_evm, &mut rlc_config_offset)?;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        /////////////////////////////// NUM_VALID_CHUNKS ///////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        let rows = assigned_rows.iter().take(2).collect::<Vec<_>>();
+        let (byte_hi, byte_lo, lc1, lc2) = (
+            &rows[0].byte,
+            &rows[1].byte,
+            &rows[0].accumulator,
+            &rows[1].accumulator,
+        );
+
+        // the linear combination starts with the most-significant byte.
+        region.constrain_equal(byte_hi.cell(), lc1.cell())?;
+
+        // do the linear combination.
+        let num_valid_chunks =
+            rlc_config.mul_add(region, lc1, &two_fifty_six, byte_lo, &mut rlc_config_offset)?;
+        region.constrain_equal(num_valid_chunks.cell(), lc2.cell())?;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////////////////////////////// CHUNK_SIZE //////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        let mut num_nonempty_chunks = zero.clone();
+        let mut is_empty_chunks = Vec::with_capacity(MAX_AGG_SNARKS);
+        let mut chunk_sizes = Vec::with_capacity(MAX_AGG_SNARKS);
+        for (i, is_padded_chunk) in chunks_are_padding.iter().enumerate() {
+            let rows = assigned_rows
+                .iter()
+                .skip(2 + 4 * i)
+                .take(4)
+                .collect::<Vec<_>>();
+            let (byte0, byte1, byte2, byte3) =
+                (&rows[0].byte, &rows[1].byte, &rows[2].byte, &rows[3].byte);
+            let (acc0, acc1, acc2, acc3) = (
+                &rows[0].accumulator,
+                &rows[1].accumulator,
+                &rows[2].accumulator,
+                &rows[3].accumulator,
+            );
+
+            // the linear combination starts with the most-significant byte.
+            region.constrain_equal(byte0.cell(), acc0.cell())?;
+
+            // do the linear combination.
+            let lc =
+                rlc_config.mul_add(region, acc0, &two_fifty_six, byte1, &mut rlc_config_offset)?;
+            region.constrain_equal(lc.cell(), acc1.cell())?;
+            let lc =
+                rlc_config.mul_add(region, acc1, &two_fifty_six, byte2, &mut rlc_config_offset)?;
+            region.constrain_equal(lc.cell(), acc2.cell())?;
+            let chunk_size =
+                rlc_config.mul_add(region, acc2, &two_fifty_six, byte3, &mut rlc_config_offset)?;
+            region.constrain_equal(chunk_size.cell(), acc3.cell())?;
+
+            // if the chunk is a padded chunk, its size must be set to 0.
+            rlc_config.conditional_enforce_equal(
+                region,
+                &chunk_size,
+                &zero,
+                is_padded_chunk,
+                &mut rlc_config_offset,
+            )?;
+
+            let is_empty_chunk = rlc_config.is_zero(region, &chunk_size, &mut rlc_config_offset)?;
+            let is_nonempty_chunk =
+                rlc_config.not(region, &is_empty_chunk, &mut rlc_config_offset)?;
+            num_nonempty_chunks = rlc_config.add(
+                region,
+                &is_nonempty_chunk,
+                &num_nonempty_chunks,
+                &mut rlc_config_offset,
+            )?;
+
+            is_empty_chunks.push(is_empty_chunk);
+            chunk_sizes.push(chunk_size);
+        }
+        let all_chunks_empty =
+            rlc_config.is_zero(region, &num_nonempty_chunks, &mut rlc_config_offset)?;
+        let not_all_chunks_empty =
+            rlc_config.not(region, &all_chunks_empty, &mut rlc_config_offset)?;
+
+        // constrain preimage_rlc column
+        let metadata_rows = &assigned_rows[..N_ROWS_METADATA];
+        region.constrain_equal(
+            metadata_rows[0].byte.cell(),
+            metadata_rows[0].preimage_rlc.cell(),
+        )?;
+        for (i, row) in metadata_rows.iter().enumerate().skip(1) {
+            let preimage_rlc = rlc_config.mul_add(
+                region,
+                &metadata_rows[i - 1].preimage_rlc,
+                &r_keccak,
+                &row.byte,
+                &mut rlc_config_offset,
+            )?;
+            region.constrain_equal(preimage_rlc.cell(), row.preimage_rlc.cell())?;
+        }
+
+        // these columns are always 0 in the metadata section.
+        for row in metadata_rows.iter() {
+            let cells =
+                [&row.chunk_idx, &row.boundary_count, &row.is_padding].map(AssignedCell::cell);
+
+            for cell in cells {
+                region.constrain_equal(cell, zero.cell())?;
+            }
+        }
+
+        // in the metadata section, these columns are 0 except (possibly) on the last row.
+        for row in metadata_rows.iter().take(N_ROWS_METADATA - 1) {
+            let cells = [&row.is_boundary, &row.digest_rlc].map(AssignedCell::cell);
+
+            for cell in cells {
+                region.constrain_equal(cell, zero.cell())?;
+            }
+        }
+
+        // in the final row of the metadata section, boundary is 1. note that this triggers a keccak
+        // lookup which constrains digest_rlc.
+        region.constrain_equal(
+            metadata_rows[N_ROWS_METADATA - 1].is_boundary.cell(),
+            one.cell(),
+        )?;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////////////////////////////// CHUNK_DATA //////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        // the first data row has a length (accumulator) of 1. But in the special case that
+        // there are no non-empty chunks, this will be 0 and must also be a padding row.
+        let rows = assigned_rows
+            .iter()
+            .skip(N_ROWS_METADATA)
+            .take(N_ROWS_DATA)
+            .collect::<Vec<_>>();
+        rlc_config.conditional_enforce_equal(
+            region,
+            &rows[0].accumulator,
+            &one,
+            &not_all_chunks_empty,
+            &mut rlc_config_offset,
+        )?;
+        rlc_config.conditional_enforce_equal(
+            region,
+            &rows[0].is_padding,
+            &zero,
+            &not_all_chunks_empty,
+            &mut rlc_config_offset,
+        )?;
+        rlc_config.conditional_enforce_equal(
+            region,
+            &rows[0].accumulator,
+            &zero,
+            &all_chunks_empty,
+            &mut rlc_config_offset,
+        )?;
+        rlc_config.conditional_enforce_equal(
+            region,
+            &rows[0].is_padding,
+            &one,
+            &all_chunks_empty,
+            &mut rlc_config_offset,
+        )?;
+
+        // get the boundary count at the end of the "chunk data" section, and equate it to
+        // the number of non-empty chunks in the batch.
+        region.constrain_equal(
+            rows.last().unwrap().boundary_count.cell(),
+            num_nonempty_chunks.cell(),
+        )?;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////////////////////////////// DIGEST RLC //////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        let rows = assigned_rows
+            .iter()
+            .skip(N_ROWS_METADATA + N_ROWS_DATA)
+            .take(N_ROWS_DIGEST_RLC)
+            .collect::<Vec<_>>();
+
+        // rows have chunk_idx set from 0 (metadata) -> MAX_AGG_SNARKS.
+        region.constrain_equal(rows[0].chunk_idx.cell(), zero.cell())?;
+        for (row, fixed_chunk_idx) in rows
+            .iter()
+            .skip(1)
+            .take(MAX_AGG_SNARKS)
+            .zip_eq(fixed_chunk_indices.iter())
+        {
+            region.constrain_equal(row.chunk_idx.cell(), fixed_chunk_idx.cell())?;
+        }
+
+        let challenge_digest_preimage_rlc_specified = &rows.last().unwrap().preimage_rlc;
+        let challenge_digest_rlc_specified = &rows.last().unwrap().digest_rlc;
+        let versioned_hash_rlc = &rows.get(N_ROWS_DIGEST_RLC - 2).unwrap().digest_rlc;
+
+        // ensure that on the last row of this section the is_boundary is turned on
+        // which would enable the keccak table lookup for challenge_digest
+        region.constrain_equal(rows.last().unwrap().is_boundary.cell(), one.cell())?;
+
+        let metadata_digest_rlc_computed =
+            &assigned_rows.get(N_ROWS_METADATA - 1).unwrap().digest_rlc;
+        let metadata_digest_rlc_specified = &rows.first().unwrap().digest_rlc;
+        region.constrain_equal(
+            metadata_digest_rlc_computed.cell(),
+            metadata_digest_rlc_specified.cell(),
+        )?;
+
+        // if the chunk is a padded chunk, then its chunk data digest should be the
+        // same as the previous chunk's data digest.
+        //
+        // Also, we know that the first chunk is valid. So we can just start the check from
+        // the second chunk's data digest.
+        region.constrain_equal(chunks_are_padding[0].cell(), zero.cell())?;
+        for i in 1..MAX_AGG_SNARKS {
+            // Note that in `rows`, the first row is the metadata row (hence anyway skip
+            // it). That's why we have a +1.
+            rlc_config.conditional_enforce_equal(
+                region,
+                &rows[i + 1].digest_rlc,
+                &rows[i].digest_rlc,
+                &chunks_are_padding[i],
+                &mut rlc_config_offset,
+            )?;
+        }
+
+        let mut chunk_digest_evm_rlcs = Vec::with_capacity(MAX_AGG_SNARKS);
+        for (((row, chunk_size_decoded), is_empty), is_padded_chunk) in rows
+            .iter()
+            .skip(1)
+            .take(MAX_AGG_SNARKS)
+            .zip_eq(chunk_sizes)
+            .zip_eq(is_empty_chunks)
+            .zip_eq(chunks_are_padding)
+        {
+            // if the chunk is a valid chunk (i.e. not padded chunk), but is empty (i.e. no
+            // L2 transactions), then the chunk's data digest should be the empty keccak
+            // digest.
+            let is_valid = rlc_config.not(region, is_padded_chunk, &mut rlc_config_offset)?;
+            let is_valid_empty =
+                rlc_config.mul(region, &is_valid, &is_empty, &mut rlc_config_offset)?;
+            rlc_config.conditional_enforce_equal(
+                region,
+                &row.digest_rlc,
+                &empty_digest_evm_rlc,
+                &is_valid_empty,
+                &mut rlc_config_offset,
+            )?;
+
+            // constrain chunk size specified here against decoded in metadata.
+            region.constrain_equal(row.accumulator.cell(), chunk_size_decoded.cell())?;
+
+            chunk_digest_evm_rlcs.push(&row.digest_rlc);
+        }
+
+        ////////////////////////////////////////////////////////////////////////////////
+        ///////////////////////////////// DIGEST BYTES /////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        let mut challenge_digest_preimage_keccak_rlc = zero.clone();
+        let rows = assigned_rows
+            .iter()
+            .skip(N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST_RLC)
+            .take(N_ROWS_DIGEST_BYTES)
+            .collect::<Vec<_>>();
+        for (i, digest_rlc_specified) in std::iter::once(metadata_digest_rlc_specified)
+            .chain(chunk_digest_evm_rlcs)
+            .chain(std::iter::once(versioned_hash_rlc))
+            .chain(std::iter::once(challenge_digest_rlc_specified))
+            .enumerate()
+        {
+            let digest_rows = rows
+                .iter()
+                .skip(N_BYTES_U256 * i)
+                .take(N_BYTES_U256)
+                .collect::<Vec<_>>();
+            let digest_bytes = digest_rows
+                .iter()
+                .map(|row| row.byte.clone())
+                .collect::<Vec<_>>();
+            let digest_rlc_computed =
+                rlc_config.rlc(region, &digest_bytes, &r_evm, &mut rlc_config_offset)?;
+            region.constrain_equal(digest_rlc_computed.cell(), digest_rlc_specified.cell())?;
+
+            // compute the keccak input RLC:
+            // we do this only for the metadata and chunks, not for the blob row itself.
+            if i < MAX_AGG_SNARKS + 1 + 1 {
+                let digest_keccak_rlc =
+                    rlc_config.rlc(region, &digest_bytes, &r_keccak, &mut rlc_config_offset)?;
+                challenge_digest_preimage_keccak_rlc = rlc_config.mul_add(
+                    region,
+                    &challenge_digest_preimage_keccak_rlc,
+                    &r32,
+                    &digest_keccak_rlc,
+                    &mut rlc_config_offset,
+                )?;
+            }
+        }
+        region.constrain_equal(
+            challenge_digest_preimage_keccak_rlc.cell(),
+            challenge_digest_preimage_rlc_specified.cell(),
+        )?;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////// EXPORT ////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        let mut chunk_data_digests = Vec::with_capacity(MAX_AGG_SNARKS);
+        let chunk_data_digests_bytes = assigned_rows
+            .iter()
+            .skip(N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST_RLC + N_BYTES_U256)
+            .take(MAX_AGG_SNARKS * N_BYTES_U256)
+            .map(|row| row.byte.clone())
+            .collect::<Vec<_>>();
+        for chunk in chunk_data_digests_bytes.chunks_exact(N_BYTES_U256) {
+            chunk_data_digests.push(chunk.to_vec());
+        }
+        let challenge_digest = assigned_rows
+            .iter()
+            .rev()
+            .take(N_BYTES_U256)
+            .map(|row| row.byte.clone())
+            .collect::<Vec<AssignedCell<Fr, Fr>>>();
+        let export = AssignedBatchDataExport {
+            num_valid_chunks,
+            versioned_hash: assigned_rows
+                .iter()
+                .rev()
+                .skip(N_BYTES_U256)
+                .take(N_BYTES_U256)
+                .map(|row| row.byte.clone())
+                .rev()
+                .collect(),
+            chunk_data_digests,
+            bytes_rlc: assigned_rows.last().unwrap().bytes_rlc.clone(),
+        };
+
+        ////////////////////////////////////////////////////////////////////////////////
+        //////////////////////////// CHALLENGE DIGEST CHECK ////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        assert_eq!(barycentric_assignments.len(), BLOB_WIDTH + 1);
+        let challenge_digest_crt = barycentric_assignments
+            .get(BLOB_WIDTH)
+            .expect("challenge digest CRT");
+        let challenge_digest_limb1 = rlc_config.inner_product(
+            region,
+            &challenge_digest[0..11],
+            &pows_of_256,
+            &mut rlc_config_offset,
+        )?;
+        let challenge_digest_limb2 = rlc_config.inner_product(
+            region,
+            &challenge_digest[11..22],
+            &pows_of_256,
+            &mut rlc_config_offset,
+        )?;
+        let challenge_digest_limb3 = rlc_config.inner_product(
+            region,
+            &challenge_digest[22..32],
+            &pows_of_256[0..10],
+            &mut rlc_config_offset,
+        )?;
+        region.constrain_equal(
+            challenge_digest_limb1.cell(),
+            challenge_digest_crt.truncation.limbs[0].cell(),
+        )?;
+        region.constrain_equal(
+            challenge_digest_limb2.cell(),
+            challenge_digest_crt.truncation.limbs[1].cell(),
+        )?;
+        region.constrain_equal(
+            challenge_digest_limb3.cell(),
+            challenge_digest_crt.truncation.limbs[2].cell(),
+        )?;
+
+        Ok(export)
+    }
+}

--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -1,351 +1,54 @@
-use ethers_core::utils::keccak256;
+use std::io::Write;
+
 use halo2_ecc::bigint::CRTInteger;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region, Value},
     halo2curves::bn256::Fr,
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, SecondPhase, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Error},
     poly::Rotation,
 };
 use itertools::Itertools;
-use zkevm_circuits::{
-    table::{KeccakTable, LookupTable, RangeTable, U8Table},
-    util::{Challenges, Expr},
-};
+use zkevm_circuits::{table::U8Table, util::Challenges};
 
 use crate::{
     aggregation::rlc::POWS_OF_256,
-    blob::{
-        BlobData, BLOB_WIDTH, N_BYTES_U256, N_DATA_BYTES_PER_COEFFICIENT, N_ROWS_BLOB_DATA_CONFIG,
-        N_ROWS_DATA, N_ROWS_DIGEST_BYTES, N_ROWS_DIGEST_RLC, N_ROWS_METADATA,
-    },
-    RlcConfig, MAX_AGG_SNARKS,
+    blob::{init_zstd_encoder, BatchData, BLOB_WIDTH, N_BLOB_BYTES, N_DATA_BYTES_PER_COEFFICIENT},
+    RlcConfig,
 };
 
+/// Blob is represented by 4096 BLS12-381 scalar field elements, where each element is represented
+/// by 32 bytes. The scalar field element is required to be in the canonical form, i.e. its value
+/// MUST BE less than the BLS_MODULUS. In order to ensure this, we hard-code the most-significant
+/// byte in each 32-bytes chunk to zero, i.e. effectively we use only 31 bytes.
+///
+/// Since the check for the most-significant byte being zero is already done in the
+/// BarycentricConfig, in the BlobDataConfig we only represent the 31 meaningful bytes. Hence the
+/// BlobDataConfig has 4096 * 31 rows. Each row is a byte value and the purpose of the
+/// BlobDataConfig is to compute a random-linear combination of these bytes. These bytes are in
+/// fact the zstd encoded form of the raw batch data represented in BatchDataConfig.
 #[derive(Clone, Debug)]
 pub struct BlobDataConfig {
     /// The byte value at this row.
     byte: Column<Advice>,
-    /// The accumulator serves several purposes.
-    /// 1. For the metadata section, the accumulator holds the running linear combination of the
-    ///    chunk size.
-    /// 2. For the chunk data section, the accumulator holds the incremental chunk size, which
-    ///    resets to 1 if we encounter a chunk boundary. The accumulator here is referenced while
-    ///    doing a lookup to the Keccak table that requires the input length.
-    accumulator: Column<Advice>,
-    /// An increasing counter that denotes the chunk ID. The chunk ID is from [1, MAX_AGG_SNARKS].
-    chunk_idx: Column<Advice>,
-    /// A boolean witness that is set only when we encounter the end of a chunk. We enable a lookup
-    /// to the Keccak table when the boundary is met.
-    is_boundary: Column<Advice>,
-    /// A running accumulator of the boundary counts.
-    boundary_count: Column<Advice>,
-    /// A boolean witness to indicate padded rows at the end of the data section.
-    is_padding: Column<Advice>,
-    /// Represents the running random linear combination of bytes seen so far, that are a part of
-    /// the preimage to the Keccak hash. It resets whenever we encounter a chunk boundary.
-    preimage_rlc: Column<Advice>,
-    /// Represents the random linear combination of the Keccak digest. This has meaningful values
-    /// only at the rows where we actually do the Keccak lookup.
-    digest_rlc: Column<Advice>,
-    /// Boolean to let us know we are in the chunk data section.
-    pub data_selector: Selector,
-    /// Boolean to let us know we are in the hash section.
-    pub hash_selector: Selector,
     /// Fixed table that consists of [0, 256).
     u8_table: U8Table,
-    /// Fixed table that consists of [0, MAX_AGG_SNARKS).
-    chunk_idx_range_table: RangeTable<MAX_AGG_SNARKS>,
 }
 
 pub struct AssignedBlobDataExport {
-    pub num_valid_chunks: AssignedCell<Fr, Fr>,
-    pub versioned_hash: Vec<AssignedCell<Fr, Fr>>,
-    pub chunk_data_digests: Vec<Vec<AssignedCell<Fr, Fr>>>,
-}
-
-pub struct AssignedBlobDataConfig {
-    pub byte: AssignedCell<Fr, Fr>,
-    pub accumulator: AssignedCell<Fr, Fr>,
-    pub chunk_idx: AssignedCell<Fr, Fr>,
-    pub is_boundary: AssignedCell<Fr, Fr>,
-    pub boundary_count: AssignedCell<Fr, Fr>,
-    pub is_padding: AssignedCell<Fr, Fr>,
-    pub preimage_rlc: AssignedCell<Fr, Fr>,
-    pub digest_rlc: AssignedCell<Fr, Fr>,
+    pub bytes_rlc: AssignedCell<Fr, Fr>,
 }
 
 impl BlobDataConfig {
-    pub fn configure(
-        meta: &mut ConstraintSystem<Fr>,
-        challenge: Challenges<Expression<Fr>>,
-        u8_table: U8Table,
-        range_table: RangeTable<MAX_AGG_SNARKS>,
-        keccak_table: &KeccakTable,
-    ) -> Self {
+    pub fn configure(meta: &mut ConstraintSystem<Fr>, u8_table: U8Table) -> Self {
         let config = Self {
-            u8_table,
-            chunk_idx_range_table: range_table,
             byte: meta.advice_column(),
-            accumulator: meta.advice_column(),
-            is_boundary: meta.advice_column(),
-            boundary_count: meta.advice_column(),
-            chunk_idx: meta.advice_column(),
-            is_padding: meta.advice_column(),
-            preimage_rlc: meta.advice_column_in(SecondPhase),
-            digest_rlc: meta.advice_column_in(SecondPhase),
-            data_selector: meta.complex_selector(),
-            hash_selector: meta.complex_selector(),
+            u8_table,
         };
-
-        // TODO: reduce the number of permutation columns
-        meta.enable_equality(config.byte);
-        meta.enable_equality(config.accumulator);
-        meta.enable_equality(config.is_boundary);
-        meta.enable_equality(config.boundary_count);
-        meta.enable_equality(config.is_padding);
-        meta.enable_equality(config.chunk_idx);
-        meta.enable_equality(config.preimage_rlc);
-        meta.enable_equality(config.digest_rlc);
-
-        let r = challenge.keccak_input();
 
         meta.lookup("BlobDataConfig (0 < byte < 256)", |meta| {
             let byte_value = meta.query_advice(config.byte, Rotation::cur());
             vec![(byte_value, u8_table.into())]
         });
-
-        meta.lookup(
-            "BlobDataConfig (chunk idx transition on boundary)",
-            |meta| {
-                let is_hash = meta.query_selector(config.hash_selector);
-                let is_not_hash = 1.expr() - is_hash;
-                let is_padding_next = meta.query_advice(config.is_padding, Rotation::next());
-                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
-                // if we are in the data section, encounter a boundary and the next row is not a
-                // padding row.
-                let cond = is_not_hash * is_boundary * (1.expr() - is_padding_next);
-                let chunk_idx_curr = meta.query_advice(config.chunk_idx, Rotation::cur());
-                let chunk_idx_next = meta.query_advice(config.chunk_idx, Rotation::next());
-                // chunk_idx increases by at least 1 and at most MAX_AGG_SNARKS when condition is
-                // met.
-                vec![(
-                    cond * (chunk_idx_next - chunk_idx_curr - 1.expr()),
-                    config.chunk_idx_range_table.into(),
-                )]
-            },
-        );
-
-        meta.lookup(
-            "BlobDataConfig (chunk_idx for non-padding, data rows in [1..MAX_AGG_SNARKS])",
-            |meta| {
-                let is_data = meta.query_selector(config.data_selector);
-                let is_padding = meta.query_advice(config.is_padding, Rotation::cur());
-                let chunk_idx = meta.query_advice(config.chunk_idx, Rotation::cur());
-                vec![(
-                    is_data * (1.expr() - is_padding) * (chunk_idx - 1.expr()),
-                    config.chunk_idx_range_table.into(),
-                )]
-            },
-        );
-
-        meta.create_gate("BlobDataConfig (boolean columns)", |meta| {
-            let is_data = meta.query_selector(config.data_selector);
-            let is_hash = meta.query_selector(config.hash_selector);
-
-            // is_data is never 1 when is_hash is 1, so we can add these selectors and still have a
-            // boolean condition.
-            let cond = is_data.clone() + is_hash.clone();
-
-            let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
-            let is_padding = meta.query_advice(config.is_padding, Rotation::cur());
-
-            vec![
-                cond.clone() * is_boundary.clone() * (1.expr() - is_boundary),
-                cond * is_padding.clone() * (1.expr() - is_padding),
-            ]
-        });
-
-        meta.create_gate("BlobDataConfig (transition when boundary)", |meta| {
-            let is_data = meta.query_selector(config.data_selector);
-            let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
-            let is_padding_next = meta.query_advice(config.is_padding, Rotation::next());
-
-            let cond = is_data * is_boundary;
-
-            let len_next = meta.query_advice(config.accumulator, Rotation::next());
-            let preimage_rlc_next = meta.query_advice(config.preimage_rlc, Rotation::next());
-            let byte_next = meta.query_advice(config.byte, Rotation::next());
-
-            let boundary_count_curr = meta.query_advice(config.boundary_count, Rotation::cur());
-            let boundary_count_prev = meta.query_advice(config.boundary_count, Rotation::prev());
-
-            vec![
-                // if boundary followed by padding, length and preimage_rlc is 0.
-                cond.expr() * is_padding_next.expr() * len_next.expr(),
-                cond.expr() * is_padding_next.expr() * preimage_rlc_next.expr(),
-                // if boundary not followed by padding, length resets to 1, preimage_rlc resets to
-                // the byte value.
-                cond.expr() * (1.expr() - is_padding_next.expr()) * (len_next.expr() - 1.expr()),
-                cond.expr()
-                    * (1.expr() - is_padding_next.expr())
-                    * (preimage_rlc_next - byte_next.expr()),
-                // the boundary count increments, i.e.
-                // boundary_count_curr == boundary_count_prev + 1
-                cond.expr() * (boundary_count_curr - boundary_count_prev - 1.expr()),
-            ]
-        });
-
-        meta.create_gate("BlobDataConfig (transition when no boundary)", |meta| {
-            let is_data = meta.query_selector(config.data_selector);
-            let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
-            let is_padding = meta.query_advice(config.is_padding, Rotation::cur());
-
-            // in the data section (not padding) when we traverse the same chunk.
-            let cond = is_data * (1.expr() - is_padding) * (1.expr() - is_boundary);
-
-            let chunk_idx_curr = meta.query_advice(config.chunk_idx, Rotation::cur());
-            let chunk_idx_next = meta.query_advice(config.chunk_idx, Rotation::next());
-            let len_curr = meta.query_advice(config.accumulator, Rotation::cur());
-            let len_next = meta.query_advice(config.accumulator, Rotation::next());
-            let preimage_rlc_curr = meta.query_advice(config.preimage_rlc, Rotation::cur());
-            let preimage_rlc_next = meta.query_advice(config.preimage_rlc, Rotation::next());
-            let byte_next = meta.query_advice(config.byte, Rotation::next());
-            let boundary_count_curr = meta.query_advice(config.boundary_count, Rotation::cur());
-            let boundary_count_prev = meta.query_advice(config.boundary_count, Rotation::prev());
-            let digest_rlc = meta.query_advice(config.digest_rlc, Rotation::cur());
-
-            vec![
-                // chunk idx unchanged.
-                cond.expr() * (chunk_idx_next - chunk_idx_curr),
-                // length is accumulated.
-                cond.expr() * (len_next - len_curr - 1.expr()),
-                // preimage rlc is updated.
-                cond.expr() * (preimage_rlc_curr * r + byte_next - preimage_rlc_next),
-                // boundary count continues.
-                cond.expr() * (boundary_count_curr - boundary_count_prev),
-                // digest_rlc is 0.
-                cond.expr() * digest_rlc,
-            ]
-        });
-
-        meta.create_gate("BlobDataConfig (\"chunk data\" section)", |meta| {
-            let is_data = meta.query_selector(config.data_selector);
-            let is_padding_curr = meta.query_advice(config.is_padding, Rotation::cur());
-            let is_padding_next = meta.query_advice(config.is_padding, Rotation::next());
-            let diff = is_padding_next - is_padding_curr.expr();
-            let byte = meta.query_advice(config.byte, Rotation::cur());
-            let chunk_idx = meta.query_advice(config.chunk_idx, Rotation::cur());
-            let accumulator = meta.query_advice(config.accumulator, Rotation::cur());
-            let preimage_rlc = meta.query_advice(config.preimage_rlc, Rotation::cur());
-            let digest_rlc = meta.query_advice(config.digest_rlc, Rotation::cur());
-            let boundary_count_curr = meta.query_advice(config.boundary_count, Rotation::cur());
-            let boundary_count_prev = meta.query_advice(config.boundary_count, Rotation::prev());
-
-            vec![
-                // byte, accumulator, digest_rlc, preimage_rlc, chunk_idx iare 0 when padding in
-                // the "chunk data" section.
-                is_data.expr() * is_padding_curr.expr() * byte,
-                is_data.expr() * is_padding_curr.expr() * accumulator,
-                is_data.expr() * is_padding_curr.expr() * digest_rlc,
-                is_data.expr() * is_padding_curr.expr() * preimage_rlc,
-                is_data.expr() * is_padding_curr.expr() * chunk_idx,
-                // diff is 0 or 1, i.e. is_padding transitions from 0 -> 1 only once.
-                is_data.expr() * diff.expr() * (1.expr() - diff.expr()),
-                // boundary count continues if padding
-                is_data.expr()
-                    * is_padding_curr.expr()
-                    * (boundary_count_curr - boundary_count_prev),
-            ]
-        });
-
-        // lookup metadata and chunk data digests in keccak table.
-        meta.lookup_any(
-            "BlobDataConfig (metadata/chunk_data/challenge digests in keccak table)",
-            |meta| {
-                let is_data = meta.query_selector(config.data_selector);
-                let is_hash = meta.query_selector(config.hash_selector);
-                let is_not_hash = 1.expr() - is_hash;
-                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
-
-                // in the "metadata" or "chunk data" section, wherever is_boundary is set.
-                let cond = is_not_hash * is_boundary;
-
-                let accumulator = meta.query_advice(config.accumulator, Rotation::cur());
-                let preimage_len =
-                    is_data.expr() * accumulator + (1.expr() - is_data) * N_ROWS_METADATA.expr();
-
-                [
-                    1.expr(),                                                // q_enable
-                    1.expr(),                                                // is final
-                    meta.query_advice(config.preimage_rlc, Rotation::cur()), // input RLC
-                    preimage_len,                                            // input len
-                    meta.query_advice(config.digest_rlc, Rotation::cur()),   // output RLC
-                ]
-                .into_iter()
-                .zip_eq(keccak_table.table_exprs(meta))
-                .map(|(value, table)| (cond.expr() * value, table))
-                .collect()
-            },
-        );
-
-        // lookup chunk data digests in the "digest rlc section" of BlobDataConfig.
-        meta.lookup_any(
-            "BlobDataConfig (chunk data digests in BlobDataConfig \"hash section\")",
-            |meta| {
-                let is_data = meta.query_selector(config.data_selector);
-                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
-
-                // in the "chunk data" section when we encounter a chunk boundary
-                let cond = is_data * is_boundary;
-
-                let hash_section_table = vec![
-                    meta.query_selector(config.hash_selector),
-                    meta.query_advice(config.chunk_idx, Rotation::cur()),
-                    meta.query_advice(config.accumulator, Rotation::cur()),
-                    meta.query_advice(config.digest_rlc, Rotation::cur()),
-                ];
-                [
-                    1.expr(),                                               // hash section
-                    meta.query_advice(config.chunk_idx, Rotation::cur()),   // chunk idx
-                    meta.query_advice(config.accumulator, Rotation::cur()), // chunk len
-                    meta.query_advice(config.digest_rlc, Rotation::cur()),  // digest rlc
-                ]
-                .into_iter()
-                .zip(hash_section_table)
-                .map(|(value, table)| (cond.expr() * value, table))
-                .collect()
-            },
-        );
-
-        // lookup challenge digest in keccak table.
-        meta.lookup_any(
-            "BlobDataConfig (metadata/chunk_data/challenge digests in keccak table)",
-            |meta| {
-                let is_hash = meta.query_selector(config.hash_selector);
-                let is_boundary = meta.query_advice(config.is_boundary, Rotation::cur());
-
-                // when is_boundary is set in the "digest RLC" section.
-                // this is also the last row of the "digest RLC" section.
-                let cond = is_hash * is_boundary;
-
-                // - metadata_digest: 32 bytes
-                // - chunk[i].chunk_data_digest: 32 bytes each
-                // - versioned_hash: 32 bytes
-                let preimage_len = 32.expr() * (MAX_AGG_SNARKS + 1 + 1).expr();
-
-                [
-                    1.expr(),                                                // q_enable
-                    1.expr(),                                                // is final
-                    meta.query_advice(config.preimage_rlc, Rotation::cur()), // input rlc
-                    preimage_len,                                            // input len
-                    meta.query_advice(config.digest_rlc, Rotation::cur()),   // output rlc
-                ]
-                .into_iter()
-                .zip_eq(keccak_table.table_exprs(meta))
-                .map(|(value, table)| (cond.expr() * value, table))
-                .collect()
-            },
-        );
 
         assert!(meta.degree() <= 5);
 
@@ -357,18 +60,16 @@ impl BlobDataConfig {
         layouter: &mut impl Layouter<Fr>,
         challenge_value: Challenges<Value<Fr>>,
         rlc_config: &RlcConfig,
-        // The chunks_are_padding assigned cells are exports from the conditional constraints in
-        // `core.rs`. Since these are already constrained, we can just use them as is.
-        chunks_are_padding: &[AssignedCell<Fr, Fr>],
-        blob: &BlobData,
+        batch_data: &BatchData,
         barycentric_assignments: &[CRTInteger<Fr>],
     ) -> Result<AssignedBlobDataExport, Error> {
-        self.load_range_tables(layouter)?;
+        self.u8_table.load(layouter)?;
 
-        let assigned_rows = layouter.assign_region(
-            || "BlobData rows",
-            |mut region| self.assign_rows(&mut region, challenge_value, blob),
+        let assigned_bytes = layouter.assign_region(
+            || "BlobData bytes",
+            |mut region| self.assign_rows(&mut region, batch_data),
         )?;
+
         layouter.assign_region(
             || "BlobData internal checks",
             |mut region| {
@@ -376,105 +77,42 @@ impl BlobDataConfig {
                     &mut region,
                     challenge_value,
                     rlc_config,
-                    chunks_are_padding,
                     barycentric_assignments,
-                    &assigned_rows,
+                    &assigned_bytes,
                 )
             },
         )
     }
 
-    pub fn load_range_tables(&self, layouter: &mut impl Layouter<Fr>) -> Result<(), Error> {
-        self.u8_table.load(layouter)?;
-        self.chunk_idx_range_table.load(layouter)
-    }
-
     pub fn assign_rows(
         &self,
         region: &mut Region<Fr>,
-        challenge_value: Challenges<Value<Fr>>,
-        blob: &BlobData,
-    ) -> Result<Vec<AssignedBlobDataConfig>, Error> {
-        let rows = blob.to_rows(challenge_value);
-        assert_eq!(rows.len(), N_ROWS_BLOB_DATA_CONFIG);
+        batch_data: &BatchData,
+    ) -> Result<Vec<AssignedCell<Fr, Fr>>, Error> {
+        let batch_bytes = batch_data.get_batch_data_bytes();
+        let blob_bytes = {
+            let mut encoder = init_zstd_encoder();
+            encoder
+                .set_pledged_src_size(Some(batch_bytes.len() as u64))
+                .map_err(|_| Error::Synthesis)?;
+            encoder
+                .write_all(&batch_bytes)
+                .map_err(|_| Error::Synthesis)?;
+            encoder.finish().map_err(|_| Error::Synthesis)?
+        };
+        assert!(blob_bytes.len() <= N_BLOB_BYTES, "too many blob bytes");
 
-        // enable data selector
-        for offset in N_ROWS_METADATA..N_ROWS_METADATA + N_ROWS_DATA {
-            self.data_selector.enable(region, offset)?;
-        }
-
-        // enable hash selector
-        for offset in
-            N_ROWS_METADATA + N_ROWS_DATA..N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST_RLC
-        {
-            self.hash_selector.enable(region, offset)?;
-        }
-
-        let mut assigned_rows = Vec::with_capacity(N_ROWS_BLOB_DATA_CONFIG);
-        let mut count = 0u64;
-        for (i, row) in rows.iter().enumerate() {
-            let byte = region.assign_advice(
+        let mut assigned_bytes = Vec::with_capacity(N_BLOB_BYTES);
+        for (i, &byte) in blob_bytes.iter().enumerate() {
+            assigned_bytes.push(region.assign_advice(
                 || "byte",
                 self.byte,
                 i,
-                || Value::known(Fr::from(row.byte as u64)),
-            )?;
-            let accumulator = region.assign_advice(
-                || "accumulator",
-                self.accumulator,
-                i,
-                || Value::known(Fr::from(row.accumulator)),
-            )?;
-            let chunk_idx = region.assign_advice(
-                || "chunk_idx",
-                self.chunk_idx,
-                i,
-                || Value::known(Fr::from(row.chunk_idx)),
-            )?;
-            let is_boundary = region.assign_advice(
-                || "is_boundary",
-                self.is_boundary,
-                i,
-                || Value::known(Fr::from(row.is_boundary as u64)),
-            )?;
-            let bcount = if (N_ROWS_METADATA..N_ROWS_METADATA + N_ROWS_DATA).contains(&i) {
-                count += row.is_boundary as u64;
-                count
-            } else {
-                0
-            };
-            let boundary_count = region.assign_advice(
-                || "boundary_count",
-                self.boundary_count,
-                i,
-                || Value::known(Fr::from(bcount)),
-            )?;
-            let is_padding = region.assign_advice(
-                || "is_padding",
-                self.is_padding,
-                i,
-                || Value::known(Fr::from(row.is_padding as u64)),
-            )?;
-            let preimage_rlc = region.assign_advice(
-                || "preimage_rlc",
-                self.preimage_rlc,
-                i,
-                || row.preimage_rlc,
-            )?;
-            let digest_rlc =
-                region.assign_advice(|| "digest_rlc", self.digest_rlc, i, || row.digest_rlc)?;
-            assigned_rows.push(AssignedBlobDataConfig {
-                byte,
-                accumulator,
-                chunk_idx,
-                is_boundary,
-                boundary_count,
-                is_padding,
-                preimage_rlc,
-                digest_rlc,
-            });
+                || Value::known(Fr::from(byte as u64)),
+            )?);
         }
-        Ok(assigned_rows)
+
+        Ok(assigned_bytes)
     }
 
     pub fn assign_internal_checks(
@@ -482,39 +120,18 @@ impl BlobDataConfig {
         region: &mut Region<Fr>,
         challenge_value: Challenges<Value<Fr>>,
         rlc_config: &RlcConfig,
-        // The chunks_are_padding assigned cells are exports from the conditional constraints in
-        // `core.rs`. Since these are already constrained, we can just use them as is.
-        chunks_are_padding: &[AssignedCell<Fr, Fr>],
         barycentric_assignments: &[CRTInteger<Fr>],
-        assigned_rows: &[AssignedBlobDataConfig],
+        assigned_bytes: &[AssignedCell<Fr, Fr>],
     ) -> Result<AssignedBlobDataExport, Error> {
         rlc_config.init(region)?;
         let mut rlc_config_offset = 0;
 
         // load some constants that we will use later.
-        let zero = {
-            let zero = rlc_config.load_private(region, &Fr::zero(), &mut rlc_config_offset)?;
-            let zero_cell = rlc_config.zero_cell(zero.cell().region_index);
-            region.constrain_equal(zero.cell(), zero_cell)?;
-            zero
-        };
         let one = {
             let one = rlc_config.load_private(region, &Fr::one(), &mut rlc_config_offset)?;
             let one_cell = rlc_config.one_cell(one.cell().region_index);
             region.constrain_equal(one.cell(), one_cell)?;
             one
-        };
-        let fixed_chunk_indices = {
-            let mut fixed_chunk_indices = vec![one.clone()];
-            for i in 2..=MAX_AGG_SNARKS {
-                let i_cell =
-                    rlc_config.load_private(region, &Fr::from(i as u64), &mut rlc_config_offset)?;
-                let i_fixed_cell =
-                    rlc_config.fixed_up_to_max_agg_snarks_cell(i_cell.cell().region_index, i);
-                region.constrain_equal(i_cell.cell(), i_fixed_cell)?;
-                fixed_chunk_indices.push(i_cell);
-            }
-            fixed_chunk_indices
         };
         let pows_of_256 = {
             let mut pows_of_256 = vec![one.clone()];
@@ -531,380 +148,10 @@ impl BlobDataConfig {
             }
             pows_of_256
         };
-        let two_fifty_six = pows_of_256[1].clone();
 
         // read randomness challenges for RLC computations.
         let r_keccak =
             rlc_config.read_challenge1(region, challenge_value, &mut rlc_config_offset)?;
-        let r_evm = rlc_config.read_challenge2(region, challenge_value, &mut rlc_config_offset)?;
-        let r32 = {
-            let r2 = rlc_config.mul(region, &r_keccak, &r_keccak, &mut rlc_config_offset)?;
-            let r4 = rlc_config.mul(region, &r2, &r2, &mut rlc_config_offset)?;
-            let r8 = rlc_config.mul(region, &r4, &r4, &mut rlc_config_offset)?;
-            let r16 = rlc_config.mul(region, &r8, &r8, &mut rlc_config_offset)?;
-            rlc_config.mul(region, &r16, &r16, &mut rlc_config_offset)?
-        };
-
-        // load cells representing the keccak digest of empty bytes.
-        let mut empty_digest_cells = Vec::with_capacity(N_BYTES_U256);
-        for (i, &byte) in keccak256([]).iter().enumerate() {
-            let cell =
-                rlc_config.load_private(region, &Fr::from(byte as u64), &mut rlc_config_offset)?;
-            let fixed_cell = rlc_config.empty_keccak_cell_i(cell.cell().region_index, i);
-            region.constrain_equal(cell.cell(), fixed_cell)?;
-            empty_digest_cells.push(cell);
-        }
-        let empty_digest_evm_rlc =
-            rlc_config.rlc(region, &empty_digest_cells, &r_evm, &mut rlc_config_offset)?;
-
-        ////////////////////////////////////////////////////////////////////////////////
-        /////////////////////////////// NUM_VALID_CHUNKS ///////////////////////////////
-        ////////////////////////////////////////////////////////////////////////////////
-
-        let rows = assigned_rows.iter().take(2).collect::<Vec<_>>();
-        let (byte_hi, byte_lo, lc1, lc2) = (
-            &rows[0].byte,
-            &rows[1].byte,
-            &rows[0].accumulator,
-            &rows[1].accumulator,
-        );
-
-        // the linear combination starts with the most-significant byte.
-        region.constrain_equal(byte_hi.cell(), lc1.cell())?;
-
-        // do the linear combination.
-        let num_valid_chunks =
-            rlc_config.mul_add(region, lc1, &two_fifty_six, byte_lo, &mut rlc_config_offset)?;
-        region.constrain_equal(num_valid_chunks.cell(), lc2.cell())?;
-
-        ////////////////////////////////////////////////////////////////////////////////
-        ////////////////////////////////// CHUNK_SIZE //////////////////////////////////
-        ////////////////////////////////////////////////////////////////////////////////
-
-        let mut num_nonempty_chunks = zero.clone();
-        let mut is_empty_chunks = Vec::with_capacity(MAX_AGG_SNARKS);
-        let mut chunk_sizes = Vec::with_capacity(MAX_AGG_SNARKS);
-        for (i, is_padded_chunk) in chunks_are_padding.iter().enumerate() {
-            let rows = assigned_rows
-                .iter()
-                .skip(2 + 4 * i)
-                .take(4)
-                .collect::<Vec<_>>();
-            let (byte0, byte1, byte2, byte3) =
-                (&rows[0].byte, &rows[1].byte, &rows[2].byte, &rows[3].byte);
-            let (acc0, acc1, acc2, acc3) = (
-                &rows[0].accumulator,
-                &rows[1].accumulator,
-                &rows[2].accumulator,
-                &rows[3].accumulator,
-            );
-
-            // the linear combination starts with the most-significant byte.
-            region.constrain_equal(byte0.cell(), acc0.cell())?;
-
-            // do the linear combination.
-            let lc =
-                rlc_config.mul_add(region, acc0, &two_fifty_six, byte1, &mut rlc_config_offset)?;
-            region.constrain_equal(lc.cell(), acc1.cell())?;
-            let lc =
-                rlc_config.mul_add(region, acc1, &two_fifty_six, byte2, &mut rlc_config_offset)?;
-            region.constrain_equal(lc.cell(), acc2.cell())?;
-            let chunk_size =
-                rlc_config.mul_add(region, acc2, &two_fifty_six, byte3, &mut rlc_config_offset)?;
-            region.constrain_equal(chunk_size.cell(), acc3.cell())?;
-
-            // if the chunk is a padded chunk, its size must be set to 0.
-            rlc_config.conditional_enforce_equal(
-                region,
-                &chunk_size,
-                &zero,
-                is_padded_chunk,
-                &mut rlc_config_offset,
-            )?;
-
-            let is_empty_chunk = rlc_config.is_zero(region, &chunk_size, &mut rlc_config_offset)?;
-            let is_nonempty_chunk =
-                rlc_config.not(region, &is_empty_chunk, &mut rlc_config_offset)?;
-            num_nonempty_chunks = rlc_config.add(
-                region,
-                &is_nonempty_chunk,
-                &num_nonempty_chunks,
-                &mut rlc_config_offset,
-            )?;
-
-            is_empty_chunks.push(is_empty_chunk);
-            chunk_sizes.push(chunk_size);
-        }
-        let all_chunks_empty =
-            rlc_config.is_zero(region, &num_nonempty_chunks, &mut rlc_config_offset)?;
-        let not_all_chunks_empty =
-            rlc_config.not(region, &all_chunks_empty, &mut rlc_config_offset)?;
-
-        // constrain preimage_rlc column
-        let metadata_rows = &assigned_rows[..N_ROWS_METADATA];
-        region.constrain_equal(
-            metadata_rows[0].byte.cell(),
-            metadata_rows[0].preimage_rlc.cell(),
-        )?;
-        for (i, row) in metadata_rows.iter().enumerate().skip(1) {
-            let preimage_rlc = rlc_config.mul_add(
-                region,
-                &metadata_rows[i - 1].preimage_rlc,
-                &r_keccak,
-                &row.byte,
-                &mut rlc_config_offset,
-            )?;
-            region.constrain_equal(preimage_rlc.cell(), row.preimage_rlc.cell())?;
-        }
-
-        // these columns are always 0 in the metadata section.
-        for row in metadata_rows.iter() {
-            let cells =
-                [&row.chunk_idx, &row.boundary_count, &row.is_padding].map(AssignedCell::cell);
-
-            for cell in cells {
-                region.constrain_equal(cell, zero.cell())?;
-            }
-        }
-
-        // in the metadata section, these columns are 0 except (possibly) on the last row.
-        for row in metadata_rows.iter().take(N_ROWS_METADATA - 1) {
-            let cells = [&row.is_boundary, &row.digest_rlc].map(AssignedCell::cell);
-
-            for cell in cells {
-                region.constrain_equal(cell, zero.cell())?;
-            }
-        }
-
-        // in the final row of the metadata section, boundary is 1. note that this triggers a keccak
-        // lookup which constrains digest_rlc.
-        region.constrain_equal(
-            metadata_rows[N_ROWS_METADATA - 1].is_boundary.cell(),
-            one.cell(),
-        )?;
-
-        ////////////////////////////////////////////////////////////////////////////////
-        ////////////////////////////////// CHUNK_DATA //////////////////////////////////
-        ////////////////////////////////////////////////////////////////////////////////
-
-        // the first data row has a length (accumulator) of 1. But in the special case that
-        // there are no non-empty chunks, this will be 0 and must also be a padding row.
-        let rows = assigned_rows
-            .iter()
-            .skip(N_ROWS_METADATA)
-            .take(N_ROWS_DATA)
-            .collect::<Vec<_>>();
-        rlc_config.conditional_enforce_equal(
-            region,
-            &rows[0].accumulator,
-            &one,
-            &not_all_chunks_empty,
-            &mut rlc_config_offset,
-        )?;
-        rlc_config.conditional_enforce_equal(
-            region,
-            &rows[0].is_padding,
-            &zero,
-            &not_all_chunks_empty,
-            &mut rlc_config_offset,
-        )?;
-        rlc_config.conditional_enforce_equal(
-            region,
-            &rows[0].accumulator,
-            &zero,
-            &all_chunks_empty,
-            &mut rlc_config_offset,
-        )?;
-        rlc_config.conditional_enforce_equal(
-            region,
-            &rows[0].is_padding,
-            &one,
-            &all_chunks_empty,
-            &mut rlc_config_offset,
-        )?;
-
-        // get the boundary count at the end of the "chunk data" section, and equate it to
-        // the number of non-empty chunks in the batch.
-        region.constrain_equal(
-            rows.last().unwrap().boundary_count.cell(),
-            num_nonempty_chunks.cell(),
-        )?;
-
-        ////////////////////////////////////////////////////////////////////////////////
-        ////////////////////////////////// DIGEST RLC //////////////////////////////////
-        ////////////////////////////////////////////////////////////////////////////////
-
-        let rows = assigned_rows
-            .iter()
-            .skip(N_ROWS_METADATA + N_ROWS_DATA)
-            .take(N_ROWS_DIGEST_RLC)
-            .collect::<Vec<_>>();
-
-        // rows have chunk_idx set from 0 (metadata) -> MAX_AGG_SNARKS.
-        region.constrain_equal(rows[0].chunk_idx.cell(), zero.cell())?;
-        for (row, fixed_chunk_idx) in rows
-            .iter()
-            .skip(1)
-            .take(MAX_AGG_SNARKS)
-            .zip_eq(fixed_chunk_indices.iter())
-        {
-            region.constrain_equal(row.chunk_idx.cell(), fixed_chunk_idx.cell())?;
-        }
-
-        let challenge_digest_preimage_rlc_specified = &rows.last().unwrap().preimage_rlc;
-        let challenge_digest_rlc_specified = &rows.last().unwrap().digest_rlc;
-        let versioned_hash_rlc = &rows.get(N_ROWS_DIGEST_RLC - 2).unwrap().digest_rlc;
-
-        // ensure that on the last row of this section the is_boundary is turned on
-        // which would enable the keccak table lookup for challenge_digest
-        region.constrain_equal(rows.last().unwrap().is_boundary.cell(), one.cell())?;
-
-        let metadata_digest_rlc_computed =
-            &assigned_rows.get(N_ROWS_METADATA - 1).unwrap().digest_rlc;
-        let metadata_digest_rlc_specified = &rows.first().unwrap().digest_rlc;
-        region.constrain_equal(
-            metadata_digest_rlc_computed.cell(),
-            metadata_digest_rlc_specified.cell(),
-        )?;
-
-        // if the chunk is a padded chunk, then its chunk data digest should be the
-        // same as the previous chunk's data digest.
-        //
-        // Also, we know that the first chunk is valid. So we can just start the check from
-        // the second chunk's data digest.
-        region.constrain_equal(chunks_are_padding[0].cell(), zero.cell())?;
-        for i in 1..MAX_AGG_SNARKS {
-            // Note that in `rows`, the first row is the metadata row (hence anyway skip
-            // it). That's why we have a +1.
-            rlc_config.conditional_enforce_equal(
-                region,
-                &rows[i + 1].digest_rlc,
-                &rows[i].digest_rlc,
-                &chunks_are_padding[i],
-                &mut rlc_config_offset,
-            )?;
-        }
-
-        let mut chunk_digest_evm_rlcs = Vec::with_capacity(MAX_AGG_SNARKS);
-        for (((row, chunk_size_decoded), is_empty), is_padded_chunk) in rows
-            .iter()
-            .skip(1)
-            .take(MAX_AGG_SNARKS)
-            .zip_eq(chunk_sizes)
-            .zip_eq(is_empty_chunks)
-            .zip_eq(chunks_are_padding)
-        {
-            // if the chunk is a valid chunk (i.e. not padded chunk), but is empty (i.e. no
-            // L2 transactions), then the chunk's data digest should be the empty keccak
-            // digest.
-            let is_valid = rlc_config.not(region, is_padded_chunk, &mut rlc_config_offset)?;
-            let is_valid_empty =
-                rlc_config.mul(region, &is_valid, &is_empty, &mut rlc_config_offset)?;
-            rlc_config.conditional_enforce_equal(
-                region,
-                &row.digest_rlc,
-                &empty_digest_evm_rlc,
-                &is_valid_empty,
-                &mut rlc_config_offset,
-            )?;
-
-            // constrain chunk size specified here against decoded in metadata.
-            region.constrain_equal(row.accumulator.cell(), chunk_size_decoded.cell())?;
-
-            chunk_digest_evm_rlcs.push(&row.digest_rlc);
-        }
-
-        ////////////////////////////////////////////////////////////////////////////////
-        ///////////////////////////////// DIGEST BYTES /////////////////////////////////
-        ////////////////////////////////////////////////////////////////////////////////
-
-        let mut challenge_digest_preimage_keccak_rlc = zero.clone();
-        let rows = assigned_rows
-            .iter()
-            .skip(N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST_RLC)
-            .take(N_ROWS_DIGEST_BYTES)
-            .collect::<Vec<_>>();
-        for (i, digest_rlc_specified) in std::iter::once(metadata_digest_rlc_specified)
-            .chain(chunk_digest_evm_rlcs)
-            .chain(std::iter::once(versioned_hash_rlc))
-            .chain(std::iter::once(challenge_digest_rlc_specified))
-            .enumerate()
-        {
-            let digest_rows = rows
-                .iter()
-                .skip(N_BYTES_U256 * i)
-                .take(N_BYTES_U256)
-                .collect::<Vec<_>>();
-            let digest_bytes = digest_rows
-                .iter()
-                .map(|row| row.byte.clone())
-                .collect::<Vec<_>>();
-            let digest_rlc_computed =
-                rlc_config.rlc(region, &digest_bytes, &r_evm, &mut rlc_config_offset)?;
-            region.constrain_equal(digest_rlc_computed.cell(), digest_rlc_specified.cell())?;
-
-            // compute the keccak input RLC:
-            // we do this only for the metadata and chunks, not for the blob row itself.
-            if i < MAX_AGG_SNARKS + 1 + 1 {
-                let digest_keccak_rlc =
-                    rlc_config.rlc(region, &digest_bytes, &r_keccak, &mut rlc_config_offset)?;
-                challenge_digest_preimage_keccak_rlc = rlc_config.mul_add(
-                    region,
-                    &challenge_digest_preimage_keccak_rlc,
-                    &r32,
-                    &digest_keccak_rlc,
-                    &mut rlc_config_offset,
-                )?;
-            }
-        }
-        region.constrain_equal(
-            challenge_digest_preimage_keccak_rlc.cell(),
-            challenge_digest_preimage_rlc_specified.cell(),
-        )?;
-
-        ////////////////////////////////////////////////////////////////////////////////
-        //////////////////////////////////// EXPORT ////////////////////////////////////
-        ////////////////////////////////////////////////////////////////////////////////
-
-        let mut blob_fields: Vec<Vec<AssignedCell<Fr, Fr>>> = Vec::with_capacity(BLOB_WIDTH);
-        let blob_bytes = assigned_rows
-            .iter()
-            .take(N_ROWS_METADATA + N_ROWS_DATA)
-            .map(|row| row.byte.clone())
-            .collect::<Vec<_>>();
-        for chunk in blob_bytes.chunks_exact(N_DATA_BYTES_PER_COEFFICIENT) {
-            // blob bytes are supposed to be deserialised in big-endianness. However, we
-            // have the export from BarycentricConfig in little-endian bytes.
-            blob_fields.push(chunk.iter().rev().cloned().collect());
-        }
-        let mut chunk_data_digests = Vec::with_capacity(MAX_AGG_SNARKS);
-        let chunk_data_digests_bytes = assigned_rows
-            .iter()
-            .skip(N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST_RLC + N_BYTES_U256)
-            .take(MAX_AGG_SNARKS * N_BYTES_U256)
-            .map(|row| row.byte.clone())
-            .collect::<Vec<_>>();
-        for chunk in chunk_data_digests_bytes.chunks_exact(N_BYTES_U256) {
-            chunk_data_digests.push(chunk.to_vec());
-        }
-        let challenge_digest = assigned_rows
-            .iter()
-            .rev()
-            .take(N_BYTES_U256)
-            .map(|row| row.byte.clone())
-            .collect::<Vec<AssignedCell<Fr, Fr>>>();
-        let export = AssignedBlobDataExport {
-            num_valid_chunks,
-            versioned_hash: assigned_rows
-                .iter()
-                .rev()
-                .skip(N_BYTES_U256)
-                .take(N_BYTES_U256)
-                .map(|row| row.byte.clone())
-                .rev()
-                .collect(),
-            chunk_data_digests,
-        };
 
         ////////////////////////////////////////////////////////////////////////////////
         //////////////////////////////////// LINKING ///////////////////////////////////
@@ -915,40 +162,12 @@ impl BlobDataConfig {
             .iter()
             .take(BLOB_WIDTH)
             .collect::<Vec<_>>();
-        let challenge_digest_crt = barycentric_assignments
-            .get(BLOB_WIDTH)
-            .expect("challenge digest CRT");
-
-        let challenge_digest_limb1 = rlc_config.inner_product(
-            region,
-            &challenge_digest[0..11],
-            &pows_of_256,
-            &mut rlc_config_offset,
-        )?;
-        let challenge_digest_limb2 = rlc_config.inner_product(
-            region,
-            &challenge_digest[11..22],
-            &pows_of_256,
-            &mut rlc_config_offset,
-        )?;
-        let challenge_digest_limb3 = rlc_config.inner_product(
-            region,
-            &challenge_digest[22..32],
-            &pows_of_256[0..10],
-            &mut rlc_config_offset,
-        )?;
-        region.constrain_equal(
-            challenge_digest_limb1.cell(),
-            challenge_digest_crt.truncation.limbs[0].cell(),
-        )?;
-        region.constrain_equal(
-            challenge_digest_limb2.cell(),
-            challenge_digest_crt.truncation.limbs[1].cell(),
-        )?;
-        region.constrain_equal(
-            challenge_digest_limb3.cell(),
-            challenge_digest_crt.truncation.limbs[2].cell(),
-        )?;
+        let mut blob_fields: Vec<Vec<AssignedCell<Fr, Fr>>> = Vec::with_capacity(BLOB_WIDTH);
+        for chunk in assigned_bytes.chunks_exact(N_DATA_BYTES_PER_COEFFICIENT) {
+            // blob bytes are supposed to be deserialised in big-endianness. However, we
+            // have the export from BarycentricConfig in little-endian bytes.
+            blob_fields.push(chunk.iter().rev().cloned().collect());
+        }
         for (blob_crt, blob_field) in blob_crts.iter().zip_eq(blob_fields.iter()) {
             let limb1 = rlc_config.inner_product(
                 region,
@@ -973,6 +192,12 @@ impl BlobDataConfig {
             region.constrain_equal(limb3.cell(), blob_crt.truncation.limbs[2].cell())?;
         }
 
-        Ok(export)
+        ////////////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////// EXPORT ////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+
+        let bytes_rlc =
+            rlc_config.rlc(region, &assigned_bytes, &r_keccak, &mut rlc_config_offset)?;
+        Ok(AssignedBlobDataExport { bytes_rlc })
     }
 }

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -1,4 +1,4 @@
-use crate::blob::BlobData;
+use crate::blob::BatchData;
 use ark_std::{end_timer, start_timer};
 use halo2_base::{Context, ContextParams};
 use halo2_proofs::{
@@ -268,9 +268,11 @@ impl Circuit<Fr> for AggregationCircuit {
                     let mut ctx = Rc::into_inner(loader).unwrap().into_ctx();
                     let barycentric = config.barycentric.assign(
                         &mut ctx,
-                        &self.batch_hash.blob.coefficients,
-                        self.batch_hash.blob.challenge_digest,
-                        self.batch_hash.blob.evaluation,
+                        &self.batch_hash.point_evaluation_assignments.coefficients,
+                        self.batch_hash
+                            .point_evaluation_assignments
+                            .challenge_digest,
+                        self.batch_hash.point_evaluation_assignments.evaluation,
                     );
 
                     ctx.print_stats(&["barycentric"]);
@@ -434,25 +436,36 @@ impl Circuit<Fr> for AggregationCircuit {
             let challenge_le = &barycentric.z_le;
             let evaluation_le = &barycentric.y_le;
 
-            let blob_data = BlobData::from(&self.batch_hash);
+            let batch_data = BatchData::from(&self.batch_hash);
+
             let blob_data_exports = config.blob_data_config.assign(
                 &mut layouter,
                 challenges,
                 &config.rlc_config,
-                &assigned_batch_hash.chunks_are_padding,
-                &blob_data,
+                &batch_data,
                 barycentric_assignments,
             )?;
 
+            let batch_data_exports = config.batch_data_config.assign(
+                &mut layouter,
+                challenges,
+                &config.rlc_config,
+                &assigned_batch_hash.chunks_are_padding,
+                &batch_data,
+                barycentric_assignments,
+            )?;
+
+            let decoder_exports = config.decoder_config.assign(&mut layouter)?;
+
             layouter.assign_region(
-                || "blob checks",
+                || "batch checks",
                 |mut region| -> Result<(), Error> {
                     region.constrain_equal(
                         assigned_batch_hash.num_valid_snarks.cell(),
-                        blob_data_exports.num_valid_chunks.cell(),
+                        batch_data_exports.num_valid_chunks.cell(),
                     )?;
 
-                    for (chunk_data_digest, expected_chunk_data_digest) in blob_data_exports
+                    for (chunk_data_digest, expected_chunk_data_digest) in batch_data_exports
                         .chunk_data_digests
                         .iter()
                         .zip_eq(assigned_batch_hash.blob.chunk_tx_data_digests.iter())
@@ -479,13 +492,25 @@ impl Circuit<Fr> for AggregationCircuit {
                         region.constrain_equal(c.cell(), ec.cell())?;
                     }
 
-                    for (c, ec) in blob_data_exports
+                    for (c, ec) in batch_data_exports
                         .versioned_hash
                         .iter()
                         .zip_eq(assigned_batch_hash.blob.versioned_hash.iter())
                     {
                         region.constrain_equal(c.cell(), ec.cell())?;
                     }
+
+                    // equate rlc (from blob data) with decoder's encoded_rlc
+                    region.constrain_equal(
+                        blob_data_exports.bytes_rlc.cell(),
+                        decoder_exports.encoded_rlc.cell(),
+                    )?;
+
+                    // equate rlc (from batch data) with decoder's decoded_rlc
+                    region.constrain_equal(
+                        batch_data_exports.bytes_rlc.cell(),
+                        decoder_exports.decoded_rlc.cell(),
+                    )?;
 
                     Ok(())
                 },
@@ -527,8 +552,8 @@ impl CircuitExt<Fr> for AggregationCircuit {
                     config.0.rlc_config.selector,
                     config.0.rlc_config.enable_challenge1,
                     config.0.rlc_config.enable_challenge2,
-                    config.0.blob_data_config.data_selector,
-                    config.0.blob_data_config.hash_selector,
+                    config.0.batch_data_config.data_selector,
+                    config.0.batch_data_config.hash_selector,
                 ]
                 .iter()
                 .cloned(),

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -188,9 +188,11 @@ impl Circuit<Fr> for AggregationCircuit {
 
                     let barycentric = config.barycentric.assign(
                         &mut ctx,
-                        &self.batch_hash.blob.coefficients,
-                        self.batch_hash.blob.challenge_digest,
-                        self.batch_hash.blob.evaluation,
+                        &self.batch_hash.point_evaluation_assignments.coefficients,
+                        self.batch_hash
+                            .point_evaluation_assignments
+                            .challenge_digest,
+                        self.batch_hash.point_evaluation_assignments.evaluation,
                     );
 
                     config.barycentric.scalar.range.finalize(&mut ctx);
@@ -455,7 +457,8 @@ impl Circuit<Fr> for AggregationCircuit {
                 barycentric_assignments,
             )?;
 
-            let decoder_exports = config.decoder_config.assign(&mut layouter)?;
+            // TODO: uncomment this line
+            // let decoder_exports = config.decoder_config.assign(&mut layouter)?;
 
             layouter.assign_region(
                 || "batch checks",
@@ -500,17 +503,16 @@ impl Circuit<Fr> for AggregationCircuit {
                         region.constrain_equal(c.cell(), ec.cell())?;
                     }
 
-                    // equate rlc (from blob data) with decoder's encoded_rlc
-                    region.constrain_equal(
-                        blob_data_exports.bytes_rlc.cell(),
-                        decoder_exports.encoded_rlc.cell(),
-                    )?;
-
-                    // equate rlc (from batch data) with decoder's decoded_rlc
-                    region.constrain_equal(
-                        batch_data_exports.bytes_rlc.cell(),
-                        decoder_exports.decoded_rlc.cell(),
-                    )?;
+                    // // equate rlc (from blob data) with decoder's encoded_rlc
+                    // region.constrain_equal(
+                    //     blob_data_exports.bytes_rlc.cell(),
+                    //     decoder_exports.encoded_rlc.cell(),
+                    // )?;
+                    // // equate rlc (from batch data) with decoder's decoded_rlc
+                    // region.constrain_equal(
+                    //     batch_data_exports.bytes_rlc.cell(),
+                    //     decoder_exports.decoded_rlc.cell(),
+                    // )?;
 
                     Ok(())
                 },

--- a/aggregator/src/aggregation/decompression.rs
+++ b/aggregator/src/aggregation/decompression.rs
@@ -1,1 +1,3 @@
+pub(crate) mod decoder;
+
 mod witgen;

--- a/aggregator/src/aggregation/decompression/decoder.rs
+++ b/aggregator/src/aggregation/decompression/decoder.rs
@@ -1,0 +1,26 @@
+use halo2_proofs::{
+    circuit::{AssignedCell, Layouter},
+    halo2curves::bn256::Fr,
+    plonk::{ConstraintSystem, Error},
+};
+
+#[derive(Clone, Debug)]
+pub struct DecoderConfig;
+
+pub struct AssignedDecoderConfigExports {
+    pub encoded_rlc: AssignedCell<Fr, Fr>,
+    pub decoded_rlc: AssignedCell<Fr, Fr>,
+}
+
+impl DecoderConfig {
+    pub fn configure(meta: &mut ConstraintSystem<Fr>) -> Self {
+        DecoderConfig
+    }
+
+    pub fn assign(
+        &self,
+        layouter: &mut impl Layouter<Fr>,
+    ) -> Result<AssignedDecoderConfigExports, Error> {
+        unimplemented!()
+    }
+}

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -5,7 +5,7 @@ use eth_types::{Field, ToBigEndian, H256};
 use ethers_core::utils::keccak256;
 
 use crate::{
-    blob::{BlobAssignments, BlobData},
+    blob::{BatchData, PointEvaluationAssignments},
     chunk::ChunkHash,
     constants::MAX_AGG_SNARKS,
 };
@@ -34,8 +34,8 @@ pub struct BatchHash {
     pub(crate) public_input_hash: H256,
     /// The number of chunks that contain meaningful data, i.e. not padded chunks.
     pub(crate) number_of_valid_chunks: usize,
-    /// 4844-Blob related fields.
-    pub(crate) blob: BlobAssignments,
+    /// 4844 point evaluation check related assignments.
+    pub(crate) point_evaluation_assignments: PointEvaluationAssignments,
     /// The 4844 versioned hash for the blob.
     pub(crate) versioned_hash: H256,
 }
@@ -118,9 +118,9 @@ impl BatchHash {
             .collect::<Vec<_>>();
         let batch_data_hash = keccak256(preimage);
 
-        let blob_data = BlobData::new(number_of_valid_chunks, chunks_with_padding);
-        let blob_assignments = BlobAssignments::from(&blob_data);
-        let versioned_hash = blob_data.get_versioned_hash();
+        let batch_data = BatchData::new(number_of_valid_chunks, chunks_with_padding);
+        let point_evaluation_assignments = PointEvaluationAssignments::from(&batch_data);
+        let versioned_hash = batch_data.get_versioned_hash();
 
         // public input hash is build as
         // keccak(
@@ -143,18 +143,26 @@ impl BatchHash {
                 .withdraw_root
                 .as_bytes(),
             batch_data_hash.as_slice(),
-            blob_assignments.challenge.to_be_bytes().as_ref(),
-            blob_assignments.evaluation.to_be_bytes().as_ref(),
+            point_evaluation_assignments
+                .challenge
+                .to_be_bytes()
+                .as_ref(),
+            point_evaluation_assignments
+                .evaluation
+                .to_be_bytes()
+                .as_ref(),
             versioned_hash.as_bytes(),
         ]
         .concat();
         let public_input_hash: H256 = keccak256(preimage).into();
+
         log::info!(
-            "batch pihash {:?}, datahash {}, z {} y {}",
+            "batch pi hash {:?}, datahash {}, z {}, y {}, versioned hash {:x}",
             public_input_hash,
             hex::encode(batch_data_hash),
-            hex::encode(blob_assignments.challenge.to_be_bytes()),
-            hex::encode(blob_assignments.evaluation.to_be_bytes())
+            hex::encode(point_evaluation_assignments.challenge.to_be_bytes()),
+            hex::encode(point_evaluation_assignments.evaluation.to_be_bytes()),
+            versioned_hash,
         );
 
         Self {
@@ -163,14 +171,14 @@ impl BatchHash {
             data_hash: batch_data_hash.into(),
             public_input_hash,
             number_of_valid_chunks,
-            blob: blob_assignments,
+            point_evaluation_assignments,
             versioned_hash,
         }
     }
 
     /// Return the blob polynomial and its evaluation at challenge
-    pub fn blob_assignments(&self) -> BlobAssignments {
-        self.blob.clone()
+    pub fn point_evaluation_assignments(&self) -> PointEvaluationAssignments {
+        self.point_evaluation_assignments.clone()
     }
 
     /// Extract all the hash inputs that will ever be used.
@@ -207,8 +215,8 @@ impl BatchHash {
                 .withdraw_root
                 .as_bytes(),
             self.data_hash.as_bytes(),
-            &self.blob.challenge.to_be_bytes(),
-            &self.blob.evaluation.to_be_bytes(),
+            &self.point_evaluation_assignments.challenge.to_be_bytes(),
+            &self.point_evaluation_assignments.evaluation.to_be_bytes(),
             self.versioned_hash.as_bytes(),
         ]
         .concat();
@@ -242,11 +250,11 @@ impl BatchHash {
         // size. We now move to the part where the preimage is dynamic.
         //
         // These include:
-        // - preimage for blob metadata
+        // - preimage for batch metadata
         // - preimage for each chunk's flattened L2 signed tx data
         // - preimage for the challenge digest
-        let blob_data = BlobData::from(self);
-        let dynamic_preimages = blob_data.preimages();
+        let batch_data = BatchData::from(self);
+        let dynamic_preimages = batch_data.preimages();
         for dynamic_preimage in dynamic_preimages {
             res.push(dynamic_preimage);
         }

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -48,10 +48,10 @@ pub const N_BLOB_BYTES: usize = BLOB_WIDTH * N_DATA_BYTES_PER_COEFFICIENT;
 /// The maximum number of bytes we will support in a single batch.
 ///
 /// For now, we assume that the zstd encoding can give us a maximum compression ratio of 5, i.e. we
-/// allow up to 5 times the number of bytes in a single blob to be in a batch.
+/// allow up to 3 times the number of bytes in a single blob to be in a batch.
 ///
 /// TODO: revisit
-pub const N_BATCH_BYTES: usize = N_BLOB_BYTES * 5;
+pub const N_BATCH_BYTES: usize = N_BLOB_BYTES * 3;
 
 /// The number of rows in Blob Data config's layout to represent the "blob metadata" section.
 pub const N_ROWS_METADATA: usize = N_ROWS_NUM_CHUNKS + N_ROWS_CHUNK_SIZES;

--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -16,6 +16,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use revm_primitives::VERSIONED_HASH_VERSION_KZG;
 use std::{
+    io::Write,
     iter::{once, repeat},
     sync::Arc,
 };
@@ -44,11 +45,19 @@ pub const N_ROWS_CHUNK_SIZES: usize = MAX_AGG_SNARKS * 4;
 /// we explicitly set the most-significant byte to 0, effectively utilising only 31 bytes.
 pub const N_BLOB_BYTES: usize = BLOB_WIDTH * N_DATA_BYTES_PER_COEFFICIENT;
 
+/// The maximum number of bytes we will support in a single batch.
+///
+/// For now, we assume that the zstd encoding can give us a maximum compression ratio of 5, i.e. we
+/// allow up to 5 times the number of bytes in a single blob to be in a batch.
+///
+/// TODO: revisit
+pub const N_BATCH_BYTES: usize = N_BLOB_BYTES * 5;
+
 /// The number of rows in Blob Data config's layout to represent the "blob metadata" section.
 pub const N_ROWS_METADATA: usize = N_ROWS_NUM_CHUNKS + N_ROWS_CHUNK_SIZES;
 
 /// The number of rows in Blob Data config's layout to represent the "chunk data" section.
-pub const N_ROWS_DATA: usize = N_BLOB_BYTES - N_ROWS_METADATA;
+pub const N_ROWS_DATA: usize = N_BATCH_BYTES - N_ROWS_METADATA;
 
 /// The number of rows in Blob Data config's layout to represent the "digest rlc" section.
 /// - metadata digest RLC (1 row)
@@ -63,8 +72,8 @@ pub const N_ROWS_DIGEST_BYTES: usize = N_ROWS_DIGEST_RLC * N_BYTES_U256;
 /// The total number of rows in "digest rlc" and "digest bytes" sections.
 pub const N_ROWS_DIGEST: usize = N_ROWS_DIGEST_RLC + N_ROWS_DIGEST_BYTES;
 
-/// The total number of rows used in Blob Data config's layout.
-pub const N_ROWS_BLOB_DATA_CONFIG: usize = N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST;
+/// The total number of rows used in Batch Data config's layout.
+pub const N_ROWS_BATCH_DATA_CONFIG: usize = N_ROWS_METADATA + N_ROWS_DATA + N_ROWS_DIGEST;
 
 /// KZG trusted setup
 pub static KZG_TRUSTED_SETUP: Lazy<Arc<c_kzg::KzgSettings>> = Lazy::new(|| {
@@ -77,9 +86,33 @@ pub static KZG_TRUSTED_SETUP: Lazy<Arc<c_kzg::KzgSettings>> = Lazy::new(|| {
     )
 });
 
-/// Helper struct to generate witness for the Blob Data Config.
+/// Zstd encoder configuration
+pub fn init_zstd_encoder() -> zstd::stream::Encoder<'static, Vec<u8>> {
+    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).expect("infallible");
+    // disable compression of literals, i.e. literals will be raw bytes.
+    encoder
+        .set_parameter(zstd::stream::raw::CParameter::LiteralCompressionMode(
+            zstd::zstd_safe::ParamSwitch::Disable,
+        ))
+        .expect("infallible");
+    // set target block size to fit within a single block.
+    encoder
+        .set_parameter(zstd::stream::raw::CParameter::TargetCBlockSize(124 * 1024))
+        .expect("infallible");
+    // do not include the checksum at the end of the encoded data.
+    encoder.include_checksum(false).expect("infallible");
+    // do not include magic bytes at the start of the frame since we will have a single
+    // frame.
+    encoder.include_magicbytes(false).expect("infallible");
+    // include the content size to know at decode time the expected size of decoded
+    // data.
+    encoder.include_contentsize(true).expect("infallible");
+    encoder
+}
+
+/// Helper struct to generate witness for the Batch Data Config.
 #[derive(Clone, Debug)]
-pub struct BlobData {
+pub struct BatchData {
     /// The number of valid chunks in the batch. This could be any number between:
     /// [1, MAX_AGG_SNARKS]
     pub num_valid_chunks: u16,
@@ -89,14 +122,14 @@ pub struct BlobData {
     pub chunk_sizes: [u32; MAX_AGG_SNARKS],
     /// Flattened L2 signed transaction data, for each chunk.
     ///
-    /// Note that in BlobData struct, only `num_valid_chunks` number of chunks' bytes are supposed
+    /// Note that in BatchData struct, only `num_valid_chunks` number of chunks' bytes are supposed
     /// to be read (for witness generation). For simplicity, the last valid chunk's bytes are
     /// copied over for the padded chunks. The `chunk_data_digest` for padded chunks is the
     /// `chunk_data_digest` of the last valid chunk (from Aggregation Circuit's perspective).
     pub chunk_data: [Vec<u8>; MAX_AGG_SNARKS],
 }
 
-impl From<&BatchHash> for BlobData {
+impl From<&BatchHash> for BatchData {
     fn from(batch_hash: &BatchHash) -> Self {
         Self::new(
             batch_hash.number_of_valid_chunks,
@@ -106,8 +139,8 @@ impl From<&BatchHash> for BlobData {
 }
 
 // If the chunk data is represented as a vector of u8's this implementation converts data from
-// dynamic number of chunks into BlobData.
-impl From<&Vec<Vec<u8>>> for BlobData {
+// dynamic number of chunks into BatchData.
+impl From<&Vec<Vec<u8>>> for BatchData {
     fn from(chunks: &Vec<Vec<u8>>) -> Self {
         let num_valid_chunks = chunks.len();
         assert!(num_valid_chunks > 0);
@@ -141,7 +174,7 @@ impl From<&Vec<Vec<u8>>> for BlobData {
     }
 }
 
-impl Default for BlobData {
+impl Default for BatchData {
     fn default() -> Self {
         // default value corresponds to a batch with 1 chunk with no transactions
         Self::from(&vec![vec![]])
@@ -154,7 +187,7 @@ fn kzg_to_versioned_hash(commitment: &c_kzg::KzgCommitment) -> H256 {
     H256::from_slice(&res[..])
 }
 
-impl BlobData {
+impl BatchData {
     pub(crate) fn new(num_valid_chunks: usize, chunks_with_padding: &[ChunkHash]) -> Self {
         assert!(num_valid_chunks > 0);
         assert!(num_valid_chunks <= MAX_AGG_SNARKS);
@@ -193,7 +226,7 @@ impl BlobData {
     }
 }
 
-impl BlobData {
+impl BatchData {
     /// Get the versioned hash as per EIP-4844.
     pub(crate) fn get_versioned_hash(&self) -> H256 {
         let coefficients = self.get_coefficients();
@@ -237,20 +270,41 @@ impl BlobData {
         U256::from_big_endian(&challenge_digest)
     }
 
+    /// Get the batch data bytes that will be populated in BatchDataConfig.
+    pub(crate) fn get_batch_data_bytes(&self) -> Vec<u8> {
+        let metadata_bytes = self.to_metadata_bytes();
+        metadata_bytes
+            .iter()
+            .chain(
+                self.chunk_data
+                    .iter()
+                    .take(self.num_valid_chunks as usize)
+                    .flatten(),
+            )
+            .cloned()
+            .collect()
+    }
+
     /// Get the BLOB_WIDTH number of scalar field elements, as 32-bytes unsigned integers.
     pub(crate) fn get_coefficients(&self) -> [U256; BLOB_WIDTH] {
         let mut coefficients = [[0u8; N_BYTES_U256]; BLOB_WIDTH];
 
         // We only consider the data from `valid` chunks and ignore the padded chunks.
-        let metadata_bytes = self.to_metadata_bytes();
-        let blob_bytes = metadata_bytes.iter().chain(
-            self.chunk_data
-                .iter()
-                .take(self.num_valid_chunks as usize)
-                .flatten(),
+        let batch_bytes = self.get_batch_data_bytes();
+        let blob_bytes = {
+            let mut encoder = init_zstd_encoder();
+            encoder
+                .set_pledged_src_size(Some(batch_bytes.len() as u64))
+                .expect("infallible");
+            encoder.write_all(&batch_bytes).expect("infallible");
+            encoder.finish().expect("infallible")
+        };
+        assert!(
+            blob_bytes.len() < N_BLOB_BYTES,
+            "too many bytes in batch data"
         );
 
-        for (i, &byte) in blob_bytes.enumerate() {
+        for (i, &byte) in blob_bytes.iter().enumerate() {
             coefficients[i / 31][1 + (i % 31)] = byte;
         }
 
@@ -278,9 +332,9 @@ impl BlobData {
     }
 }
 
-impl BlobData {
+impl BatchData {
     /// Get the witness rows for assignment to the BlobDataConfig.
-    pub(crate) fn to_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BlobDataRow<Fr>> {
+    pub(crate) fn to_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BatchDataRow<Fr>> {
         let metadata_rows = self.to_metadata_rows(challenge);
         assert_eq!(metadata_rows.len(), N_ROWS_METADATA);
 
@@ -294,7 +348,7 @@ impl BlobData {
             .into_iter()
             .chain(data_rows)
             .chain(digest_rows)
-            .collect::<Vec<BlobDataRow<Fr>>>()
+            .collect::<Vec<BatchDataRow<Fr>>>()
     }
 
     /// Get the blob bytes that encode the batch's metadata.
@@ -321,7 +375,7 @@ impl BlobData {
     }
 
     /// Get the witness rows for the "metadata" section of Blob data config.
-    fn to_metadata_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BlobDataRow<Fr>> {
+    fn to_metadata_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BatchDataRow<Fr>> {
         // metadata bytes.
         let bytes = self.to_metadata_bytes();
 
@@ -366,7 +420,7 @@ impl BlobData {
             .zip_eq(digest_rlc_iter)
             .enumerate()
             .map(
-                |(i, (((&byte, accumulator), preimage_rlc), digest_rlc))| BlobDataRow {
+                |(i, (((&byte, accumulator), preimage_rlc), digest_rlc))| BatchDataRow {
                     byte,
                     accumulator,
                     preimage_rlc,
@@ -381,7 +435,7 @@ impl BlobData {
     }
 
     /// Get the witness rows for the "chunk data" section of Blob data config.
-    fn to_data_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BlobDataRow<Fr>> {
+    fn to_data_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BatchDataRow<Fr>> {
         // consider only the `valid` chunks while constructing rows for the "chunk data" section.
         self.chunk_data
             .iter()
@@ -402,7 +456,7 @@ impl BlobData {
                         acc.0 += 1;
                         acc.1 =
                             acc.1 * challenge.keccak_input() + Value::known(Fr::from(byte as u64));
-                        Some(BlobDataRow {
+                        Some(BatchDataRow {
                             byte,
                             accumulator: acc.0,
                             chunk_idx,
@@ -418,13 +472,13 @@ impl BlobData {
                     },
                 )
             })
-            .chain(repeat(BlobDataRow::padding_row()))
+            .chain(repeat(BatchDataRow::padding_row()))
             .take(N_ROWS_DATA)
             .collect()
     }
 
     /// Get the witness rows for both "digest rlc" and "digest bytes" sections of Blob data config.
-    fn to_digest_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BlobDataRow<Fr>> {
+    fn to_digest_rows(&self, challenge: Challenges<Value<Fr>>) -> Vec<BatchDataRow<Fr>> {
         let zero = Value::known(Fr::zero());
 
         // metadata
@@ -475,7 +529,7 @@ impl BlobData {
         // - chunks[i].chunk_data_digest bytes for each chunk
         // - versioned hash bytes
         // - challenge digest bytes
-        once(BlobDataRow {
+        once(BatchDataRow {
             preimage_rlc: Value::known(Fr::zero()),
             digest_rlc: metadata_digest_rlc,
             // this is_padding assignment does not matter as we have already crossed the "chunk
@@ -489,7 +543,7 @@ impl BlobData {
                 .iter()
                 .zip_eq(self.chunk_sizes.iter())
                 .enumerate()
-                .map(|(i, (&digest_rlc, &chunk_size))| BlobDataRow {
+                .map(|(i, (&digest_rlc, &chunk_size))| BatchDataRow {
                     preimage_rlc: Value::known(Fr::zero()),
                     digest_rlc,
                     chunk_idx: (i + 1) as u64,
@@ -498,26 +552,26 @@ impl BlobData {
                 }),
         )
         // versioned hash RLC
-        .chain(once(BlobDataRow {
+        .chain(once(BatchDataRow {
             preimage_rlc: Value::known(Fr::zero()),
             digest_rlc: versioned_hash_rlc,
             ..Default::default()
         }))
-        .chain(once(BlobDataRow {
+        .chain(once(BatchDataRow {
             preimage_rlc: challenge_digest_preimage_rlc,
             digest_rlc: challenge_digest_rlc,
             accumulator: 32 * (MAX_AGG_SNARKS + 1 + 1) as u64,
             is_boundary: true,
             ..Default::default()
         }))
-        .chain(metadata_digest.iter().map(|&byte| BlobDataRow {
+        .chain(metadata_digest.iter().map(|&byte| BatchDataRow {
             preimage_rlc: Value::known(Fr::zero()),
             digest_rlc: Value::known(Fr::zero()),
             byte,
             ..Default::default()
         }))
         .chain(chunk_digests.iter().flat_map(|digest| {
-            digest.iter().map(|&byte| BlobDataRow {
+            digest.iter().map(|&byte| BatchDataRow {
                 preimage_rlc: Value::known(Fr::zero()),
                 digest_rlc: Value::known(Fr::zero()),
                 byte,
@@ -525,13 +579,13 @@ impl BlobData {
             })
         }))
         // bytes of versioned hash
-        .chain(versioned_hash.as_bytes().iter().map(|&byte| BlobDataRow {
+        .chain(versioned_hash.as_bytes().iter().map(|&byte| BatchDataRow {
             preimage_rlc: Value::known(Fr::zero()),
             digest_rlc: Value::known(Fr::zero()),
             byte,
             ..Default::default()
         }))
-        .chain(challenge_digest.iter().map(|&byte| BlobDataRow {
+        .chain(challenge_digest.iter().map(|&byte| BatchDataRow {
             preimage_rlc: Value::known(Fr::zero()),
             digest_rlc: Value::known(Fr::zero()),
             byte,
@@ -542,7 +596,7 @@ impl BlobData {
 }
 
 #[derive(Clone, Debug)]
-pub struct BlobAssignments {
+pub struct PointEvaluationAssignments {
     /// The random challenge scalar z.
     pub challenge: U256,
     /// The 32-bytes keccak digest for the challenge. We have the relation:
@@ -554,7 +608,7 @@ pub struct BlobAssignments {
     pub coefficients: [U256; BLOB_WIDTH],
 }
 
-impl Default for BlobAssignments {
+impl Default for PointEvaluationAssignments {
     fn default() -> Self {
         Self {
             challenge: U256::default(),
@@ -565,18 +619,18 @@ impl Default for BlobAssignments {
     }
 }
 
-impl From<&BlobData> for BlobAssignments {
-    fn from(blob: &BlobData) -> Self {
+impl From<&BatchData> for PointEvaluationAssignments {
+    fn from(batch_data: &BatchData) -> Self {
         // blob polynomial in evaluation form.
         //
         // also termed P(x)
-        let coefficients = blob.get_coefficients();
+        let coefficients = batch_data.get_coefficients();
         let coefficients_as_scalars = coefficients.map(|coeff| Scalar::from_raw(coeff.0));
 
         // challenge := challenge_digest % BLS_MODULUS
         //
         // also termed z
-        let challenge_digest = blob.get_challenge_digest();
+        let challenge_digest = batch_data.get_challenge_digest();
         let (_, challenge) = challenge_digest.div_mod(*BLS_MODULUS);
 
         // y = P(z)
@@ -595,7 +649,7 @@ impl From<&BlobData> for BlobAssignments {
 
 /// Witness row to the Blob Data Config.
 #[derive(Clone, Copy, Default, Debug)]
-pub struct BlobDataRow<Fr> {
+pub struct BatchDataRow<Fr> {
     /// Byte value at this row.
     pub byte: u8,
     /// Multi-purpose accumulator value.
@@ -612,7 +666,7 @@ pub struct BlobDataRow<Fr> {
     pub digest_rlc: Value<Fr>,
 }
 
-impl BlobDataRow<Fr> {
+impl BatchDataRow<Fr> {
     fn padding_row() -> Self {
         Self {
             is_padding: true,
@@ -685,26 +739,30 @@ mod tests {
         ]
         .iter()
         {
-            let blob: BlobData = tcase.into();
-            let blob_assignments = BlobAssignments::from(&blob);
+            let batch_data: BatchData = tcase.into();
+            let point_evaluation_assignments = PointEvaluationAssignments::from(&batch_data);
+            let versioned_hash = batch_data.get_versioned_hash();
             println!(
-                "{:60}: challenge (z) = {:0>64x}, evaluation (y) = {:0>64x}",
-                annotation, blob_assignments.challenge, blob_assignments.evaluation
+                "[[ {:60} ]]\nchallenge (z) = {:0>64x}, evaluation (y) = {:0>64x}, versioned hash = {:0>64x}\n\n",
+                annotation,
+                point_evaluation_assignments.challenge,
+                point_evaluation_assignments.evaluation,
+                versioned_hash,
             );
         }
     }
 
     #[test]
-    fn default_blob_data() {
+    fn default_batch_data() {
         let mut default_metadata = [0u8; 62];
         default_metadata[1] = 1;
         let default_metadata_digest = keccak256(default_metadata);
         let default_chunk_digests = [keccak256([]); MAX_AGG_SNARKS];
 
-        let default_blob = BlobData::default();
-        let versioned_hash = default_blob.get_versioned_hash();
+        let default_batch = BatchData::default();
+        let versioned_hash = default_batch.get_versioned_hash();
         assert_eq!(
-            default_blob.get_challenge_digest(),
+            default_batch.get_challenge_digest(),
             U256::from(keccak256(
                 default_metadata_digest
                     .into_iter()
@@ -713,14 +771,5 @@ mod tests {
                     .collect::<Vec<u8>>()
             )),
         )
-    }
-
-    #[test]
-    fn coefficients_endianness() {
-        // Check that the blob bytes are being packed into coefficients in big endian order.
-        let coefficients = BlobData::default().get_coefficients();
-
-        assert_eq!(coefficients[0], U256::one() << 232);
-        assert_eq!(coefficients[1..], vec![U256::zero(); BLOB_WIDTH - 1]);
     }
 }

--- a/aggregator/src/tests/blob.rs
+++ b/aggregator/src/tests/blob.rs
@@ -250,7 +250,8 @@ fn check_data(data: BatchData) -> Result<(), Vec<VerifyFailure>> {
 }
 
 fn check_circuit(circuit: &BlobCircuit) -> Result<(), Vec<VerifyFailure>> {
-    let k = 20;
+    // TODO: check where rows were not sufficient that we had to increase k from 20 to 21.
+    let k = 21;
     let mock_prover = MockProver::<Fr>::run(k, circuit, vec![]).expect("failed to run mock prover");
     mock_prover.verify_par()
 }

--- a/aggregator/src/tests/blob.rs
+++ b/aggregator/src/tests/blob.rs
@@ -3,11 +3,11 @@ use crate::{
         AssignedBarycentricEvaluationConfig, BarycentricEvaluationConfig, BlobDataConfig, RlcConfig,
     },
     blob::{
-        BlobAssignments, BlobData, N_BYTES_U256, N_ROWS_BLOB_DATA_CONFIG, N_ROWS_DATA,
+        BatchData, PointEvaluationAssignments, N_BYTES_U256, N_ROWS_BATCH_DATA_CONFIG, N_ROWS_DATA,
         N_ROWS_METADATA,
     },
     param::ConfigParams,
-    MAX_AGG_SNARKS,
+    BatchDataConfig, MAX_AGG_SNARKS,
 };
 use halo2_base::{
     gates::range::{RangeConfig, RangeStrategy},
@@ -26,7 +26,7 @@ use zkevm_circuits::{
 
 #[derive(Default)]
 struct BlobCircuit {
-    data: BlobData,
+    data: BatchData,
 
     overwrite_num_valid_chunks: bool,
     overwrite_challenge_digest: Option<usize>,
@@ -46,6 +46,7 @@ struct BlobConfig {
     keccak_table: KeccakTable,
 
     rlc: RlcConfig,
+    batch_data_config: BatchDataConfig,
     blob_data: BlobDataConfig,
     barycentric: BarycentricEvaluationConfig,
 }
@@ -79,13 +80,14 @@ impl Circuit<Fr> for BlobCircuit {
         let barycentric = BarycentricEvaluationConfig::construct(range);
 
         let challenge_expressions = challenges.exprs(meta);
-        let blob_data = BlobDataConfig::configure(
+        let batch_data_config = BatchDataConfig::configure(
             meta,
             challenge_expressions,
             u8_table,
             range_table,
             &keccak_table,
         );
+        let blob_data = BlobDataConfig::configure(meta, u8_table);
 
         BlobConfig {
             challenges,
@@ -93,6 +95,7 @@ impl Circuit<Fr> for BlobCircuit {
             keccak_table,
 
             rlc,
+            batch_data_config,
             blob_data,
             barycentric,
         }
@@ -128,12 +131,12 @@ impl Circuit<Fr> for BlobCircuit {
                     },
                 );
 
-                let blob = BlobAssignments::from(&self.data);
+                let point_eval = PointEvaluationAssignments::from(&self.data);
                 Ok(config.barycentric.assign(
                     &mut ctx,
-                    &blob.coefficients,
-                    blob.challenge_digest,
-                    blob.evaluation,
+                    &point_eval.coefficients,
+                    point_eval.challenge_digest,
+                    point_eval.evaluation,
                 ))
             },
         )?;
@@ -159,16 +162,25 @@ impl Circuit<Fr> for BlobCircuit {
             },
         )?;
 
-        config.blob_data.load_range_tables(&mut layouter)?;
+        config.batch_data_config.load_range_tables(&mut layouter)?;
+
+        config.blob_data.assign(
+            &mut layouter,
+            challenge_values,
+            &config.rlc,
+            &self.data,
+            &barycentric_assignments.barycentric_assignments,
+        )?;
 
         layouter.assign_region(
-            || "BlobDataConfig",
+            || "BatchDataConfig",
             |mut region| {
-                let assigned_rows =
-                    config
-                        .blob_data
-                        .assign_rows(&mut region, challenge_values, &self.data)?;
-                let assigned_blob_data_export = config.blob_data.assign_internal_checks(
+                let assigned_rows = config.batch_data_config.assign_rows(
+                    &mut region,
+                    challenge_values,
+                    &self.data,
+                )?;
+                let assigned_batch_data_export = config.batch_data_config.assign_internal_checks(
                     &mut region,
                     challenge_values,
                     &config.rlc,
@@ -196,18 +208,18 @@ impl Circuit<Fr> for BlobCircuit {
                     increment_cell(&mut region, &assigned_rows[i].is_padding)?;
                 }
                 if self.overwrite_num_valid_chunks {
-                    increment_cell(&mut region, &assigned_blob_data_export.num_valid_chunks)?;
+                    increment_cell(&mut region, &assigned_batch_data_export.num_valid_chunks)?;
                 }
                 if let Some(i) = self.overwrite_challenge_digest {
                     increment_cell(
                         &mut region,
-                        &assigned_rows[N_ROWS_BLOB_DATA_CONFIG - N_BYTES_U256 + i].byte,
+                        &assigned_rows[N_ROWS_BATCH_DATA_CONFIG - N_BYTES_U256 + i].byte,
                     )?;
                 }
                 if let Some((i, j)) = self.overwrite_chunk_data_digests {
                     increment_cell(
                         &mut region,
-                        &assigned_blob_data_export.chunk_data_digests[i][j],
+                        &assigned_batch_data_export.chunk_data_digests[i][j],
                     )?;
                 }
                 Ok(())
@@ -229,7 +241,7 @@ fn increment_cell(
     )
 }
 
-fn check_data(data: BlobData) -> Result<(), Vec<VerifyFailure>> {
+fn check_data(data: BatchData) -> Result<(), Vec<VerifyFailure>> {
     let circuit = BlobCircuit {
         data,
         ..Default::default()
@@ -278,12 +290,12 @@ fn blob_circuit_completeness() {
         empty_and_nonempty_chunks,
         all_empty_except_last,
     ] {
-        assert_eq!(check_data(BlobData::from(&blob)), Ok(()), "{:?}", blob);
+        assert_eq!(check_data(BatchData::from(&blob)), Ok(()), "{:?}", blob);
     }
 }
 
-fn generic_blob_data() -> BlobData {
-    BlobData::from(&vec![
+fn generic_batch_data() -> BatchData {
+    BatchData::from(&vec![
         vec![3, 100, 24, 30],
         vec![],
         vec![100; 300],
@@ -295,34 +307,34 @@ fn generic_blob_data() -> BlobData {
 }
 
 #[test]
-fn generic_blob_data_is_valid() {
-    assert_eq!(check_data(generic_blob_data()), Ok(()));
+fn generic_batch_data_is_valid() {
+    assert_eq!(check_data(generic_batch_data()), Ok(()));
 }
 
 #[test]
 fn inconsistent_chunk_size() {
-    let mut blob_data = generic_blob_data();
+    let mut blob_data = generic_batch_data();
     blob_data.chunk_sizes[4] += 1;
     assert!(check_data(blob_data).is_err());
 }
 
 #[test]
 fn too_many_empty_chunks() {
-    let mut blob_data = generic_blob_data();
+    let mut blob_data = generic_batch_data();
     blob_data.num_valid_chunks += 1;
     assert!(check_data(blob_data).is_err());
 }
 
 #[test]
 fn too_few_empty_chunks() {
-    let mut blob_data = generic_blob_data();
+    let mut blob_data = generic_batch_data();
     blob_data.num_valid_chunks -= 1;
     assert!(check_data(blob_data).is_err());
 }
 
 #[test]
 fn inconsistent_chunk_bytes() {
-    let mut blob_data = generic_blob_data();
+    let mut blob_data = generic_batch_data();
     blob_data.chunk_data[0].push(128);
     assert!(check_data(blob_data).is_err());
 }
@@ -330,7 +342,7 @@ fn inconsistent_chunk_bytes() {
 #[test]
 fn overwrite_num_valid_chunks() {
     let circuit = BlobCircuit {
-        data: generic_blob_data(),
+        data: generic_batch_data(),
         overwrite_num_valid_chunks: true,
         ..Default::default()
     };
@@ -341,7 +353,7 @@ fn overwrite_num_valid_chunks() {
 fn overwrite_challenge_digest_byte() {
     for i in [0, 1, 10, 31] {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_challenge_digest: Some(i),
             ..Default::default()
         };
@@ -353,7 +365,7 @@ fn overwrite_challenge_digest_byte() {
 fn overwrite_chunk_data_digest_byte() {
     for indices in [(0, 0), (4, 30), (10, 31), (MAX_AGG_SNARKS - 1, 2)] {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_chunk_data_digests: Some(indices),
             ..Default::default()
         };
@@ -374,7 +386,7 @@ const OVERWRITE_ROWS: [usize; 6] = [
 fn overwrite_chunk_idx() {
     for row in OVERWRITE_ROWS {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_chunk_idx: Some(row),
             ..Default::default()
         };
@@ -386,7 +398,7 @@ fn overwrite_chunk_idx() {
 fn overwrite_accumulator() {
     for row in OVERWRITE_ROWS {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_accumulator: Some(row),
             ..Default::default()
         };
@@ -398,7 +410,7 @@ fn overwrite_accumulator() {
 fn overwrite_preimage_rlc() {
     for row in OVERWRITE_ROWS {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_preimage_rlc: Some(row),
             ..Default::default()
         };
@@ -410,7 +422,7 @@ fn overwrite_preimage_rlc() {
 fn overwrite_digest_rlc() {
     for row in OVERWRITE_ROWS {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_digest_rlc: Some(row),
             ..Default::default()
         };
@@ -422,7 +434,7 @@ fn overwrite_digest_rlc() {
 fn overwrite_is_boundary() {
     for row in OVERWRITE_ROWS {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_is_boundary: Some(row),
             ..Default::default()
         };
@@ -434,7 +446,7 @@ fn overwrite_is_boundary() {
 fn overwrite_is_padding() {
     for row in OVERWRITE_ROWS {
         let circuit = BlobCircuit {
-            data: generic_blob_data(),
+            data: generic_batch_data(),
             overwrite_is_padding: Some(row),
             ..Default::default()
         };


### PR DESCRIPTION
After DA-Compression:
- `BatchDataConfig` handles the raw batch bytes (metadata and chunk data)
- `BlobDataConfig` handles the `zstd` encoded batch bytes