### PR TITLE
FSE `Predefined_Mode` support for sequences section

### DIFF
--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -2224,6 +2224,7 @@ impl DecoderConfig {
                     block_idx,
                     fse_table_kind,
                     fse_table_size,
+                    0.expr(), // is_predefined
                     fse_symbol,
                     norm_prob.expr(),
                     norm_prob.expr(),
@@ -2722,6 +2723,7 @@ impl DecoderConfig {
                     block_idx,
                     table_kind,
                     table_size,
+                    0.expr(), // is_predefined
                     0.expr(), // is_padding
                 ]
                 .into_iter()
@@ -2807,6 +2809,7 @@ impl DecoderConfig {
                     block_idx,
                     table_kind,
                     table_size,
+                    0.expr(), // is_predefined
                     state,
                     symbol,
                     baseline,

--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -187,6 +187,16 @@ struct BlockConfig {
     is_block: Column<Advice>,
     /// Number of sequences decoded from the sequences section header in the block.
     num_sequences: Column<Advice>,
+    /// For sequence decoding, the tag=ZstdBlockSequenceHeader bytes tell us the Compression_Mode
+    /// utilised for Literals Lengths, Match Offsets and Match Lengths. We expect only 2
+    /// possibilities:
+    /// 1. Predefined_Mode (value=0)
+    /// 2. Fse_Compressed_Mode (value=2)
+    ///
+    /// Which means a single boolean flag is sufficient to take note of which compression mode is
+    /// utilised for each of the above purposes. The boolean flag will be set if we utilise the
+    /// Fse_Compressed_Mode.
+    compression_modes: [Column<Advice>; 3],
 }
 
 impl BlockConfig {
@@ -197,7 +207,55 @@ impl BlockConfig {
             is_last_block: meta.advice_column(),
             is_block: meta.advice_column(),
             num_sequences: meta.advice_column(),
+            compression_modes: [
+                meta.advice_column(),
+                meta.advice_column(),
+                meta.advice_column(),
+            ],
         }
+    }
+}
+
+impl BlockConfig {
+    fn is_predefined_llt(&self, meta: &mut VirtualCells<Fr>, rotation: Rotation) -> Expression<Fr> {
+        not::expr(meta.query_advice(self.compression_modes[0], rotation))
+    }
+
+    fn is_predefined_mot(&self, meta: &mut VirtualCells<Fr>, rotation: Rotation) -> Expression<Fr> {
+        not::expr(meta.query_advice(self.compression_modes[1], rotation))
+    }
+
+    fn is_predefined_mlt(&self, meta: &mut VirtualCells<Fr>, rotation: Rotation) -> Expression<Fr> {
+        not::expr(meta.query_advice(self.compression_modes[2], rotation))
+    }
+
+    fn are_predefined_all(
+        &self,
+        meta: &mut VirtualCells<Fr>,
+        rotation: Rotation,
+    ) -> Expression<Fr> {
+        and::expr([
+            self.is_predefined_llt(meta, rotation),
+            self.is_predefined_mot(meta, rotation),
+            self.is_predefined_mlt(meta, rotation),
+        ])
+    }
+
+    fn is_predefined(
+        &self,
+        meta: &mut VirtualCells<Fr>,
+        fse_decoder: &FseDecoder,
+        rotation: Rotation,
+    ) -> Expression<Fr> {
+        select::expr(
+            fse_decoder.is_llt(meta, rotation),
+            self.is_predefined_llt(meta, rotation),
+            select::expr(
+                fse_decoder.is_mlt(meta, rotation),
+                self.is_predefined_mlt(meta, rotation),
+                self.is_predefined_mot(meta, rotation),
+            ),
+        )
     }
 }
 
@@ -1687,6 +1745,15 @@ impl DecoderConfig {
                 meta.query_advice(config.block_config.num_sequences, Rotation::prev()),
             );
 
+            // the compression modes are remembered throughout the block's context.
+            for column in config.block_config.compression_modes {
+                cb.require_equal(
+                    "compression_modes::cur == compression_modes::prev (during block)",
+                    meta.query_advice(column, Rotation::cur()),
+                    meta.query_advice(column, Rotation::prev()),
+                );
+            }
+
             cb.gate(condition)
         });
 
@@ -1845,24 +1912,46 @@ impl DecoderConfig {
             );
 
             // The compression modes for literals length, match length and offsets are expected to
-            // be FSE, i.e. compression mode == 2, i.e. bit0 == 0 and bit1 == 1.
+            // be either Predefined_Mode or Fse_Compressed_Mode, i.e. compression mode==0 or
+            // compression_mode==2. i.e. bit0==0.
             cb.require_zero("ll: bit0 == 0", decoded_sequences_header.comp_mode_bit0_ll);
             cb.require_zero("om: bit0 == 0", decoded_sequences_header.comp_mode_bit0_om);
             cb.require_zero("ml: bit0 == 0", decoded_sequences_header.comp_mode_bit0_ml);
+
+            // Depending on bit1==0 or bit1==1 we know whether the compression mode is
+            // Predefined_Mode or Fse_Compressed_Mode. The compression_modes flag is set when
+            // Fse_Compressed_Mode is utilised.
             cb.require_equal(
-                "ll: bit1 == 1",
+                "block_config: compression_modes llt",
+                meta.query_advice(config.block_config.compression_modes[0], Rotation::cur()),
                 decoded_sequences_header.comp_mode_bit1_ll,
-                1.expr(),
             );
             cb.require_equal(
-                "om: bit1 == 1",
+                "block_config: compression_modes mot",
+                meta.query_advice(config.block_config.compression_modes[1], Rotation::cur()),
                 decoded_sequences_header.comp_mode_bit1_om,
-                1.expr(),
             );
             cb.require_equal(
-                "ml: bit1 == 1",
+                "block_config: compression_modes mlt",
+                meta.query_advice(config.block_config.compression_modes[2], Rotation::cur()),
                 decoded_sequences_header.comp_mode_bit1_ml,
-                1.expr(),
+            );
+
+            // If all the three LLT, MOT and MLT use the Predefined_Mode, we have no FSE tables to
+            // decode in the sequences section. And the tag=ZstdBlockSequenceHeader will
+            // immediately be followed by tag=ZstdBlockSequenceData.
+            let no_fse_tables = config
+                .block_config
+                .are_predefined_all(meta, Rotation::cur());
+            cb.require_equal(
+                "SequenceHeader: tag_next=FseCode or tag_next=SequencesData",
+                meta.query_advice(config.tag_config.tag_next, Rotation::cur()),
+                select::expr(
+                    no_fse_tables,
+                    // TODO: replace with SequencesData once witgen code is merged.
+                    ZstdTag::ZstdBlockHuffmanCode.expr(),
+                    ZstdTag::ZstdBlockFseCode.expr(),
+                ),
             );
 
             cb.gate(condition)
@@ -1959,6 +2048,9 @@ impl DecoderConfig {
                 ]);
 
                 [
+                    meta.query_advice(config.block_config.compression_modes[0], Rotation::cur()),
+                    meta.query_advice(config.block_config.compression_modes[1], Rotation::cur()),
+                    meta.query_advice(config.block_config.compression_modes[2], Rotation::cur()),
                     meta.query_advice(config.tag_config.tag, Rotation::prev()), // tag_prev
                     meta.query_advice(config.tag_config.tag, Rotation::cur()),  // tag_cur
                     meta.query_advice(config.tag_config.tag_next, Rotation::cur()), // tag_next
@@ -2716,6 +2808,10 @@ impl DecoderConfig {
                     meta.query_advice(config.fse_decoder.table_kind, Rotation::cur()),
                     meta.query_advice(config.fse_decoder.table_size, Rotation::cur()),
                 );
+                let is_predefined_mode =
+                    config
+                        .block_config
+                        .is_predefined(meta, &config.fse_decoder, Rotation::cur());
 
                 [
                     0.expr(), // q_first
@@ -2723,8 +2819,8 @@ impl DecoderConfig {
                     block_idx,
                     table_kind,
                     table_size,
-                    0.expr(), // is_predefined
-                    0.expr(), // is_padding
+                    is_predefined_mode, // is_predefined
+                    0.expr(),           // is_padding
                 ]
                 .into_iter()
                 .zip_eq(config.fse_table.table_exprs_metadata(meta))
@@ -2803,13 +2899,17 @@ impl DecoderConfig {
                         .bitstream_decoder
                         .bitstring_len(meta, Rotation::cur()),
                 );
+                let is_predefined_mode =
+                    config
+                        .block_config
+                        .is_predefined(meta, &config.fse_decoder, Rotation::cur());
 
                 [
                     0.expr(), // q_first
                     block_idx,
                     table_kind,
                     table_size,
-                    0.expr(), // is_predefined
+                    is_predefined_mode, // is_predefined
                     state,
                     symbol,
                     baseline,

--- a/aggregator/src/aggregation/decoder/tables.rs
+++ b/aggregator/src/aggregation/decoder/tables.rs
@@ -14,7 +14,10 @@ pub use literals_header::LiteralsHeaderTable;
 
 /// Validate the assignment of FSE table kind while decoding FSE tables in the sequences section.
 mod rom_fse_order;
-pub use rom_fse_order::{FseTableKind, RomFseOrderTable, RomSequencesDataInterleavedOrder};
+pub use rom_fse_order::{
+    predefined_table, predefined_table_values, FseTableKind, RomFseOrderTable,
+    RomSequencesDataInterleavedOrder,
+};
 
 /// The fixed code to Baseline/NumBits for Literal Length.
 mod rom_sequence_codes;

--- a/aggregator/src/aggregation/decoder/tables.rs
+++ b/aggregator/src/aggregation/decoder/tables.rs
@@ -15,7 +15,7 @@ pub use literals_header::LiteralsHeaderTable;
 /// Validate the assignment of FSE table kind while decoding FSE tables in the sequences section.
 mod rom_fse_order;
 pub use rom_fse_order::{
-    predefined_table, predefined_table_values, FseTableKind, RomFseOrderTable,
+    predefined_table, predefined_table_values, FsePredefinedTable, FseTableKind, RomFseOrderTable,
     RomSequencesDataInterleavedOrder,
 };
 

--- a/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
+++ b/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
@@ -369,9 +369,13 @@ impl LookupTable<Fr> for RomSequencesDataInterleavedOrder {
     }
 }
 
-trait FsePredefinedTable {
+pub trait FsePredefinedTable {
+    /// Get the accuracy log of the predefined table.
+    fn accuracy_log(&self) -> u8;
     /// Get the number of states in the FSE table.
-    fn table_size(&self) -> u64;
+    fn table_size(&self) -> u64 {
+        1 << self.accuracy_log()
+    }
     /// Get the symbol in the FSE table for the given state.
     fn symbol(&self, state: u64) -> u64;
     /// Get the baseline in the FSE table for the given state.
@@ -381,11 +385,11 @@ trait FsePredefinedTable {
 }
 
 impl FsePredefinedTable for FseTableKind {
-    fn table_size(&self) -> u64 {
+    fn accuracy_log(&self) -> u8 {
         match self {
-            Self::LLT => 64,
-            Self::MOT => 32,
-            Self::MLT => 64,
+            Self::LLT => 6,
+            Self::MOT => 5,
+            Self::MLT => 6,
         }
     }
 
@@ -457,7 +461,98 @@ impl FsePredefinedTable for FseTableKind {
                 63 => 32,
                 _ => unreachable!(),
             },
-            _ => unimplemented!(),
+            Self::MOT => match state {
+                0 => 0,
+                1 => 6,
+                2 => 9,
+                3 => 15,
+                4 => 21,
+                5 => 3,
+                6 => 7,
+                7 => 12,
+                8 => 18,
+                9 => 23,
+                10 => 5,
+                11 => 8,
+                12 => 14,
+                13 => 20,
+                14 => 2,
+                15 => 7,
+                16 => 11,
+                17 => 17,
+                18 => 22,
+                19 => 4,
+                20 => 8,
+                21 => 13,
+                22 => 19,
+                23 => 1,
+                24 => 6,
+                25 => 10,
+                26 => 16,
+                27 => 28,
+                28 => 27,
+                29 => 26,
+                30 => 25,
+                31 => 24,
+                _ => unreachable!(),
+            },
+            Self::MLT => match state {
+                0..=3 => state,
+                4..=5 => state + 1,
+                6 => 8,
+                7 => 10,
+                8 => 13,
+                9 => 16,
+                10 => 19,
+                11 => 22,
+                12 => 25,
+                13 => 28,
+                14 => 31,
+                15 => 33,
+                16 => 35,
+                17 => 37,
+                18 => 39,
+                19 => 41,
+                20 => 43,
+                21 => 45,
+                22..=25 => state - 21,
+                26..=27 => state - 20,
+                28 => 9,
+                29 => 12,
+                30 => 15,
+                31 => 18,
+                32 => 21,
+                33 => 24,
+                34 => 27,
+                35 => 30,
+                36 => 32,
+                37 => 34,
+                38 => 36,
+                39 => 38,
+                40 => 40,
+                41 => 42,
+                42 => 44,
+                43..=44 => 1,
+                45 => 2,
+                46..=47 => state - 42,
+                48 => 7,
+                49 => 8,
+                50 => 11,
+                51 => 14,
+                52 => 17,
+                53 => 20,
+                54 => 23,
+                55 => 26,
+                56 => 29,
+                57 => 52,
+                58 => 51,
+                59 => 50,
+                60 => 49,
+                61 => 48,
+                62 => 47,
+                63 => 46,
+                _ => unreachable!(),
+            },
         }
     }
 
@@ -477,7 +572,18 @@ impl FsePredefinedTable for FseTableKind {
                 45..=52 | 54..=59 => 32,
                 _ => unreachable!(),
             },
-            _ => unimplemented!(),
+            Self::MOT => match state {
+                0..=14 | 16..=19 | 21..=23 | 25..=31 => 0,
+                15 | 20 | 24 => 16,
+                _ => unreachable!(),
+            },
+            Self::MLT => match state {
+                0..=1 | 3..=21 | 23 | 25 | 27..=42 | 50..=63 => 0,
+                2 | 24 | 26 | 43 | 46..=49 => 32,
+                22 | 45 => 16,
+                44 => 48,
+                _ => unreachable!(),
+            },
         }
     }
 
@@ -489,7 +595,17 @@ impl FsePredefinedTable for FseTableKind {
                 10 | 19..=21 | 31 | 41..=42 | 53 | 60..=63 => 6,
                 _ => unreachable!(),
             },
-            _ => unimplemented!(),
+            Self::MOT => match state {
+                0 | 2..=5 | 7..=10 | 12..=14 | 16..=19 | 21..=23 | 25..=31 => 5,
+                1 | 6 | 11 | 15 | 20 | 24 => 4,
+                _ => unreachable!(),
+            },
+            Self::MLT => match state {
+                0 | 7..=21 | 28..=42 | 50..=63 => 6,
+                1 | 22..=23 | 43..=45 => 4,
+                2..=6 | 24..=27 | 46..=49 => 5,
+                _ => unreachable!(),
+            },
         }
     }
 }

--- a/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
+++ b/aggregator/src/aggregation/decoder/tables/rom_fse_order.rs
@@ -494,7 +494,21 @@ impl FsePredefinedTable for FseTableKind {
     }
 }
 
-fn predefined_table_values(table_kind: FseTableKind) -> Vec<[Value<Fr>; 6]> {
+pub fn predefined_table(table_kind: FseTableKind) -> Vec<(u64, u64, u64, u64)> {
+    let table_size = table_kind.table_size();
+    (0..table_size)
+        .map(|state| {
+            (
+                state,
+                table_kind.symbol(state),
+                table_kind.baseline(state),
+                table_kind.nb(state),
+            )
+        })
+        .collect()
+}
+
+pub fn predefined_table_values(table_kind: FseTableKind) -> Vec<[Value<Fr>; 6]> {
     let table_size = table_kind.table_size();
     (0..table_size)
         .map(|state| {

--- a/aggregator/src/aggregation/decoder/witgen/types.rs
+++ b/aggregator/src/aggregation/decoder/witgen/types.rs
@@ -580,7 +580,6 @@ type FseStateMapping = BTreeMap<u64, (u64, u64, u64)>;
 type ReconstructedFse = (usize, Vec<(u32, u64)>, FseAuxiliaryTableData);
 
 impl FseAuxiliaryTableData {
-    #[allow(non_snake_case)]
     /// While we reconstruct an FSE table from a bitstream, we do not know before reconstruction
     /// how many exact bytes we would finally be reading.
     ///
@@ -588,6 +587,7 @@ impl FseAuxiliaryTableData {
     /// with the reconstructed FSE table. After processing the entire bitstream to reconstruct the
     /// FSE table, if the read bitstream was not byte aligned, then we discard the 1..8 bits from
     /// the last byte that we read from.
+    #[allow(non_snake_case)]
     pub fn reconstruct(
         src: &[u8],
         block_idx: u64,
@@ -687,9 +687,44 @@ impl FseAuxiliaryTableData {
             ));
         }
 
+        // sanity check: sum(probabilities) == table_size.
+        assert_eq!(
+            normalised_probs
+                .values()
+                .map(|&prob| if prob == -1 { 1u64 } else { prob as u64 })
+                .sum::<u64>(),
+            table_size
+        );
+
         ////////////////////////////////////////////////////////////////////////////////////////
         ///////////////////////////// Allocate States to Symbols ///////////////////////////////
         ////////////////////////////////////////////////////////////////////////////////////////
+        let (sym_to_states, sym_to_sorted_states) =
+            Self::transform_normalised_probs(&normalised_probs, accuracy_log);
+
+        Ok((
+            t,
+            bit_boundaries,
+            Self {
+                block_idx,
+                table_kind,
+                table_size,
+                sym_to_states,
+                sym_to_sorted_states,
+            },
+        ))
+    }
+
+    #[allow(non_snake_case)]
+    fn transform_normalised_probs(
+        normalised_probs: &BTreeMap<u64, i32>,
+        accuracy_log: u8,
+    ) -> (
+        BTreeMap<u64, Vec<FseTableRow>>,
+        BTreeMap<u64, Vec<FseTableRow>>,
+    ) {
+        let table_size = 1 << accuracy_log;
+
         let mut sym_to_states = BTreeMap::new();
         let mut sym_to_sorted_states = BTreeMap::new();
         let mut state = 0;
@@ -701,7 +736,7 @@ impl FseAuxiliaryTableData {
             .iter()
             .filter(|(_symbol, &prob)| prob == -1)
         {
-            allocated_states.insert(symbol, true);
+            allocated_states.insert(retreating_state, true);
             let fse_table_row = FseTableRow {
                 state: retreating_state,
                 num_bits: accuracy_log as u64,
@@ -799,17 +834,7 @@ impl FseAuxiliaryTableData {
             );
         }
 
-        Ok((
-            t,
-            bit_boundaries,
-            Self {
-                block_idx,
-                table_kind,
-                table_size,
-                sym_to_states,
-                sym_to_sorted_states,
-            },
-        ))
+        (sym_to_states, sym_to_sorted_states)
     }
 
     /// Convert an FseAuxiliaryTableData into a state-mapped representation.
@@ -866,6 +891,8 @@ impl<F: Field> ZstdWitnessRow<F> {
 
 #[cfg(test)]
 mod tests {
+    use crate::aggregation::decoder::tables::predefined_table;
+
     use super::*;
 
     #[test]
@@ -908,6 +935,54 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_fse_reconstruction_predefined_llt() {
+        // Here we test whether we can actually reconstruct the FSE table for distributions that
+        // include prob=-1 cases, one such example is the Predefined FSE table as per
+        // specifications.
+        //
+        // short literalsLength_defaultDistribution[36] =
+        // { 4, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1,
+        //   2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 1, 1, 1, 1, 1,
+        //  -1,-1,-1,-1 };
+        let default_distribution_llt = [
+            4, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 1, 1,
+            1, 1, 1, -1, -1, -1, -1,
+        ];
+        let normalised_probs_llt = {
+            let mut normalised_probs = BTreeMap::new();
+            for (i, &prob) in default_distribution_llt.iter().enumerate() {
+                normalised_probs.insert(i as u64, prob);
+            }
+            normalised_probs
+        };
+        let (sym_to_states, _sym_to_sorted_states) =
+            FseAuxiliaryTableData::transform_normalised_probs(&normalised_probs_llt, 6);
+        let expected_predefined_table = predefined_table(FseTableKind::LLT);
+
+        let mut computed_predefined_table = sym_to_states
+            .values()
+            .flatten()
+            .filter(|row| !row.is_state_skipped)
+            .collect::<Vec<_>>();
+        computed_predefined_table.sort_by_key(|row| row.state);
+
+        for (i, (expected, computed)) in expected_predefined_table
+            .iter()
+            .zip_eq(computed_predefined_table.iter())
+            .enumerate()
+        {
+            assert_eq!(computed.state, expected.0, "state mismatch at i={}", i);
+            assert_eq!(computed.symbol, expected.1, "symbol mismatch at i={}", i);
+            assert_eq!(
+                computed.baseline, expected.2,
+                "baseline mismatch at i={}",
+                i
+            );
+            assert_eq!(computed.num_bits, expected.3, "nb mismatch at i={}", i);
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR adds support for the compression mode `Predefined_Mode` in the sequences section, whereby we can decode sequences from a predefined distribution table specified [here](https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#appendix-a---decoding-tables-for-predefined-codes) and [here](https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#default-distributions).

- [x] ROM table for Predefined table
- [x] Validation from `FseTable` for a table marked as "predefined"
- [x] Allow compression mode (from `SequencesHeader`) to be `Predefined_Mode` and store this flag (`is_predefined`) in `DecoderConfig::FseDecoder`
- [x] Refactor `Fse::reconstruct` to split out "read normalised probabilities" and "transform normalised probabilities to fse fields" to allow more tests