### PR TITLE
L1geth support cancun time

### DIFF
--- a/geth-utils/l1geth/trace.go
+++ b/geth-utils/l1geth/trace.go
@@ -164,6 +164,7 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
+		CancunTime:          newUint64(0),
 	}
 
 	if config.ChainConfig != nil {
@@ -271,7 +272,8 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 			"prestateTracer": null
 		}
 		`, loggerConfig))
-		muxTracer, err := tracers.DefaultDirectory.New("muxTracer", new(tracers.Context), muxTracerConfig); if err != nil {
+		muxTracer, err := tracers.DefaultDirectory.New("muxTracer", new(tracers.Context), muxTracerConfig)
+		if err != nil {
 			return nil, err
 		}
 		evm := vm.NewEVM(blockCtx, txContext, stateDB, &chainConfig, vm.Config{Tracer: muxTracer.Hooks, NoBaseFee: true})


### PR DESCRIPTION
### Description
fix missing item in previous l1geth upgrading. 
trace add cancun time in chain config, otherwise cancun opcodes can not be recognized. 

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
