### PR TITLE
Sequence Decoding and Execution

### DIFF
--- a/aggregator/src/aggregation/decoder/tables.rs
+++ b/aggregator/src/aggregation/decoder/tables.rs
@@ -18,9 +18,7 @@ pub use rom_fse_order::{FseTableKind, RomFseOrderTable, RomSequencesDataInterlea
 
 /// The fixed code to Baseline/NumBits for Literal Length.
 mod rom_sequence_codes;
-pub use rom_sequence_codes::{
-    LiteralLengthCodes, MatchLengthCodes, MatchOffsetCodes, RomSequenceCodes,
-};
+pub use rom_sequence_codes::RomSequenceCodes;
 
 /// Validate the following tag given the tag currently being processed.
 mod rom_tag;

--- a/aggregator/src/aggregation/decoder/tables.rs
+++ b/aggregator/src/aggregation/decoder/tables.rs
@@ -14,7 +14,7 @@ pub use literals_header::LiteralsHeaderTable;
 
 /// Validate the assignment of FSE table kind while decoding FSE tables in the sequences section.
 mod rom_fse_order;
-pub use rom_fse_order::RomFseOrderTable;
+pub use rom_fse_order::{FseTableKind, RomFseOrderTable, RomSequencesDataInterleavedOrder};
 
 /// The fixed code to Baseline/NumBits for Literal Length.
 mod rom_sequence_codes;

--- a/aggregator/src/aggregation/decoder/tables/fse.rs
+++ b/aggregator/src/aggregation/decoder/tables/fse.rs
@@ -593,4 +593,16 @@ impl FseTable {
             meta.query_advice(self.is_padding, Rotation::cur()),
         ]
     }
+
+    /// Lookup table expressions for (table_kind, table_size) to know that the FSE decoder values
+    /// were correctly populated even at the "init-state" stage.
+    pub fn table_exprs_metadata(&self, meta: &mut VirtualCells<Fr>) -> Vec<Expression<Fr>> {
+        vec![
+            meta.query_fixed(self.q_first, Rotation::cur()),
+            meta.query_advice(self.block_idx, Rotation::cur()),
+            meta.query_advice(self.table_kind, Rotation::cur()),
+            meta.query_advice(self.table_size, Rotation::cur()),
+            meta.query_advice(self.is_padding, Rotation::cur()),
+        ]
+    }
 }

--- a/aggregator/src/aggregation/decoder/tables/fse.rs
+++ b/aggregator/src/aggregation/decoder/tables/fse.rs
@@ -1,5 +1,4 @@
 use gadgets::{
-    comparator::{ComparatorChip, ComparatorConfig},
     is_equal::{IsEqualChip, IsEqualConfig},
     util::{and, not, select, Expr},
 };
@@ -16,12 +15,740 @@ use zkevm_circuits::{
 
 use crate::aggregation::decoder::tables::rom_fse_order::{FseTableKind, RomFseTableTransition};
 
-/// An auxiliary table used to ensure that the FSE table was reconstructed appropriately. Contrary
-/// to the FseTable where the state is incremental, in the Auxiliary table we club together rows by
-/// symbol. Which means, we will have rows with symbol s0 (and varying, but not necessarily
-/// incremental states) clubbed together, followed by symbol s1 and so on.
+/// The FSE table verifies that given the symbols and the states allocated to those symbols, the
+/// baseline and number of bits (nb) are assigned correctly to them.
+///
+/// The FSE table's layout is setup in a specific order, so that we cannot specify multiple FSE
+/// table's of the same kind at the same block index. Every block has 3 FSE tables, namely for
+/// Literal Length (LLT), Match Offset (MOT) and Match Length (MLT). They appear in the below
+/// order:
+///
+/// - block_idx=1, table_kind=LLT
+/// - block_idx=1, table_kind=MOT
+/// - block_idx=1, table_kind=MLT
+/// - block_idx=2, table_kind=LLT
+/// - ... and so on
+///
+/// Each table spans over a maximum of 1024 rows, and the start of an FSE table is marked by the
+/// fixed column ``q_start``. Upon finishing the FSE table, remaining rows are marked with the
+/// ``is_padding`` column.
+///
+/// Each table begins with symbols that have a "less than 1" probability, whereby the state
+/// allocated to them is at the end of the table (highest state) and retreating. For example, if
+/// the symbol=3 has a normalised probability of prob==-1, then it is allocated the state 0x3f (63)
+/// in an FSE table of accuracy_log=6. For subsequent symbols that have a prob>1, the state=0x3f is
+/// skipped and we continue the same computation for the next successive state:
+///
+/// - state'  == state'' & (table_size - 1)
+/// - state'' == state + (table_size >> 3) + (table_size >> 1) + 3
+///
+/// where state' signifies the next state.
+///
+/// We cannot anticipate how many times we end up on such a "skipped" (or pre-allocated) state
+/// while computing the states for a symbol, so we mark such rows with the boolean column
+/// ``is_skipped_state``. On these rows, the ``state`` should have been taken by a
+/// ``is_prob_less_than1`` symbol that reads AL number of bits at a baseline of 0x00.
+///
+/// | State | Symbol | is_prob_less_than1 |
+/// |-------|--------|--------------------|
+/// | 0     | 0      | 0                  | <- q_first
+/// |-------|--------|--------------------|
+/// | 0x3f  | 3      | 1                  | <- q_start
+/// | 0x3e  | 4      | 1                  |
+/// | 0x00  | 0      | 0                  |
+/// | ...   | 0      | 0                  |
+/// | 0x1d  | 0      | 0                  |
+/// | 0x03  | 1  ->  | 0                  |
+/// | 0x0c  | 1  ->  | 0                  |
+/// | 0x11  | 1  ->  | 0                  |
+/// | 0x15  | 1  ->  | 0                  |
+/// | 0x1a  | 1  ->  | 0                  |
+/// | 0x1e  | 1  ->  | 0                  |
+/// | 0x08  | 2      | 0                  |
+/// | ...   | ...    | 0                  |
+/// | 0x09  | 6      | 0                  |
+/// | 0x00  | 0      | 0                  | <- is_padding
+/// | ...   | ...    | 0                  | <- is_padding
+/// | 0x00  | 0      | 0                  | <- is_padding
+/// |-------|--------|--------------------|
+/// | ...   | ...    | ...                | <- q_start
+/// |-------|--------|--------------------|
+///
+/// For more details, refer the [FSE reconstruction][doclink] section.
+///
+/// [doclink]: https://nigeltao.github.io/blog/2022/zstandard-part-5-fse.html#fse-reconstruction
+#[derive(Clone, Debug)]
+pub struct FseTable {
+    /// The helper table to validate that the (baseline, nb) were assigned correctly to each state.
+    fse_sorted_states_table: FseSortedStatesTable,
+    /// A boolean to mark whether this row represents a symbol with probability "less than 1".
+    is_prob_less_than1: Column<Advice>,
+    /// Boolean column to mark whether the row is a padded row.
+    is_padding: Column<Advice>,
+    /// Helper column for (table_size >> 1).
+    table_size_rs_1: Column<Advice>,
+    /// Helper column for (table_size >> 3).
+    table_size_rs_3: Column<Advice>,
+    /// Incremental index given to a state, idx in 1..=table_size.
+    idx: Column<Advice>,
+    /// The FSE symbol, starting at symbol=0.
+    symbol: Column<Advice>,
+    /// Boolean column to tell us when symbol is changing.
+    is_new_symbol: Column<Advice>,
+    /// Represents the number of times this symbol appears in the FSE table. This value does not
+    /// change while the symbol in the table remains the same.
+    symbol_count: Column<Advice>,
+    /// An accumulator that resets to 1 each time we encounter a new symbol in the FSE table.
+    /// It increments while the symbol remains the same if we are not skipping the state. When we
+    /// encounter a new symbol, we validate that on the previous row, symbol_count equaled
+    /// symbol_count_acc.
+    symbol_count_acc: Column<Advice>,
+    /// The state in FSE. In the Auxiliary table, it does not increment by 1. Instead, it follows:
+    ///
+    /// - state'' == state   + table_size_rs_1 + table_size_rs_3 + 3
+    /// - state'  == state'' & (table_size - 1)
+    ///
+    /// where state' is the next row's state.
+    state: Column<Advice>,
+    /// Boolean column to mark if the computed state must be "skipped" because it was
+    /// pre-allocated to one of the symbols with a "less than 1" probability.
+    is_skipped_state: Column<Advice>,
+    /// The assigned baseline for this state.
+    baseline: Column<Advice>,
+    /// The number of bits to read from bitstream when at this state.
+    nb: Column<Advice>,
+    /// ROM table for verifying FSE table kind and block_idx transition.
+    rom_fse_transition: RomFseTableTransition,
+}
+
+impl FseTable {
+    /// Configure the FSE table.
+    pub fn configure(
+        meta: &mut ConstraintSystem<Fr>,
+        u8_table: U8Table,
+        range8_table: RangeTable<8>,
+        pow2_table: Pow2Table<20>,
+        bitwise_op_table: BitwiseOpTable,
+    ) -> Self {
+        // Fixed table to check the transition of table kinds and block idx.
+        let rom_fse_transition = RomFseTableTransition::construct(meta);
+
+        // Auxiliary table to validate that (baseline, nb) were assigned correctly to the states
+        // allocated to a symbol.
+        let fse_sorted_states_table = FseSortedStatesTable::configure(meta, pow2_table, u8_table);
+
+        let config = Self {
+            fse_sorted_states_table,
+            is_prob_less_than1: meta.advice_column(),
+            is_padding: meta.advice_column(),
+            table_size_rs_1: meta.advice_column(),
+            table_size_rs_3: meta.advice_column(),
+            idx: meta.advice_column(),
+            symbol: meta.advice_column(),
+            is_new_symbol: meta.advice_column(),
+            symbol_count: meta.advice_column(),
+            symbol_count_acc: meta.advice_column(),
+            state: meta.advice_column(),
+            is_skipped_state: meta.advice_column(),
+            baseline: meta.advice_column(),
+            nb: meta.advice_column(),
+            rom_fse_transition,
+        };
+
+        // Check that on the starting row of each FSE table, i.e. q_start=true:
+        // - table_size_rs_3 == table_size >> 3.
+        meta.lookup("FseTable: table_size >> 3", |meta| {
+            let condition = and::expr([
+                meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
+
+            let range_value = meta
+                .query_advice(config.fse_sorted_states_table.table_size, Rotation::cur())
+                - (meta.query_advice(config.table_size_rs_3, Rotation::cur()) * 8.expr());
+
+            vec![(condition * range_value, range8_table.into())]
+        });
+
+        // Every FSE symbol is a byte.
+        meta.lookup("FseTable: symbol in [0, 256)", |meta| {
+            vec![(
+                meta.query_advice(config.symbol, Rotation::cur()),
+                u8_table.into(),
+            )]
+        });
+
+        // The first row of the FseTable layout, i.e. q_first=true.
+        meta.create_gate("FseTable: first row", |meta| {
+            let condition =
+                meta.query_fixed(config.fse_sorted_states_table.q_first, Rotation::cur());
+
+            let mut cb = BaseConstraintBuilder::default();
+
+            // The first row is all 0s. This is then followed by a q_start==1 fixed column. We want
+            // to make sure the first FSE table belongs to block_idx=1.
+            cb.require_equal(
+                "block_idx == 1 for the first FSE table",
+                meta.query_advice(config.fse_sorted_states_table.block_idx, Rotation::next()),
+                1.expr(),
+            );
+
+            // The first FSE table described should be the LLT table.
+            cb.require_equal(
+                "table_kind == LLT for the first FSE table",
+                meta.query_advice(config.fse_sorted_states_table.table_kind, Rotation::next()),
+                FseTableKind::LLT.expr(),
+            );
+
+            cb.gate(condition)
+        });
+
+        // Check that on the starting row of every FSE table, i.e. q_start=true:
+        //
+        // - tuple (block_idx::prev, block_idx::cur, table_kind::prev, table_kind::cur)
+        //
+        // is in fact a valid transition. All valid transitions are provided in the fixed-table
+        // RomFseTableTransition.
+        meta.lookup_any(
+            "FseSortedStatesTable: start row (ROM block_idx and table_kind transition)",
+            |meta| {
+                let condition = and::expr([
+                    meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                    not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+                ]);
+
+                let (block_idx_prev, block_idx_curr, table_kind_prev, table_kind_curr) = (
+                    meta.query_advice(config.fse_sorted_states_table.block_idx, Rotation::prev()),
+                    meta.query_advice(config.fse_sorted_states_table.block_idx, Rotation::cur()),
+                    meta.query_advice(config.fse_sorted_states_table.table_kind, Rotation::prev()),
+                    meta.query_advice(config.fse_sorted_states_table.table_kind, Rotation::cur()),
+                );
+
+                [
+                    block_idx_prev,
+                    block_idx_curr,
+                    table_kind_prev,
+                    table_kind_curr,
+                ]
+                .into_iter()
+                .zip_eq(config.rom_fse_transition.table_exprs(meta))
+                .map(|(arg, table)| (condition.expr() * arg, table))
+                .collect()
+            },
+        );
+
+        // The starting row of every FSE table, i.e. q_start=true.
+        meta.create_gate("FseTable: start row", |meta| {
+            let condition = and::expr([
+                meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
+
+            let mut cb = BaseConstraintBuilder::default();
+
+            let is_prob_less_than1 = meta.query_advice(config.is_prob_less_than1, Rotation::cur());
+            cb.require_boolean("prob=-1 is boolean", is_prob_less_than1.expr());
+
+            // 1. If we start with a symbol that has prob "less than 1"
+            cb.condition(is_prob_less_than1.expr(), |cb| {
+                cb.require_equal(
+                    "prob=-1: state inits at table_size - 1",
+                    meta.query_advice(config.state, Rotation::cur()),
+                    meta.query_advice(config.fse_sorted_states_table.table_size, Rotation::cur())
+                        - 1.expr(),
+                );
+            });
+
+            // 2. If no symbol has a prob "less than 1"
+            cb.condition(not::expr(is_prob_less_than1), |cb| {
+                cb.require_zero(
+                    "state inits at 0",
+                    meta.query_advice(config.state, Rotation::cur()),
+                );
+            });
+
+            cb.require_equal(
+                "idx == 1",
+                meta.query_advice(config.idx, Rotation::cur()),
+                1.expr(),
+            );
+
+            // table_size_rs_1 == table_size >> 1.
+            cb.require_boolean(
+                "table_size >> 1",
+                meta.query_advice(config.fse_sorted_states_table.table_size, Rotation::cur())
+                    - (meta.query_advice(config.table_size_rs_1, Rotation::cur()) * 2.expr()),
+            );
+
+            // The start row is a new symbol.
+            cb.require_equal(
+                "is_new_symbol==true",
+                meta.query_advice(config.is_new_symbol, Rotation::cur()),
+                1.expr(),
+            );
+
+            cb.gate(condition)
+        });
+
+        // For every symbol that has a normalised probability prob=-1.
+        meta.lookup_any("FseTable: all symbols with prob=-1 (nb==AL)", |meta| {
+            let condition = meta.query_advice(config.is_prob_less_than1, Rotation::cur());
+
+            // for a symbol with prob=-1, we do a full state reset, i.e.
+            // read nb=AL bits, i.e. 1 << nb == table_size.
+            [
+                meta.query_advice(config.nb, Rotation::cur()),
+                meta.query_advice(config.fse_sorted_states_table.table_size, Rotation::cur()),
+            ]
+            .into_iter()
+            .zip_eq(pow2_table.table_exprs(meta))
+            .map(|(arg, table)| (condition.expr() * arg, table))
+            .collect()
+        });
+
+        // For every symbol that has a normalised probability prob=-1.
+        meta.create_gate("FseTable: all symbols with prob=-1", |meta| {
+            let condition = meta.query_advice(config.is_prob_less_than1, Rotation::cur());
+
+            let mut cb = BaseConstraintBuilder::default();
+
+            // Each such row is a new symbol.
+            cb.require_equal(
+                "prob=-1: is_new_symbol==true",
+                meta.query_advice(config.is_new_symbol, Rotation::cur()),
+                1.expr(),
+            );
+
+            // prob=-1 indicates a baseline==0x00.
+            cb.require_zero(
+                "prob=-1: baseline==0x00",
+                meta.query_advice(config.baseline, Rotation::cur()),
+            );
+
+            // prob=-1 symbol cannot be padding.
+            cb.require_zero(
+                "prob=-1: is_padding==false",
+                meta.query_advice(config.is_padding, Rotation::cur()),
+            );
+
+            // prob=-1 symbol is not a skipped state.
+            cb.require_zero(
+                "prob=-1: is_skipped_state=false",
+                meta.query_advice(config.is_skipped_state, Rotation::cur()),
+            );
+
+            cb.gate(condition)
+        });
+
+        // Symbols with prob=-1 are in increasing order.
+        meta.lookup(
+            "FseTable: subsequent symbols with prob=-1 (symbol increasing)",
+            |meta| {
+                let condition = and::expr([
+                    not::expr(
+                        meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                    ),
+                    meta.query_advice(config.is_prob_less_than1, Rotation::cur()),
+                ]);
+
+                // Symbols with prob=-1 are assigned cells from the end (state==table_size-1) and
+                // retreating. However those symbols are processed in natural order, i.e. symbols
+                // are in increasing order.
+                //
+                // - symbol::cur - symbol::prev > 0
+                //
+                // We check that (symbol - symbol_prev - 1) lies in the [0, 256) range.
+                let (symbol_curr, symbol_prev) = (
+                    meta.query_advice(config.symbol, Rotation::cur()),
+                    meta.query_advice(config.symbol, Rotation::prev()),
+                );
+                let delta = symbol_curr - symbol_prev - 1.expr();
+
+                vec![(condition * delta, u8_table.into())]
+            },
+        );
+
+        // Symbols with prob=-1 are assigned states from the end and retreating.
+        meta.create_gate(
+            "FseTable: subsequent symbols with prob=-1 (state retreating)",
+            |meta| {
+                let condition = and::expr([
+                    not::expr(
+                        meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                    ),
+                    meta.query_advice(config.is_prob_less_than1, Rotation::cur()),
+                ]);
+
+                let mut cb = BaseConstraintBuilder::default();
+
+                // While prob=-1, state is retreating, i.e. decrements by 1.
+                cb.require_equal(
+                    "state == state::prev - 1",
+                    meta.query_advice(config.state, Rotation::cur()),
+                    meta.query_advice(config.state, Rotation::prev()) - 1.expr(),
+                );
+
+                cb.gate(condition)
+            },
+        );
+
+        // Symbols with prob>=1 are also in increasing order. We skip this check if this is the
+        // first symbol with prob>=1.
+        meta.lookup(
+            "FseTable: symbols with prob>=1 (symbol increasing)",
+            |meta| {
+                let condition = and::expr([
+                    not::expr(
+                        meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                    ),
+                    not::expr(meta.query_advice(config.is_prob_less_than1, Rotation::prev())),
+                    meta.query_advice(config.is_new_symbol, Rotation::cur()),
+                ]);
+
+                // Whenever we move to a new symbol (is_new_symbol=true), excluding the first symbol
+                // with prob>=1, the symbol is increasing.
+                //
+                // - symbol::cur - symbol::prev > 0
+                //
+                // We check that (symbol - symbol_prev - 1) lies in the [0, 256) range.
+                let (symbol_curr, symbol_prev) = (
+                    meta.query_advice(config.symbol, Rotation::cur()),
+                    meta.query_advice(config.symbol, Rotation::prev()),
+                );
+                let delta = symbol_curr - symbol_prev - 1.expr();
+
+                vec![(condition * delta, u8_table.into())]
+            },
+        );
+
+        // Symbols with prob>=1 continue the same symbol if not a new symbol.
+        meta.create_gate("FseTable: symbols with prob>=1", |meta| {
+            let condition = and::expr([
+                not::expr(
+                    meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                ),
+                not::expr(meta.query_advice(config.is_prob_less_than1, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
+
+            let mut cb = BaseConstraintBuilder::default();
+
+            // When we are not seeing a new symbol, make sure the symbol is equal to the symbol on
+            // the previous row.
+            let is_not_new_symbol =
+                not::expr(meta.query_advice(config.is_new_symbol, Rotation::cur()));
+            cb.condition(is_not_new_symbol, |cb| {
+                cb.require_equal(
+                    "prob>=1: same symbol",
+                    meta.query_advice(config.symbol, Rotation::cur()),
+                    meta.query_advice(config.symbol, Rotation::prev()),
+                );
+            });
+
+            cb.gate(condition)
+        });
+
+        // All rows in an instance of FSE table, except the starting row (q_start=true).
+        meta.create_gate("FseTable: every FSE table (except q_start=1)", |meta| {
+            let condition = not::expr(
+                meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+            );
+
+            let mut cb = BaseConstraintBuilder::default();
+
+            // FSE table's columns that remain unchanged.
+            for column in [config.table_size_rs_1, config.table_size_rs_3] {
+                cb.require_equal(
+                    "FseTable: columns that remain unchanged",
+                    meta.query_advice(column, Rotation::cur()),
+                    meta.query_advice(column, Rotation::prev()),
+                );
+            }
+
+            // The symbols with prob "less than 1" are assigned at the starting rows of the FSE
+            // table with maximum (and retreating) state values.
+            let (is_prob_less_than1_prev, is_prob_less_than1_curr) = (
+                meta.query_advice(config.is_prob_less_than1, Rotation::prev()),
+                meta.query_advice(config.is_prob_less_than1, Rotation::cur()),
+            );
+            let delta = is_prob_less_than1_prev - is_prob_less_than1_curr.expr();
+            cb.require_boolean("prob=-1 is boolean", is_prob_less_than1_curr);
+            cb.require_boolean("prob=-1 symbols occur in the start of the layout", delta);
+
+            // Once we enter padding territory, we stay in padding territory, i.e.
+            // is_padding transitions from 0 -> 1 only once.
+            let (is_padding_curr, is_padding_prev) = (
+                meta.query_advice(config.is_padding, Rotation::cur()),
+                meta.query_advice(config.is_padding, Rotation::prev()),
+            );
+            let is_padding_delta = is_padding_curr.expr() - is_padding_prev.expr();
+            cb.require_boolean("is_padding is boolean", is_padding_curr.expr());
+            cb.require_boolean("is_padding_delta is boolean", is_padding_delta);
+
+            // If we are not in the padding region and don't skip state on this row, then this is a
+            // new state in the FSE table, i.e. idx increments.
+            let is_skipped_state = meta.query_advice(config.is_skipped_state, Rotation::cur());
+            cb.require_equal(
+                "idx increments in non-padding region if we don't skip state",
+                meta.query_advice(config.idx, Rotation::cur()),
+                select::expr(
+                    and::expr([
+                        not::expr(is_padding_curr.expr()),
+                        not::expr(is_skipped_state),
+                    ]),
+                    meta.query_advice(config.idx, Rotation::prev()) + 1.expr(),
+                    meta.query_advice(config.idx, Rotation::prev()),
+                ),
+            );
+
+            // If we are entering the padding region on this row, the idx on the previous row must
+            // equal the table size, i.e. all states must be generated.
+            cb.condition(
+                and::expr([not::expr(is_padding_prev), is_padding_curr]),
+                |cb| {
+                    cb.require_equal(
+                        "idx == table_size on the last state",
+                        meta.query_advice(config.idx, Rotation::prev()),
+                        meta.query_advice(
+                            config.fse_sorted_states_table.table_size,
+                            Rotation::prev(),
+                        ),
+                    );
+                },
+            );
+
+            cb.gate(condition)
+        });
+
+        // A state is skipped only if that state was pre-allocated to a symbol with prob=-1.
+        meta.lookup_any("FseTable: skipped state", |meta| {
+            let condition = meta.query_advice(config.is_skipped_state, Rotation::cur());
+
+            // A state can be skipped only if it was pre-allocated to a symbol with prob=-1. So we
+            // check that there exists a row with the same block_idx, table_kind and the skipped
+            // state with a prob=-1.
+            let fse_table_exprs = [
+                meta.query_advice(config.fse_sorted_states_table.block_idx, Rotation::cur()),
+                meta.query_advice(config.fse_sorted_states_table.table_kind, Rotation::cur()),
+                meta.query_advice(config.state, Rotation::cur()),
+                meta.query_advice(config.is_prob_less_than1, Rotation::cur()),
+            ];
+
+            [
+                meta.query_advice(config.fse_sorted_states_table.block_idx, Rotation::cur()),
+                meta.query_advice(config.fse_sorted_states_table.table_kind, Rotation::cur()),
+                meta.query_advice(config.state, Rotation::cur()),
+                1.expr(), // prob=-1
+            ]
+            .into_iter()
+            .zip_eq(fse_table_exprs)
+            .map(|(arg, table)| (condition.expr() * arg, table))
+            .collect()
+        });
+
+        // For every symbol with prob>=1 and a valid state allocated, we check that the baseline
+        // and nb fields were assigned correctly.
+        meta.lookup_any(
+            "FseTable: assigned state (baseline, nb) validation",
+            |meta| {
+                let condition = and::expr([
+                    not::expr(meta.query_advice(config.is_prob_less_than1, Rotation::cur())),
+                    not::expr(meta.query_advice(config.is_skipped_state, Rotation::cur())),
+                    not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+                ]);
+
+                let (block_idx, table_kind, table_size, state, symbol, symbol_count, baseline, nb) = (
+                    meta.query_advice(config.fse_sorted_states_table.block_idx, Rotation::cur()),
+                    meta.query_advice(config.fse_sorted_states_table.table_kind, Rotation::cur()),
+                    meta.query_advice(config.fse_sorted_states_table.table_size, Rotation::cur()),
+                    meta.query_advice(config.state, Rotation::cur()),
+                    meta.query_advice(config.symbol, Rotation::cur()),
+                    meta.query_advice(config.symbol_count, Rotation::cur()),
+                    meta.query_advice(config.baseline, Rotation::cur()),
+                    meta.query_advice(config.nb, Rotation::cur()),
+                );
+
+                [
+                    block_idx,
+                    table_kind,
+                    table_size,
+                    state,
+                    symbol,
+                    symbol_count,
+                    baseline,
+                    nb,
+                    0.expr(),
+                ]
+                .into_iter()
+                .zip_eq(config.fse_sorted_states_table.table_exprs(meta))
+                .map(|(arg, table)| (condition.expr() * arg, table))
+                .collect()
+            },
+        );
+
+        // For every new symbol detected.
+        meta.create_gate("FseTable: new symbol", |meta| {
+            let condition = and::expr([
+                meta.query_advice(config.is_new_symbol, Rotation::cur()),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
+
+            let mut cb = BaseConstraintBuilder::default();
+
+            // We first do validations for the previous symbol.
+            //
+            // - symbol_count_acc accumulated to symbol_count.
+            //
+            // This is also expected to pass on the starting row of each FSE table, since the
+            // previous row is either q_first=true or is_padding=true, where in both
+            // cases we expect:
+            // - symbol_count == symbol_count_acc == 0.
+            cb.require_equal(
+                "symbol_count == symbol_count_acc",
+                meta.query_advice(config.symbol_count, Rotation::prev()),
+                meta.query_advice(config.symbol_count_acc, Rotation::prev()),
+            );
+
+            // The symbol_count_acc inits at 1.
+            cb.require_equal(
+                "symbol_count_acc inits at 1",
+                meta.query_advice(config.symbol_count_acc, Rotation::cur()),
+                1.expr(),
+            );
+
+            cb.gate(condition)
+        });
+
+        // Whenever we continue allocating states to the same symbol.
+        meta.create_gate("FseTable: same symbol, transitioned state", |meta| {
+            let condition = and::expr([
+                not::expr(meta.query_advice(config.is_new_symbol, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
+
+            let mut cb = BaseConstraintBuilder::default();
+
+            // While we allocate more states to the same symbol:
+            //
+            // - symbol_count does not change
+            cb.require_equal(
+                "if symbol continues: symbol_count unchanged",
+                meta.query_advice(config.symbol_count, Rotation::cur()),
+                meta.query_advice(config.symbol_count, Rotation::prev()),
+            );
+
+            // symbol count accumulator increments if the state is not skipped.
+            cb.require_equal(
+                "symbol_count_acc increments if state not skipped",
+                meta.query_advice(config.symbol_count_acc, Rotation::cur()),
+                select::expr(
+                    meta.query_advice(config.is_skipped_state, Rotation::cur()),
+                    meta.query_advice(config.symbol_count_acc, Rotation::prev()),
+                    meta.query_advice(config.symbol_count_acc, Rotation::prev()) + 1.expr(),
+                ),
+            );
+
+            cb.gate(condition)
+        });
+
+        // Constraint for state' calculation. We wish to constrain:
+        //
+        // - state' == state'' & (table_size - 1)
+        // - state'' == state + (table_size >> 3) + (table_size >> 1) + 3
+        meta.lookup_any("FseTable: state transition", |meta| {
+            let condition = and::expr([
+                not::expr(
+                    meta.query_fixed(config.fse_sorted_states_table.q_start, Rotation::cur()),
+                ),
+                not::expr(meta.query_advice(config.is_prob_less_than1, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
+
+            let state_prime = meta.query_advice(config.state, Rotation::cur());
+            let state_prime_prime = meta.query_advice(config.state, Rotation::prev())
+                + meta.query_advice(config.table_size_rs_3, Rotation::cur())
+                + meta.query_advice(config.table_size_rs_1, Rotation::cur())
+                + 3.expr();
+            let table_size_minus_one = meta
+                .query_advice(config.fse_sorted_states_table.table_size, Rotation::cur())
+                - 1.expr();
+
+            [
+                BitwiseOp::AND.expr(), // op
+                state_prime_prime,     // operand1
+                table_size_minus_one,  // operand2
+                state_prime,           // result
+            ]
+            .into_iter()
+            .zip_eq(bitwise_op_table.table_exprs(meta))
+            .map(|(arg, table)| (condition.expr() * arg, table))
+            .collect()
+        });
+
+        debug_assert!(meta.degree() <= 9);
+
+        config
+    }
+}
+
+impl FseTable {
+    /// Lookup table expressions for (state, symbol, baseline, nb) tuple check.
+    ///
+    /// This check can be done on any row within the FSE table.
+    pub fn table_exprs_by_state(&self, meta: &mut VirtualCells<Fr>) -> Vec<Expression<Fr>> {
+        vec![
+            meta.query_fixed(self.fse_sorted_states_table.q_first, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.block_idx, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.table_kind, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.table_size, Rotation::cur()),
+            meta.query_advice(self.state, Rotation::cur()),
+            meta.query_advice(self.symbol, Rotation::cur()),
+            meta.query_advice(self.baseline, Rotation::cur()),
+            meta.query_advice(self.nb, Rotation::cur()),
+            meta.query_advice(self.is_skipped_state, Rotation::cur()),
+            meta.query_advice(self.is_padding, Rotation::cur()),
+        ]
+    }
+
+    /// Lookup table expressions for (symbol, symbol_count) tuple check.
+    ///
+    /// This check is only done on the last occurence of a particular symbol, i.e. where:
+    /// - symbol_count == symbol_count_acc
+    pub fn table_exprs_by_symbol(&self, meta: &mut VirtualCells<Fr>) -> Vec<Expression<Fr>> {
+        vec![
+            meta.query_fixed(self.fse_sorted_states_table.q_first, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.block_idx, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.table_kind, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.table_size, Rotation::cur()),
+            meta.query_advice(self.symbol, Rotation::cur()),
+            meta.query_advice(self.symbol_count, Rotation::cur()),
+            meta.query_advice(self.symbol_count_acc, Rotation::cur()),
+            meta.query_advice(self.is_prob_less_than1, Rotation::cur()),
+            meta.query_advice(self.is_padding, Rotation::cur()),
+        ]
+    }
+
+    /// Lookup table expressions for (table_kind, table_size) to know that the FSE decoder values
+    /// were correctly populated even at the "init-state" stage.
+    pub fn table_exprs_metadata(&self, meta: &mut VirtualCells<Fr>) -> Vec<Expression<Fr>> {
+        vec![
+            meta.query_fixed(self.fse_sorted_states_table.q_first, Rotation::cur()),
+            meta.query_fixed(self.fse_sorted_states_table.q_start, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.block_idx, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.table_kind, Rotation::cur()),
+            meta.query_advice(self.fse_sorted_states_table.table_size, Rotation::cur()),
+            meta.query_advice(self.is_padding, Rotation::cur()),
+        ]
+    }
+}
+
+/// Contrary to the FSE table where states are allocated as per the state transition rules, in the
+/// FseSortedStatesTable, for every symbol with prob>=1 we sort its states in increasing order to
+/// appropriately compute the (baseline, nb) fields assigned to those states.
 ///
 /// | State | Symbol | Baseline | Nb  | Baseline Mark |
+/// |-------|--------|----------|-----|---------------|
+/// | 0     | 0      | 0        | 0   | 0             | <- q_first
 /// |-------|--------|----------|-----|---------------|
 /// | 0x00  | s0     | ...      | ... | 0             | <- q_start
 /// | 0x01  | s0     | ...      | ... | 0             |
@@ -40,16 +767,15 @@ use crate::aggregation::decoder::tables::rom_fse_order::{FseTableKind, RomFseTab
 /// | 0x00  | 0      | 0        | 0   | 0             | <- is_padding
 /// | ...   | ...    | ...      | ... | ...           | <- is_padding
 /// | 0x00  | 0      | 0        | 0   | 0             | <- is_padding
-///
-/// Above is a representation of this table. Primarily we are interested in verifying that:
-/// - next state (for the same symbol) was assigned correctly
-/// - the number of times this symbol appears is assigned correctly
+/// |-------|--------|----------|-----|---------------|
+/// | ...   | ...    | ...      | ... | ...           | <- q_start
+/// |-------|--------|----------|-----|---------------|
 ///
 /// For more details, refer the [FSE reconstruction][doclink] section.
 ///
 /// [doclink]: https://nigeltao.github.io/blog/2022/zstandard-part-5-fse.html#fse-reconstruction
 #[derive(Clone, Debug)]
-pub struct FseTable {
+struct FseSortedStatesTable {
     /// Fixed column to mark the first row of the FSE table layout. We reserve the first row to
     /// populate all 0s. q_start=1 starts from the second row onwards.
     q_first: Column<Fixed>,
@@ -59,47 +785,35 @@ pub struct FseTable {
     /// indicate the start of a new FSE table. Within an FSE table, we will only have rows up to
     /// table_size (1 << AL), and the rest of the rows will be marked with is_padding=1.
     q_start: Column<Fixed>,
-    /// Boolean column to mark whether the row is a padded row.
-    is_padding: Column<Advice>,
     /// The block index in which this FSE table is found.
     block_idx: Column<Advice>,
     /// The table kind, i.e. LLT=1, MOT=2 or MLT=3.
     table_kind: Column<Advice>,
-    /// The size of the FSE table.
+    /// The number of states in the FSE table, i.e. 1 << AL.
     table_size: Column<Advice>,
-    /// Helper column for (table_size >> 1).
-    table_size_rs_1: Column<Advice>,
-    /// Helper column for (table_size >> 3).
-    table_size_rs_3: Column<Advice>,
-    /// Incremental index given to a state, idx in 1..=table_size.
-    idx: Column<Advice>,
-    /// The FSE symbol, starting at symbol=0.
+    /// The FSE symbol, starting at the first symbol with prob>=1.
     symbol: Column<Advice>,
-    /// Helper gadget to know whether the symbol is the same or not.
-    symbol_cmp: ComparatorConfig<Fr, 1>,
-    /// Boolean column to tell us when symbol is changing.
-    is_symbol_change: Column<Advice>,
+    /// Boolean column to mark if we are moving to the next symbol.
+    is_new_symbol: Column<Advice>,
     /// Represents the number of times this symbol appears in the FSE table. This value does not
     /// change while the symbol in the table remains the same.
     symbol_count: Column<Advice>,
     /// An accumulator that resets to 1 each time we encounter a new symbol in the FSE table.
-    /// It increments while the symbol remains the same. At the row where we encounter a symbol
-    /// change, such that: symbol' != symbol, we have: symbol_count == symbol_count_acc.
+    /// It increments while the symbol remains the same. When we encounter a new symbol, we
+    /// validate that on the previous row, symbol_count equaled symbol_count_acc.
     symbol_count_acc: Column<Advice>,
-    /// The state in FSE. In the Auxiliary table, it does not increment by 1. Instead, it follows:
-    /// - state'' == state   + table_size_rs_1 + table_size_rs_3 + 3
-    /// - state'  == state'' & (table_size - 1)
-    ///
-    /// where state' is the next row's state.
+    /// The state in FSE. In this table the state is in increasing order for each symbol.
     state: Column<Advice>,
     /// Denotes the baseline field.
     baseline: Column<Advice>,
+    /// The number of bits to be read from bitstream at this state.
+    nb: Column<Advice>,
+    /// Boolean column to mark whether the row is a padded row.
+    is_padding: Column<Advice>,
     /// Helper gadget to compute whether baseline==0x00.
     baseline_0x00: IsEqualConfig<Fr>,
     /// Helper column to mark the baseline observed at the last state allocated to a symbol.
     last_baseline: Column<Advice>,
-    /// The number of bits to be read from bitstream at this state.
-    nb: Column<Advice>,
     /// The smaller power of two assigned to this state. The following must hold:
     /// - 2 ^ nb == SPoT.
     spot: Column<Advice>,
@@ -109,50 +823,30 @@ pub struct FseTable {
     smallest_spot: Column<Advice>,
     /// Helper boolean column which is set only from baseline == 0x00.
     baseline_mark: Column<Advice>,
-    /// ROM table for verifying FSE table kind and block_idx transition.
-    rom_fse_transition: RomFseTableTransition,
 }
 
-impl FseTable {
-    /// Configure the FSE table.
-    pub fn configure(
+impl FseSortedStatesTable {
+    fn configure(
         meta: &mut ConstraintSystem<Fr>,
-        u8_table: U8Table,
-        range8_table: RangeTable<8>,
         pow2_table: Pow2Table<20>,
-        bitwise_op_table: BitwiseOpTable,
+        u8_table: U8Table,
     ) -> Self {
-        // Fixed table to check the transition of table kinds and block idx.
-        let rom_fse_transition = RomFseTableTransition::construct(meta);
+        let (is_padding, baseline) = (meta.advice_column(), meta.advice_column());
 
-        let (is_padding, symbol, baseline) = (
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-        );
         let config = Self {
             q_first: meta.fixed_column(),
             q_start: meta.fixed_column(),
-            is_padding: meta.advice_column(),
             block_idx: meta.advice_column(),
             table_kind: meta.advice_column(),
             table_size: meta.advice_column(),
-            table_size_rs_1: meta.advice_column(),
-            table_size_rs_3: meta.advice_column(),
-            idx: meta.advice_column(),
-            symbol,
-            is_symbol_change: meta.advice_column(),
-            symbol_cmp: ComparatorChip::configure(
-                meta,
-                |meta| not::expr(meta.query_advice(is_padding, Rotation::prev())),
-                |meta| meta.query_advice(symbol, Rotation::prev()),
-                |meta| meta.query_advice(symbol, Rotation::cur()),
-                u8_table.into(),
-            ),
+            symbol: meta.advice_column(),
+            is_new_symbol: meta.advice_column(),
             symbol_count: meta.advice_column(),
             symbol_count_acc: meta.advice_column(),
             state: meta.advice_column(),
             baseline,
+            nb: meta.advice_column(),
+            is_padding,
             baseline_0x00: IsEqualChip::configure(
                 meta,
                 |meta| not::expr(meta.query_advice(is_padding, Rotation::cur())),
@@ -160,15 +854,14 @@ impl FseTable {
                 |_| 0.expr(),
             ),
             last_baseline: meta.advice_column(),
-            nb: meta.advice_column(),
             spot: meta.advice_column(),
             spot_acc: meta.advice_column(),
             smallest_spot: meta.advice_column(),
             baseline_mark: meta.advice_column(),
-            rom_fse_transition,
         };
 
-        meta.lookup_any("FseTable: spot == 1 << nb", |meta| {
+        // For every non-padded row, the SPoT is 2^nb.
+        meta.lookup_any("FseSortedStatesTable: spot == 1 << nb", |meta| {
             let condition = not::expr(meta.query_advice(config.is_padding, Rotation::cur()));
 
             [
@@ -181,29 +874,8 @@ impl FseTable {
             .collect()
         });
 
-        meta.lookup("FseTable: table_size >> 3", |meta| {
-            // We only check on the starting row. We have a custom gate to check that the
-            // table_size_rs_3 column's value does not change over the rest of the rows for a
-            // particular instance of FSE table.
-            let condition = and::expr([
-                meta.query_fixed(config.q_start, Rotation::cur()),
-                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
-            ]);
-
-            let range_value = meta.query_advice(config.table_size, Rotation::cur())
-                - (meta.query_advice(config.table_size_rs_3, Rotation::cur()) * 8.expr());
-
-            vec![(condition * range_value, range8_table.into())]
-        });
-
-        meta.lookup("FseTable: symbol in [0, 256)", |meta| {
-            vec![(
-                meta.query_advice(config.symbol, Rotation::cur()),
-                u8_table.into(),
-            )]
-        });
-
-        meta.create_gate("FseTable: first row", |meta| {
+        // The first row of the FseTable layout, i.e. q_first=true.
+        meta.create_gate("FseSortedStatesTable: first row", |meta| {
             let condition = meta.query_fixed(config.q_first, Rotation::cur());
 
             let mut cb = BaseConstraintBuilder::default();
@@ -226,35 +898,8 @@ impl FseTable {
             cb.gate(condition)
         });
 
-        meta.lookup_any(
-            "FseTable: start row (FSE table kind and block_idx transition)",
-            |meta| {
-                let condition = and::expr([
-                    meta.query_fixed(config.q_start, Rotation::cur()),
-                    not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
-                ]);
-
-                let (block_idx_prev, block_idx_curr, table_kind_prev, table_kind_curr) = (
-                    meta.query_advice(config.block_idx, Rotation::prev()),
-                    meta.query_advice(config.block_idx, Rotation::cur()),
-                    meta.query_advice(config.table_kind, Rotation::prev()),
-                    meta.query_advice(config.table_kind, Rotation::cur()),
-                );
-
-                [
-                    block_idx_prev,
-                    block_idx_curr,
-                    table_kind_prev,
-                    table_kind_curr,
-                ]
-                .into_iter()
-                .zip_eq(config.rom_fse_transition.table_exprs(meta))
-                .map(|(arg, table)| (condition.expr() * arg, table))
-                .collect()
-            },
-        );
-
-        meta.create_gate("FseTable: start row", |meta| {
+        // The starting row of every FSE table, i.e. q_start=true.
+        meta.create_gate("FseSortedStatesTable: start row", |meta| {
             let condition = and::expr([
                 meta.query_fixed(config.q_start, Rotation::cur()),
                 not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
@@ -262,113 +907,125 @@ impl FseTable {
 
             let mut cb = BaseConstraintBuilder::default();
 
-            cb.require_zero(
-                "state inits at 0",
-                meta.query_advice(config.state, Rotation::cur()),
-            );
-
-            cb.require_equal(
-                "idx == 1",
-                meta.query_advice(config.idx, Rotation::cur()),
-                1.expr(),
-            );
-
-            // table_size_rs_1 == table_size >> 1.
-            cb.require_boolean(
-                "table_size >> 1",
-                meta.query_advice(config.table_size, Rotation::cur())
-                    - (meta.query_advice(config.table_size_rs_1, Rotation::cur()) * 2.expr()),
-            );
-
             // The start row is a new symbol.
             cb.require_equal(
-                "is_symbol_change == 1",
-                meta.query_advice(config.is_symbol_change, Rotation::cur()),
+                "is_new_symbol==true",
+                meta.query_advice(config.is_new_symbol, Rotation::cur()),
                 1.expr(),
             );
 
             cb.gate(condition)
         });
 
-        meta.create_gate("FseTable: other rows in the same FSE table", |meta| {
-            let condition = not::expr(meta.query_fixed(config.q_start, Rotation::cur()));
+        // Symbols are in increasing order.
+        meta.lookup(
+            "FseSortedStatesTable: symbols are in increasing order",
+            |meta| {
+                let condition = and::expr([
+                    not::expr(meta.query_fixed(config.q_start, Rotation::cur())),
+                    meta.query_advice(config.is_new_symbol, Rotation::cur()),
+                ]);
+
+                // Whenever we move to a new symbol (is_new_symbol=true), excluding the first symbol
+                // with prob>=1, the symbol is increasing.
+                //
+                // - symbol::cur - symbol::prev > 0
+                //
+                // We check that (symbol - symbol_prev - 1) lies in the [0, 256) range.
+                let (symbol_curr, symbol_prev) = (
+                    meta.query_advice(config.symbol, Rotation::cur()),
+                    meta.query_advice(config.symbol, Rotation::prev()),
+                );
+                let delta = symbol_curr - symbol_prev - 1.expr();
+
+                vec![(condition * delta, u8_table.into())]
+            },
+        );
+
+        // We continue the same symbol if not a new symbol.
+        meta.create_gate("FseSortedStatesTable: same symbol", |meta| {
+            let condition = and::expr([
+                not::expr(meta.query_fixed(config.q_first, Rotation::cur())),
+                not::expr(meta.query_fixed(config.q_start, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_new_symbol, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
 
             let mut cb = BaseConstraintBuilder::default();
 
-            // FSE table's columns that remain unchanged.
-            for column in [
-                config.block_idx,
-                config.table_kind,
-                config.table_size,
-                config.table_size_rs_1,
-                config.table_size_rs_3,
-            ] {
-                cb.require_equal(
-                    "FseTable: columns that remain unchanged",
-                    meta.query_advice(column, Rotation::cur()),
-                    meta.query_advice(column, Rotation::prev()),
-                );
-            }
-
-            // If the symbol comparator says that the current symbol is the same as the previous
-            // symbol, then the current row cannot be marked as a is_symbol_change row.
-            let (prev_lt_cur, prev_eq_cur) = config.symbol_cmp.expr(meta, Some(Rotation::cur()));
-            let is_symbol_change = meta.query_advice(config.is_symbol_change, Rotation::cur());
-            cb.condition(prev_eq_cur.expr(), |cb| {
-                cb.require_zero("is_symbol_change == 0", is_symbol_change.expr());
-            });
-            cb.condition(prev_lt_cur.expr(), |cb| {
-                cb.require_equal("is_symbol_change == 1", is_symbol_change.expr(), 1.expr());
-            });
-
-            // If symbol is changing on the current row, then the symbol has increased from the
-            // previous row.
-            cb.condition(is_symbol_change.expr(), |cb| {
-                cb.require_equal("symbol::prev < symbol::cur", prev_lt_cur, 1.expr());
-            });
-            cb.condition(not::expr(is_symbol_change.expr()), |cb| {
-                cb.require_equal("symbol::prev == symbol::cur", prev_eq_cur, 1.expr());
-            });
-
-            // Once we enter padding territory, we stay in padding territory, i.e.
-            // is_padding transitions from 0 -> 1 only once.
-            let (is_padding_curr, is_padding_prev) = (
-                meta.query_advice(config.is_padding, Rotation::cur()),
-                meta.query_advice(config.is_padding, Rotation::prev()),
-            );
-            let is_padding_delta = is_padding_curr.expr() - is_padding_prev.expr();
-            cb.require_boolean("is_padding is boolean", is_padding_curr.expr());
-            cb.require_boolean("is_padding_delta is boolean", is_padding_delta);
-
-            // While we have not entered the padding region in this table, the idx should
-            // increment.
-            cb.condition(not::expr(is_padding_curr.expr()), |cb| {
-                cb.require_equal(
-                    "idx increments",
-                    meta.query_advice(config.idx, Rotation::cur()),
-                    meta.query_advice(config.idx, Rotation::prev()) + 1.expr(),
-                );
-            });
-
-            // If we are entering the padding region on this row, the idx on the previous row must
-            // equal the table size, i.e. all states must be generated.
-            cb.condition(
-                and::expr([not::expr(is_padding_prev), is_padding_curr]),
-                |cb| {
-                    cb.require_equal(
-                        "idx == table_size on the last state",
-                        meta.query_advice(config.idx, Rotation::prev()),
-                        meta.query_advice(config.table_size, Rotation::prev()),
-                    );
-                },
+            // When we are not seeing a new symbol, make sure the symbol is equal to the symbol on
+            // the previous row.
+            cb.require_equal(
+                "prob>=1: same symbol",
+                meta.query_advice(config.symbol, Rotation::cur()),
+                meta.query_advice(config.symbol, Rotation::prev()),
             );
 
             cb.gate(condition)
         });
 
-        meta.create_gate("FseTable: symbol changes", |meta| {
+        // While continuing the same symbol, states are in increasing order.
+        meta.lookup(
+            "FseSortedStatesTable: states are in increasing order",
+            |meta| {
+                let condition = and::expr([
+                    not::expr(meta.query_fixed(config.q_first, Rotation::cur())),
+                    not::expr(meta.query_fixed(config.q_start, Rotation::cur())),
+                    not::expr(meta.query_advice(config.is_new_symbol, Rotation::cur())),
+                    not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+                ]);
+
+                // While traversing the same symbol (is_new_symbol=false), the states allocated to
+                // it in the FseSortedStatesTable are in increasing order. So we check that:
+                //
+                // - state::cur - state::prev > 0
+                //
+                // We check that (state::cur - state::prev - 1) lies in the [0, 256) range.
+                let (state_curr, state_prev) = (
+                    meta.query_advice(config.state, Rotation::cur()),
+                    meta.query_advice(config.state, Rotation::prev()),
+                );
+                let delta = state_curr - state_prev - 1.expr();
+
+                vec![(condition * delta, u8_table.into())]
+            },
+        );
+
+        // All rows in an instance of FSE table, except the starting row (q_start=true).
+        meta.create_gate(
+            "FseSortedStatesTable: every FSE table (except q_start=1)",
+            |meta| {
+                let condition = not::expr(meta.query_fixed(config.q_start, Rotation::cur()));
+
+                let mut cb = BaseConstraintBuilder::default();
+
+                // FSE table's columns that remain unchanged.
+                for column in [config.block_idx, config.table_kind, config.table_size] {
+                    cb.require_equal(
+                        "FseSortedStatesTable: columns that remain unchanged",
+                        meta.query_advice(column, Rotation::cur()),
+                        meta.query_advice(column, Rotation::prev()),
+                    );
+                }
+
+                // Once we enter padding territory, we stay in padding territory, i.e.
+                // is_padding transitions from 0 -> 1 only once.
+                let (is_padding_curr, is_padding_prev) = (
+                    meta.query_advice(config.is_padding, Rotation::cur()),
+                    meta.query_advice(config.is_padding, Rotation::prev()),
+                );
+                let is_padding_delta = is_padding_curr.expr() - is_padding_prev.expr();
+                cb.require_boolean("is_padding is boolean", is_padding_curr.expr());
+                cb.require_boolean("is_padding_delta is boolean", is_padding_delta);
+
+                cb.gate(condition)
+            },
+        );
+
+        // For every new symbol detected.
+        meta.create_gate("FseSortedStatesTable: new symbol", |meta| {
             let condition = and::expr([
-                meta.query_advice(config.is_symbol_change, Rotation::cur()),
+                meta.query_advice(config.is_new_symbol, Rotation::cur()),
                 not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
             ]);
 
@@ -407,6 +1064,8 @@ impl FseTable {
             // encounter baseline==0x00.
             let is_baseline_mark = meta.query_advice(config.baseline_mark, Rotation::cur());
             let is_baseline_0x00 = config.baseline_0x00.expr();
+
+            cb.require_boolean("is_baseline_mark is boolean", is_baseline_mark.expr());
             cb.condition(is_baseline_0x00.expr(), |cb| {
                 cb.require_equal(
                     "baseline_mark set at baseline==0x00",
@@ -458,9 +1117,10 @@ impl FseTable {
             cb.gate(condition)
         });
 
-        meta.create_gate("FseTable: symbol continues", |meta| {
+        // Whenever we continue allocating states to the same symbol.
+        meta.create_gate("FseSortedStatesTable: same symbol, new state", |meta| {
             let condition = and::expr([
-                not::expr(meta.query_advice(config.is_symbol_change, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_new_symbol, Rotation::cur())),
                 not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
             ]);
 
@@ -482,7 +1142,7 @@ impl FseTable {
                 config.last_baseline,
             ] {
                 cb.require_equal(
-                    "unchanged columns",
+                    "FseSortedStatesTable: unchanged columns (same symbol)",
                     meta.query_advice(column, Rotation::cur()),
                     meta.query_advice(column, Rotation::prev()),
                 );
@@ -495,7 +1155,7 @@ impl FseTable {
             );
 
             cb.require_equal(
-                "spot_acc accumlates",
+                "spot_acc accumulates",
                 meta.query_advice(config.spot_acc, Rotation::cur()),
                 meta.query_advice(config.spot_acc, Rotation::prev())
                     + meta.query_advice(config.spot, Rotation::cur()),
@@ -506,9 +1166,10 @@ impl FseTable {
                 meta.query_advice(config.baseline_mark, Rotation::prev()),
             );
             let baseline_mark_delta = baseline_mark_curr.expr() - baseline_mark_prev;
-            cb.require_boolean("baseline_mark_delta is boolean", baseline_mark_delta);
+            cb.require_boolean("baseline_mark is boolean", baseline_mark_curr);
+            cb.require_boolean("baseline_mark_delta is boolean", baseline_mark_delta.expr());
 
-            // baseline == baseline_mark_curr == 1 ? 0x00 : baseline_prev + spot_prev
+            // baseline == baseline_mark_delta == 1 ? 0x00 : baseline_prev + spot_prev
             let (baseline_curr, baseline_prev, spot_prev) = (
                 meta.query_advice(config.baseline, Rotation::cur()),
                 meta.query_advice(config.baseline, Rotation::prev()),
@@ -517,92 +1178,42 @@ impl FseTable {
             cb.require_equal(
                 "baseline calculation",
                 baseline_curr,
-                select::expr(baseline_mark_curr, 0x00.expr(), baseline_prev + spot_prev),
+                select::expr(baseline_mark_delta, 0x00.expr(), baseline_prev + spot_prev),
             );
 
             cb.gate(condition)
         });
 
-        // Constraint for state' calculation. We wish to constrain:
-        //
-        // - state' == state'' & (table_size - 1)
-        // - state'' == state + (table_size >> 3) + (table_size >> 1) + 3
-        meta.lookup_any("FseTable: state transition", |meta| {
-            let condition = and::expr([
-                not::expr(meta.query_fixed(config.q_start, Rotation::cur())),
-                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
-            ]);
-
-            let state_prime = meta.query_advice(config.state, Rotation::cur());
-            let state_prime_prime = meta.query_advice(config.state, Rotation::prev())
-                + meta.query_advice(config.table_size_rs_3, Rotation::cur())
-                + meta.query_advice(config.table_size_rs_1, Rotation::cur())
-                + 3.expr();
-            let table_size_minus_one =
-                meta.query_advice(config.table_size, Rotation::cur()) - 1.expr();
-
-            [
-                BitwiseOp::AND.expr(), // op
-                state_prime_prime,     // operand1
-                table_size_minus_one,  // operand2
-                state_prime,           // result
-            ]
-            .into_iter()
-            .zip_eq(bitwise_op_table.table_exprs(meta))
-            .map(|(arg, table)| (condition.expr() * arg, table))
-            .collect()
-        });
-
-        debug_assert!(meta.degree() <= 9);
-
         config
     }
 }
 
-impl FseTable {
-    /// Lookup table expressions for (state, symbol, baseline, nb) tuple check.
-    ///
-    /// This check can be done on any row within the FSE table.
-    pub fn table_exprs_by_state(&self, meta: &mut VirtualCells<Fr>) -> Vec<Expression<Fr>> {
+impl LookupTable<Fr> for FseSortedStatesTable {
+    fn columns(&self) -> Vec<Column<halo2_proofs::plonk::Any>> {
         vec![
-            meta.query_fixed(self.q_first, Rotation::cur()),
-            meta.query_advice(self.block_idx, Rotation::cur()),
-            meta.query_advice(self.table_kind, Rotation::cur()),
-            meta.query_advice(self.table_size, Rotation::cur()),
-            meta.query_advice(self.state, Rotation::cur()),
-            meta.query_advice(self.symbol, Rotation::cur()),
-            meta.query_advice(self.baseline, Rotation::cur()),
-            meta.query_advice(self.nb, Rotation::cur()),
-            meta.query_advice(self.is_padding, Rotation::cur()),
+            self.block_idx.into(),
+            self.table_kind.into(),
+            self.table_size.into(),
+            self.symbol.into(),
+            self.symbol_count.into(),
+            self.state.into(),
+            self.baseline.into(),
+            self.nb.into(),
+            self.is_padding.into(),
         ]
     }
 
-    /// Lookup table expressions for (symbol, symbol_count) tuple check.
-    ///
-    /// This check is only done on the last occurence of a particular symbol, i.e. where:
-    /// - symbol_count == symbol_count_acc
-    pub fn table_exprs_by_symbol(&self, meta: &mut VirtualCells<Fr>) -> Vec<Expression<Fr>> {
+    fn annotations(&self) -> Vec<String> {
         vec![
-            meta.query_fixed(self.q_first, Rotation::cur()),
-            meta.query_advice(self.block_idx, Rotation::cur()),
-            meta.query_advice(self.table_kind, Rotation::cur()),
-            meta.query_advice(self.table_size, Rotation::cur()),
-            meta.query_advice(self.symbol, Rotation::cur()),
-            meta.query_advice(self.symbol_count, Rotation::cur()),
-            meta.query_advice(self.symbol_count_acc, Rotation::cur()),
-            meta.query_advice(self.is_padding, Rotation::cur()),
-        ]
-    }
-
-    /// Lookup table expressions for (table_kind, table_size) to know that the FSE decoder values
-    /// were correctly populated even at the "init-state" stage.
-    pub fn table_exprs_metadata(&self, meta: &mut VirtualCells<Fr>) -> Vec<Expression<Fr>> {
-        vec![
-            meta.query_fixed(self.q_first, Rotation::cur()),
-            meta.query_advice(self.block_idx, Rotation::cur()),
-            meta.query_advice(self.table_kind, Rotation::cur()),
-            meta.query_advice(self.table_size, Rotation::cur()),
-            meta.query_advice(self.is_padding, Rotation::cur()),
+            String::from("block_idx"),
+            String::from("table_kind"),
+            String::from("table_size"),
+            String::from("symbol"),
+            String::from("symbol_count"),
+            String::from("state"),
+            String::from("baseline"),
+            String::from("nb"),
+            String::from("is_padding"),
         ]
     }
 }

--- a/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
+++ b/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
@@ -15,7 +15,7 @@ use crate::aggregation::decoder::witgen::ZstdTag::{
 };
 
 /// FSE table variants that we observe in the sequences section.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum FseTableKind {
     /// Literal length FSE table.

--- a/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
+++ b/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
@@ -248,3 +248,121 @@ impl LookupTable<Fr> for RomFseTableTransition {
         ]
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct RomSequencesDataInterleavedOrder {
+    /// FSE table used in the previous bitstring.
+    table_kind_prev: Column<Fixed>,
+    /// FSE table used in the current bitstring.
+    table_kind_curr: Column<Fixed>,
+    /// Boolean flag to indicate whether we are initialising the FSE state.
+    is_init_state: Column<Fixed>,
+    /// Boolean flag to indicate whether we are updating the FSE state.
+    is_update_state: Column<Fixed>,
+}
+
+impl RomSequencesDataInterleavedOrder {
+    pub fn construct(meta: &mut ConstraintSystem<Fr>) -> Self {
+        Self {
+            table_kind_prev: meta.fixed_column(),
+            table_kind_curr: meta.fixed_column(),
+            is_init_state: meta.fixed_column(),
+            is_update_state: meta.fixed_column(),
+        }
+    }
+
+    pub fn load(&self, layouter: &mut impl Layouter<Fr>) -> Result<(), Error> {
+        layouter.assign_region(
+            || "(ROM): sequences data interleaved order",
+            |mut region| {
+                // handle the first row, i.e. (None, LLT, init_state=true, update_state=false).
+                region.assign_fixed(
+                    || "table_kind_prev",
+                    self.table_kind_prev,
+                    0,
+                    || Value::known(Fr::zero()),
+                )?;
+                region.assign_fixed(
+                    || "table_kind_curr",
+                    self.table_kind_curr,
+                    0,
+                    || Value::known(Fr::from(FseTableKind::LLT as u64)),
+                )?;
+                region.assign_fixed(
+                    || "is_init_state",
+                    self.is_init_state,
+                    0,
+                    || Value::known(Fr::one()),
+                )?;
+                region.assign_fixed(
+                    || "is_update_state",
+                    self.is_update_state,
+                    0,
+                    || Value::known(Fr::zero()),
+                )?;
+
+                for (i, &(table_kind_prev, table_kind_curr, is_init_state, is_update_state)) in [
+                    (FseTableKind::LLT, FseTableKind::MOT, true, false), // init state (MOT)
+                    (FseTableKind::MOT, FseTableKind::MLT, true, false), // init state (MLT)
+                    (FseTableKind::MLT, FseTableKind::MOT, false, false),
+                    (FseTableKind::MOT, FseTableKind::MLT, false, false),
+                    (FseTableKind::MLT, FseTableKind::LLT, false, false),
+                    (FseTableKind::LLT, FseTableKind::LLT, false, true),
+                    (FseTableKind::LLT, FseTableKind::MLT, false, true),
+                    (FseTableKind::MLT, FseTableKind::MOT, false, true),
+                    (FseTableKind::MOT, FseTableKind::MOT, false, false),
+                ]
+                .iter()
+                .enumerate()
+                {
+                    region.assign_fixed(
+                        || "table_kind_prev",
+                        self.table_kind_prev,
+                        i + 1,
+                        || Value::known(Fr::from(table_kind_prev as u64)),
+                    )?;
+                    region.assign_fixed(
+                        || "table_kind_curr",
+                        self.table_kind_curr,
+                        i + 1,
+                        || Value::known(Fr::from(table_kind_curr as u64)),
+                    )?;
+                    region.assign_fixed(
+                        || "is_init_state",
+                        self.is_init_state,
+                        i + 1,
+                        || Value::known(Fr::from(is_init_state as u64)),
+                    )?;
+                    region.assign_fixed(
+                        || "is_update_state",
+                        self.is_update_state,
+                        i + 1,
+                        || Value::known(Fr::from(is_update_state as u64)),
+                    )?;
+                }
+
+                Ok(())
+            },
+        )
+    }
+}
+
+impl LookupTable<Fr> for RomSequencesDataInterleavedOrder {
+    fn columns(&self) -> Vec<Column<halo2_proofs::plonk::Any>> {
+        vec![
+            self.table_kind_prev.into(),
+            self.table_kind_curr.into(),
+            self.is_init_state.into(),
+            self.is_update_state.into(),
+        ]
+    }
+
+    fn annotations(&self) -> Vec<String> {
+        vec![
+            String::from("table_kind_prev"),
+            String::from("table_kind_curr"),
+            String::from("is_init_state"),
+            String::from("is_update_state"),
+        ]
+    }
+}

--- a/aggregator/src/aggregation/decoder/witgen/types.rs
+++ b/aggregator/src/aggregation/decoder/witgen/types.rs
@@ -608,17 +608,20 @@ impl FseAuxiliaryTableData {
             offset += n_bits_read;
             bit_boundaries.push((offset, value));
 
+            let N = match value {
+                0 => 1,
+                _ => value - 1,
+            };
+
             if value == 0 {
                 unimplemented!("value=0 => prob=-1: scenario unimplemented");
             }
-
-            let N = value - 1;
 
             // When a symbol has a probability of zero, it is followed by a 2-bits repeat flag. This
             // repeat flag tells how many probabilities of zeroes follow the current one. It
             // provides a number ranging from 0 to 3. If it is a 3, another 2-bits repeat flag
             // follows, and so on.
-            if N == 0 {
+            if value == 1 {
                 sym_to_states.insert(symbol, vec![]);
                 symbol += 1;
 
@@ -638,7 +641,7 @@ impl FseAuxiliaryTableData {
                 }
             }
 
-            if N >= 1 {
+            if value >= 2 {
                 let states = std::iter::once(state)
                     .chain((1..N).map(|_| {
                         state += (table_size >> 1) + (table_size >> 3) + 3;

--- a/aggregator/src/aggregation/decoder/witgen/types.rs
+++ b/aggregator/src/aggregation/decoder/witgen/types.rs
@@ -10,6 +10,8 @@ use halo2_proofs::{circuit::Value, plonk::Expression};
 use itertools::Itertools;
 use strum_macros::EnumIter;
 
+use crate::aggregation::decoder::tables::FseTableKind;
+
 use super::{
     params::N_BITS_PER_BYTE,
     util::{bit_length, read_variable_bit_packing, smaller_powers_of_two, value_bits_le},
@@ -522,8 +524,10 @@ pub struct FseTableRow {
     pub symbol: u64,
     /// During FSE table decoding, keep track of the number of symbol emitted
     pub num_emitted: u64,
-    /// During FSE table decoding, keep track of accumulated states assigned
-    pub n_acc: u64,
+    /// A boolean marker to indicate that as per the state transition rules of FSE codes, this
+    /// state was reached for this symbol, however it was already pre-allocated to a prior symbol,
+    /// this can happen in case we have symbols with prob=-1.
+    pub is_state_skipped: bool,
 }
 
 // Used for tracking bit markers for non-byte-aligned bitstream decoding
@@ -553,15 +557,19 @@ pub struct FseTableData {
 /// Auxiliary data accompanying the FSE table's witness values.
 #[derive(Clone, Debug)]
 pub struct FseAuxiliaryTableData {
-    /// The byte offset in the frame at which the FSE table is described.
-    pub byte_offset: u64,
+    /// The block index in which this FSE table appears.
+    pub block_idx: u64,
+    /// The FSE table kind, variants are: LLT=1, MOT=2, MLT=3.
+    pub table_kind: FseTableKind,
     /// The FSE table's size, i.e. 1 << AL (accuracy log).
     pub table_size: u64,
     /// A map from FseSymbol (weight) to states, also including fields for that state, for
     /// instance, the baseline and the number of bits to read from the FSE bitstream.
     ///
-    /// For each symbol, the states are in strictly increasing order.
+    /// For each symbol, the states as per the state transition rule.
     pub sym_to_states: BTreeMap<u64, Vec<FseTableRow>>,
+    /// Similar map, but where the states for each symbol are in increasing order (sorted).
+    pub sym_to_sorted_states: BTreeMap<u64, Vec<FseTableRow>>,
 }
 
 /// Another form of Fse table that has state as key instead of the FseSymbol.
@@ -580,7 +588,12 @@ impl FseAuxiliaryTableData {
     /// with the reconstructed FSE table. After processing the entire bitstream to reconstruct the
     /// FSE table, if the read bitstream was not byte aligned, then we discard the 1..8 bits from
     /// the last byte that we read from.
-    pub fn reconstruct(src: &[u8], byte_offset: usize) -> std::io::Result<ReconstructedFse> {
+    pub fn reconstruct(
+        src: &[u8],
+        block_idx: u64,
+        table_kind: FseTableKind,
+        byte_offset: usize,
+    ) -> std::io::Result<ReconstructedFse> {
         // construct little-endian bit-reader.
         let data = src.iter().skip(byte_offset).cloned().collect::<Vec<u8>>();
         let mut reader = BitReader::endian(Cursor::new(&data), LittleEndian);
@@ -596,9 +609,11 @@ impl FseAuxiliaryTableData {
         bit_boundaries.push((offset, accuracy_log as u64 - 5));
         let table_size = 1 << accuracy_log;
 
-        let mut sym_to_states = BTreeMap::new();
+        ////////////////////////////////////////////////////////////////////////////////////////
+        //////////////////////////// Parse Normalised Probabilities ////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////////////
+        let mut normalised_probs = BTreeMap::new();
         let mut R = table_size;
-        let mut state = 0x00;
         let mut symbol = 0;
         while R > 0 {
             // number of bits and value read from the variable bit-packed data.
@@ -608,30 +623,38 @@ impl FseAuxiliaryTableData {
             offset += n_bits_read;
             bit_boundaries.push((offset, value));
 
+            // Number of states allocated to this symbol.
+            // - prob=-1 => 1
+            // - prob=0  => 0
+            // - prob>=1 => prob
             let N = match value {
                 0 => 1,
                 _ => value - 1,
             };
 
+            // When a symbol has a value==0, it signifies a case of prob=-1 (or probability "less
+            // than 1"), where such symbols are allocated states from the end and retreating. In
+            // such cases, we reset the FSE state, i.e. read accuracy_log number of bits from the
+            // bitstream with a baseline==0x00.
             if value == 0 {
-                unimplemented!("value=0 => prob=-1: scenario unimplemented");
+                normalised_probs.insert(symbol, -1);
+                symbol += 1;
             }
 
-            // When a symbol has a probability of zero, it is followed by a 2-bits repeat flag. This
+            // When a symbol has a value==1 (prob==0), it is followed by a 2-bits repeat flag. This
             // repeat flag tells how many probabilities of zeroes follow the current one. It
             // provides a number ranging from 0 to 3. If it is a 3, another 2-bits repeat flag
             // follows, and so on.
             if value == 1 {
-                sym_to_states.insert(symbol, vec![]);
+                normalised_probs.insert(symbol, 0);
                 symbol += 1;
-
                 loop {
                     let repeat_bits = reader.read::<u8>(2)?;
                     offset += 2;
                     bit_boundaries.push((offset, repeat_bits as u64));
 
                     for k in 0..repeat_bits {
-                        sym_to_states.insert(symbol + (k as u64), vec![]);
+                        normalised_probs.insert(symbol + (k as u64), 0);
                     }
                     symbol += repeat_bits as u64;
 
@@ -641,56 +664,11 @@ impl FseAuxiliaryTableData {
                 }
             }
 
-            if value >= 2 {
-                let states = std::iter::once(state)
-                    .chain((1..N).map(|_| {
-                        state += (table_size >> 1) + (table_size >> 3) + 3;
-                        state &= table_size - 1;
-                        state
-                    }))
-                    .sorted()
-                    .collect::<Vec<u64>>();
-                let (smallest_spot_idx, nbs) = smaller_powers_of_two(table_size, N);
-                let baselines = if N == 1 {
-                    vec![0x00]
-                } else {
-                    let mut rotated_nbs = nbs.clone();
-                    rotated_nbs.rotate_left(smallest_spot_idx);
-
-                    let mut baselines = std::iter::once(0x00)
-                        .chain(rotated_nbs.iter().scan(0x00, |baseline, nb| {
-                            *baseline += 1 << nb;
-                            Some(*baseline)
-                        }))
-                        .take(N as usize)
-                        .collect::<Vec<u64>>();
-
-                    baselines.rotate_right(smallest_spot_idx);
-                    baselines
-                };
-                sym_to_states.insert(
-                    symbol,
-                    states
-                        .iter()
-                        .zip(nbs.iter())
-                        .zip(baselines.iter())
-                        .map(|((&state, &nb), &baseline)| FseTableRow {
-                            state,
-                            num_bits: nb,
-                            baseline,
-                            symbol,
-                            num_emitted: 0,
-                            n_acc: 0,
-                        })
-                        .collect(),
-                );
-
-                // increment symbol.
+            // When a symbol has a value>1 (prob>=1), it is allocated that many number of states in
+            // the FSE table.
+            if value > 1 {
+                normalised_probs.insert(symbol, N as i32);
                 symbol += 1;
-
-                // update state.
-                state += (table_size >> 1) + (table_size >> 3) + 3;
-                state &= table_size - 1;
             }
 
             // remove N slots from a total of R.
@@ -709,13 +687,127 @@ impl FseAuxiliaryTableData {
             ));
         }
 
+        ////////////////////////////////////////////////////////////////////////////////////////
+        ///////////////////////////// Allocate States to Symbols ///////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////////////
+        let mut sym_to_states = BTreeMap::new();
+        let mut sym_to_sorted_states = BTreeMap::new();
+        let mut state = 0;
+        let mut retreating_state = table_size - 1;
+        let mut allocated_states = HashMap::<u64, bool>::new();
+
+        // We start with the symbols that have prob=-1.
+        for (&symbol, _prob) in normalised_probs
+            .iter()
+            .filter(|(_symbol, &prob)| prob == -1)
+        {
+            allocated_states.insert(symbol, true);
+            let fse_table_row = FseTableRow {
+                state: retreating_state,
+                num_bits: accuracy_log as u64,
+                baseline: 0,
+                symbol,
+                is_state_skipped: false,
+                num_emitted: 0,
+            };
+            sym_to_states.insert(symbol, vec![fse_table_row.clone()]);
+            sym_to_sorted_states.insert(symbol, vec![fse_table_row]);
+            retreating_state -= 1;
+        }
+
+        // We now move to the symbols with prob>=1.
+        for (&symbol, &prob) in normalised_probs
+            .iter()
+            .filter(|(_symbol, &prob)| prob.is_positive())
+        {
+            let N = prob as usize;
+            let mut count = 0;
+            let mut states_with_skipped: Vec<(u64, bool)> = Vec::with_capacity(N);
+            while count < N {
+                if allocated_states.get(&state).is_some() {
+                    // if state has been pre-allocated to some symbol with prob=-1.
+                    states_with_skipped.push((state, true));
+                } else {
+                    // if state is not yet allocated, i.e. available for this symbol.
+                    states_with_skipped.push((state, false));
+                    count += 1;
+                }
+
+                // update state.
+                state += (table_size >> 1) + (table_size >> 3) + 3;
+                state &= table_size - 1;
+            }
+            let sorted_states = states_with_skipped
+                .iter()
+                .filter(|&(_s, is_state_skipped)| !is_state_skipped)
+                .map(|&(s, _)| s)
+                .sorted()
+                .collect::<Vec<u64>>();
+            let (smallest_spot_idx, nbs) = smaller_powers_of_two(table_size, N as u64);
+            let baselines = if N == 1 {
+                vec![0x00]
+            } else {
+                let mut rotated_nbs = nbs.clone();
+                rotated_nbs.rotate_left(smallest_spot_idx);
+
+                let mut baselines = std::iter::once(0x00)
+                    .chain(rotated_nbs.iter().scan(0x00, |baseline, nb| {
+                        *baseline += 1 << nb;
+                        Some(*baseline)
+                    }))
+                    .take(N)
+                    .collect::<Vec<u64>>();
+
+                baselines.rotate_right(smallest_spot_idx);
+                baselines
+            };
+            sym_to_states.insert(
+                symbol,
+                states_with_skipped
+                    .iter()
+                    .map(|&(s, is_state_skipped)| {
+                        let (baseline, nb) = match sorted_states.iter().position(|&ss| ss == s) {
+                            None => (0, 0),
+                            Some(sorted_idx) => (baselines[sorted_idx], nbs[sorted_idx]),
+                        };
+                        FseTableRow {
+                            state: s,
+                            num_bits: nb,
+                            baseline,
+                            symbol,
+                            num_emitted: 0,
+                            is_state_skipped,
+                        }
+                    })
+                    .collect(),
+            );
+            sym_to_sorted_states.insert(
+                symbol,
+                sorted_states
+                    .iter()
+                    .zip(nbs.iter())
+                    .zip(baselines.iter())
+                    .map(|((&s, &nb), &baseline)| FseTableRow {
+                        state: s,
+                        num_bits: nb,
+                        baseline,
+                        symbol,
+                        num_emitted: 0,
+                        is_state_skipped: false,
+                    })
+                    .collect(),
+            );
+        }
+
         Ok((
             t,
             bit_boundaries,
             Self {
-                byte_offset: byte_offset as u64,
+                block_idx,
+                table_kind,
                 table_size,
                 sym_to_states,
+                sym_to_sorted_states,
             },
         ))
     }
@@ -785,14 +877,15 @@ mod tests {
         // sure FSE reconstruction ignores them.
         let src = vec![0xff, 0xff, 0xff, 0x30, 0x6f, 0x9b, 0x03, 0xff, 0xff, 0xff];
 
-        let (n_bytes, _bit_boundaries, table) = FseAuxiliaryTableData::reconstruct(&src, 3)?;
+        let (n_bytes, _bit_boundaries, table) =
+            FseAuxiliaryTableData::reconstruct(&src, 1, FseTableKind::LLT, 3)?;
 
         // TODO: assert equality for the entire table.
         // for now only comparing state/baseline/nb for S1, i.e. weight == 1.
 
         assert_eq!(n_bytes, 4);
         assert_eq!(
-            table.sym_to_states.get(&1).cloned().unwrap(),
+            table.sym_to_sorted_states.get(&1).cloned().unwrap(),
             [
                 (0x03, 0x10, 3),
                 (0x0c, 0x18, 3),
@@ -803,13 +896,13 @@ mod tests {
             ]
             .iter()
             .enumerate()
-            .map(|(i, &(state, baseline, num_bits))| FseTableRow {
+            .map(|(_i, &(state, baseline, num_bits))| FseTableRow {
                 state,
                 symbol: 1,
                 baseline,
                 num_bits,
                 num_emitted: 0,
-                n_acc: 0,
+                is_state_skipped: false,
             })
             .collect::<Vec<FseTableRow>>(),
         );
@@ -823,7 +916,8 @@ mod tests {
             0x21, 0x9d, 0x51, 0xcc, 0x18, 0x42, 0x44, 0x81, 0x8c, 0x94, 0xb4, 0x50, 0x1e,
         ];
 
-        let (n_bytes, _bit_boundaries, table) = FseAuxiliaryTableData::reconstruct(&src, 0)?;
+        let (n_bytes, _bit_boundaries, table) =
+            FseAuxiliaryTableData::reconstruct(&src, 1, FseTableKind::LLT, 0)?;
         let parsed_state_map = table.parse_state_table();
 
         // TODO: assertions


### PR DESCRIPTION
Additions
- [x] Lookup to more ROM tables
- [ ] Lookup to `SequenceInstructionTable` (sequence count)
- [ ] Lookup to `SequenceInstructionTable` (sequence values)
- [x] `SequenceDecoderConfig` in `DecoderConfig`
- [x] Gates for `tag=ZstdBlockSequencesData`
- [x] Lookups to `FseTable`

Updates/Fixes
- [x] `FseTable` split into `FseTable` and `FseSortedStatesTable`
- [x] `FseTable` can handle `prob=-1` "less than 1" case
- [x] Related updates in doing lookups to the `FseTable` from `DecoderConfig`