### PR TITLE
Self-review and missing constraints (misc fixes/refactoring)

### DIFF
--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -274,9 +274,9 @@ impl BlockConfig {
 #[derive(Clone, Debug)]
 struct SequencesHeaderDecoder {
     /// Helper gadget to evaluate byte0 < 128.
-    pub byte0_lt_0x80: LtConfig<Fr, 8>,
+    pub byte0_lt_0x80: LtConfig<Fr, 1>,
     /// Helper gadget to evaluate byte0 < 255.
-    pub byte0_lt_0xff: LtConfig<Fr, 8>,
+    pub byte0_lt_0xff: LtConfig<Fr, 1>,
 }
 
 struct DecodedSequencesHeader {

--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -1025,6 +1025,7 @@ impl DecoderConfig {
 
         is_prev_tag!(is_prev_frame_content_size, FrameContentSize);
         is_prev_tag!(is_prev_sequence_header, ZstdBlockSequenceHeader);
+        // TODO: update to ZstdBlockSequenceData once witgen code is merged.
         is_prev_tag!(is_prev_sequence_data, ZstdBlockHuffmanCode);
 
         meta.lookup("DecoderConfig: 0 <= encoded byte < 256", |meta| {

--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -2249,11 +2249,16 @@ impl DecoderConfig {
                         not::expr(is_repeat_bits_loop.expr()),
                     ]),
                     |cb| {
-                        // prob_acc_cur == prob_acc_prev + (value - 1)
+                        // if value>=1: prob_acc_cur == prob_acc_prev + (value - 1)
+                        // if value==0: prob_acc_cur == prob_acc_prev + 1
                         cb.require_equal(
                             "fse: probability_acc is updated correctly",
-                            prob_acc_cur.expr() + 1.expr(),
-                            prob_acc_prev.expr() + value.expr(),
+                            prob_acc_cur.expr(),
+                            select::expr(
+                                config.bitstream_decoder.is_prob0(meta, Rotation::cur()),
+                                prob_acc_prev.expr() + 1.expr(),
+                                prob_acc_prev.expr() + value.expr() - 1.expr(),
+                            ),
                         );
                         cb.require_equal(
                             "fse: symbol increments",
@@ -2288,6 +2293,29 @@ impl DecoderConfig {
                         fse_symbol_prev + value,
                     );
                 });
+
+                cb.gate(condition)
+            },
+        );
+
+        meta.create_gate(
+            "DecoderConfig: tag ZstdBlockSequenceFseCode (last row)",
+            |meta| {
+                let condition = and::expr([
+                    meta.query_advice(config.tag_config.is_fse_code, Rotation::cur()),
+                    meta.query_advice(config.tag_config.is_change, Rotation::next()),
+                ]);
+
+                let mut cb = BaseConstraintBuilder::default();
+
+                // cumulative prob of symbols == table_size
+                cb.require_equal(
+                    "cumulative normalised probabilities over all symbols is the table size",
+                    meta.query_advice(config.fse_decoder.probability_acc, Rotation::cur()),
+                    meta.query_advice(config.fse_decoder.table_size, Rotation::cur()),
+                );
+
+                // TODO: bitstream can be byte-unaligned (trailing bits are ignored)
 
                 cb.gate(condition)
             },
@@ -2701,11 +2729,86 @@ impl DecoderConfig {
         meta.create_gate(
             "DecoderConfig: tag ZstdBlockSequenceData (last row)",
             |meta| {
-                let condition = meta.query_advice(config.tag_config.is_change, Rotation::next());
+                let condition = and::expr([
+                    meta.query_advice(config.tag_config.is_sequence_data, Rotation::cur()),
+                    meta.query_advice(config.tag_config.is_change, Rotation::next()),
+                ]);
 
                 let mut cb = BaseConstraintBuilder::default();
 
-                // TODO
+                // last operation is: code-to-value for LLT.
+                cb.require_zero(
+                    "last operation (sequences data): is_init",
+                    meta.query_advice(config.sequences_data_decoder.is_init_state, Rotation::cur()),
+                );
+                cb.require_zero(
+                    "last operation (sequences data): is_update_state",
+                    meta.query_advice(
+                        config.sequences_data_decoder.is_update_state,
+                        Rotation::cur(),
+                    ),
+                );
+                cb.require_equal(
+                    "last operation (sequences data): table_kind",
+                    meta.query_advice(config.fse_decoder.table_kind, Rotation::cur()),
+                    FseTableKind::LLT.expr(),
+                );
+
+                // idx == block.num_sequences.
+                cb.require_equal(
+                    "last row: idx = num_sequences",
+                    meta.query_advice(config.sequences_data_decoder.idx, Rotation::cur()),
+                    meta.query_advice(config.block_config.num_sequences, Rotation::cur()),
+                );
+
+                // tag::next == is_last_block ? Null : BlockHeader.
+                cb.require_equal(
+                    "last row: tag::next",
+                    meta.query_advice(config.tag_config.tag_next, Rotation::cur()),
+                    select::expr(
+                        meta.query_advice(config.block_config.is_last_block, Rotation::cur()),
+                        ZstdTag::Null.expr(),
+                        ZstdTag::BlockHeader.expr(),
+                    ),
+                );
+
+                // bitstream was consumed completely (byte-aligned):
+                // - if not_nil(cur) -> bit_index_end == 7
+                // - if nil(cur) and not_nil(prev) -> bit_index_end == 15
+                // - if nil(cur) and nil(prev) -> not_nil(-2) and bit_index_end == 23
+                let (is_nil_curr, is_nil_prev, is_nil_prev_prev) = (
+                    config.bitstream_decoder.is_nil(meta, Rotation::cur()),
+                    config.bitstream_decoder.is_nil(meta, Rotation::prev()),
+                    config.bitstream_decoder.is_nil(meta, Rotation(-2)),
+                );
+                cb.condition(not::expr(is_nil_curr.expr()), |cb| {
+                    cb.require_equal(
+                        "is_not_nil: bit_index_end==7",
+                        meta.query_advice(config.bitstream_decoder.bit_index_end, Rotation::cur()),
+                        7.expr(),
+                    );
+                });
+                cb.condition(
+                    and::expr([is_nil_curr.expr(), not::expr(is_nil_prev.expr())]),
+                    |cb| {
+                        cb.require_equal(
+                            "is_nil and is_not_nil(prev): bit_index_end==15",
+                            meta.query_advice(
+                                config.bitstream_decoder.bit_index_end,
+                                Rotation::prev(),
+                            ),
+                            15.expr(),
+                        );
+                    },
+                );
+                cb.condition(and::expr([is_nil_curr, is_nil_prev]), |cb| {
+                    cb.require_zero("is_nil and is_nil(prev): is_not_nil(-2)", is_nil_prev_prev);
+                    cb.require_equal(
+                        "is_nil and is_nil(prev): bit_index_end==23",
+                        meta.query_advice(config.bitstream_decoder.bit_index_end, Rotation(-2)),
+                        23.expr(),
+                    );
+                });
 
                 cb.gate(condition)
             },

--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -971,7 +971,7 @@ impl DecoderConfig {
 
         // Helper tables
         let literals_header_table = LiteralsHeaderTable::configure(meta, range8, range16);
-        let bitstring_table = BitstringTable::configure(meta);
+        let bitstring_table = BitstringTable::configure(meta, u8_table);
         let fse_table = FseTable::configure(
             meta,
             &fixed_table,

--- a/aggregator/src/aggregation/decoder/tables/bitstring.rs
+++ b/aggregator/src/aggregation/decoder/tables/bitstring.rs
@@ -7,7 +7,7 @@ use halo2_proofs::{
 };
 use zkevm_circuits::{
     evm_circuit::{BaseConstraintBuilder, ConstrainBuilderCommon},
-    table::LookupTable,
+    table::{LookupTable, RangeTable, U8Table},
 };
 
 use crate::aggregation::decoder::witgen::ZstdWitnessRow;
@@ -104,7 +104,7 @@ pub struct BitstringTable {
 
 impl BitstringTable {
     /// Construct the bitstring accumulation table.
-    pub fn configure(meta: &mut ConstraintSystem<Fr>) -> Self {
+    pub fn configure(meta: &mut ConstraintSystem<Fr>, u8_table: U8Table) -> Self {
         let config = Self {
             q_first: meta.fixed_column(),
             byte_idx_1: meta.advice_column(),
@@ -125,7 +125,7 @@ impl BitstringTable {
             is_padding: meta.advice_column(),
         };
 
-        meta.create_gate("BitstringAccumulationTable: bit_index == 0", |meta| {
+        meta.create_gate("BitstringTable: bit_index == 0", |meta| {
             let condition = and::expr([
                 meta.query_fixed(config.q_start, Rotation::cur()),
                 not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
@@ -137,9 +137,20 @@ impl BitstringTable {
                 .map(|i| meta.query_advice(config.bit, Rotation(i)))
                 .collect::<Vec<Expression<Fr>>>();
 
+            let (byte_idx_1, byte_idx_2, byte_idx_3) = (
+                meta.query_advice(config.byte_idx_1, Rotation::cur()),
+                meta.query_advice(config.byte_idx_2, Rotation::cur()),
+                meta.query_advice(config.byte_idx_3, Rotation::cur()),
+            );
+            let (byte_1, byte_2, byte_3) = (
+                meta.query_advice(config.byte_1, Rotation::cur()),
+                meta.query_advice(config.byte_2, Rotation::cur()),
+                meta.query_advice(config.byte_3, Rotation::cur()),
+            );
+
             cb.require_equal(
                 "byte1 is the binary accumulation of 0 <= bit_index <= 7",
-                meta.query_advice(config.byte_1, Rotation::cur()),
+                byte_1,
                 select::expr(
                     meta.query_advice(config.is_reverse, Rotation::cur()),
                     bits[7].expr()
@@ -163,7 +174,7 @@ impl BitstringTable {
 
             cb.require_equal(
                 "byte2 is the binary accumulation of 8 <= bit_index <= 15",
-                meta.query_advice(config.byte_2, Rotation::cur()),
+                byte_2,
                 select::expr(
                     meta.query_advice(config.is_reverse, Rotation::cur()),
                     bits[15].expr()
@@ -187,7 +198,7 @@ impl BitstringTable {
 
             cb.require_equal(
                 "byte3 is the binary accumulation of 16 <= bit_index <= 23",
-                meta.query_advice(config.byte_3, Rotation::cur()),
+                byte_3,
                 select::expr(
                     meta.query_advice(config.is_reverse, Rotation::cur()),
                     bits[23].expr()
@@ -224,7 +235,7 @@ impl BitstringTable {
             cb.gate(condition)
         });
 
-        meta.create_gate("BitstringAccumulationTable: bit_index > 0", |meta| {
+        meta.create_gate("BitstringTable: bit_index > 0", |meta| {
             let condition = and::expr([
                 not::expr(meta.query_fixed(config.q_start, Rotation::cur())),
                 not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
@@ -259,111 +270,106 @@ impl BitstringTable {
             cb.gate(condition)
         });
 
-        meta.create_gate(
-            "BitstringAccumulationTable: bitstring_value accumulation",
-            |meta| {
-                let condition = not::expr(meta.query_advice(config.is_padding, Rotation::cur()));
+        meta.create_gate("BitstringTable: bitstring_value accumulation", |meta| {
+            let condition = not::expr(meta.query_advice(config.is_padding, Rotation::cur()));
 
-                let mut cb = BaseConstraintBuilder::default();
+            let mut cb = BaseConstraintBuilder::default();
 
-                let is_start = meta.query_fixed(config.q_start, Rotation::cur());
-                let is_end = meta.query_fixed(config.q_start, Rotation::next());
+            let is_start = meta.query_fixed(config.q_start, Rotation::cur());
+            let is_end = meta.query_fixed(config.q_start, Rotation::next());
 
-                // bit value is boolean.
-                cb.require_boolean(
-                    "bit is boolean",
+            // bit value is boolean.
+            cb.require_boolean(
+                "bit is boolean",
+                meta.query_advice(config.bit, Rotation::cur()),
+            );
+
+            // Columns from_start and until_end are boolean.
+            cb.require_boolean(
+                "from_start is boolean",
+                meta.query_advice(config.from_start, Rotation::cur()),
+            );
+            cb.require_boolean(
+                "until_end is boolean",
+                meta.query_advice(config.until_end, Rotation::cur()),
+            );
+
+            // until_end transitions from 0 to 1 only once, i.e. delta is boolean
+            let delta = meta.query_advice(config.until_end, Rotation::next())
+                - meta.query_advice(config.until_end, Rotation::cur());
+
+            cb.condition(is_end.expr(), |cb| {
+                cb.require_equal(
+                    "if bit_index == 23: until_end == 1",
+                    meta.query_advice(config.until_end, Rotation::cur()),
+                    1.expr(),
+                );
+            });
+            cb.condition(not::expr(is_end.expr()), |cb| {
+                cb.require_boolean("until_end delta is boolean", delta);
+            });
+
+            // Constraints at meaningful bits.
+            let is_set = and::expr([
+                meta.query_advice(config.from_start, Rotation::cur()),
+                meta.query_advice(config.until_end, Rotation::cur()),
+            ]);
+            cb.condition(is_start.expr() * is_set.expr(), |cb| {
+                cb.require_equal(
+                    "if is_start && is_set: bit == bitstring_value_acc",
                     meta.query_advice(config.bit, Rotation::cur()),
+                    meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
                 );
-
-                // Columns from_start and until_end are boolean.
-                cb.require_boolean(
-                    "from_start is boolean",
-                    meta.query_advice(config.from_start, Rotation::cur()),
+                cb.require_equal(
+                    "if is_start && is_set: bitstring_len == 1",
+                    meta.query_advice(config.bitstring_len, Rotation::cur()),
+                    1.expr(),
                 );
-                cb.require_boolean(
-                    "until_end is boolean",
-                    meta.query_advice(config.until_end, Rotation::cur()),
+            });
+            cb.condition(not::expr(is_start) * is_set, |cb| {
+                cb.require_equal(
+                    "is_set: bitstring_value_acc == bitstring_value_acc::prev * 2 + bit",
+                    meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
+                    meta.query_advice(config.bitstring_value_acc, Rotation::prev()) * 2.expr()
+                        + meta.query_advice(config.bit, Rotation::cur()),
                 );
+                cb.require_equal(
+                    "is_set: bitstring_len == bitstring_len::prev + 1",
+                    meta.query_advice(config.bitstring_len, Rotation::cur()),
+                    meta.query_advice(config.bitstring_len, Rotation::prev()) + 1.expr(),
+                );
+            });
 
-                // until_end transitions from 0 to 1 only once, i.e. delta is boolean
-                let delta = meta.query_advice(config.until_end, Rotation::next())
-                    - meta.query_advice(config.until_end, Rotation::cur());
+            // Constraints at bits to be ignored (at the start).
+            let is_ignored_start = not::expr(meta.query_advice(config.until_end, Rotation::cur()));
+            cb.condition(is_ignored_start, |cb| {
+                cb.require_zero(
+                    "while until_end == 0: bitstring_len == 0",
+                    meta.query_advice(config.bitstring_len, Rotation::cur()),
+                );
+                cb.require_zero(
+                    "while until_end == 0: bitstring_value_acc == 0",
+                    meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
+                );
+            });
 
-                cb.condition(is_end.expr(), |cb| {
-                    cb.require_equal(
-                        "if bit_index == 23: until_end == 1",
-                        meta.query_advice(config.until_end, Rotation::cur()),
-                        1.expr(),
-                    );
-                });
-                cb.condition(not::expr(is_end.expr()), |cb| {
-                    cb.require_boolean("until_end delta is boolean", delta);
-                });
+            // Constraints at bits to be ignored (towards the end).
+            let is_ignored_end = not::expr(meta.query_advice(config.from_start, Rotation::cur()));
+            cb.condition(is_ignored_end, |cb| {
+                cb.require_equal(
+                    "bitstring_len unchanged at the last ignored bits",
+                    meta.query_advice(config.bitstring_len, Rotation::cur()),
+                    meta.query_advice(config.bitstring_len, Rotation::prev()),
+                );
+                cb.require_equal(
+                    "bitstring_value_acc unchanged at the last ignored bits",
+                    meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
+                    meta.query_advice(config.bitstring_value_acc, Rotation::prev()),
+                );
+            });
 
-                // Constraints at meaningful bits.
-                let is_set = and::expr([
-                    meta.query_advice(config.from_start, Rotation::cur()),
-                    meta.query_advice(config.until_end, Rotation::cur()),
-                ]);
-                cb.condition(is_start.expr() * is_set.expr(), |cb| {
-                    cb.require_equal(
-                        "if is_start && is_set: bit == bitstring_value_acc",
-                        meta.query_advice(config.bit, Rotation::cur()),
-                        meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
-                    );
-                    cb.require_equal(
-                        "if is_start && is_set: bitstring_len == 1",
-                        meta.query_advice(config.bitstring_len, Rotation::cur()),
-                        1.expr(),
-                    );
-                });
-                cb.condition(not::expr(is_start) * is_set, |cb| {
-                    cb.require_equal(
-                        "is_set: bitstring_value_acc == bitstring_value_acc::prev * 2 + bit",
-                        meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
-                        meta.query_advice(config.bitstring_value_acc, Rotation::prev()) * 2.expr()
-                            + meta.query_advice(config.bit, Rotation::cur()),
-                    );
-                    cb.require_equal(
-                        "is_set: bitstring_len == bitstring_len::prev + 1",
-                        meta.query_advice(config.bitstring_len, Rotation::cur()),
-                        meta.query_advice(config.bitstring_len, Rotation::prev()) + 1.expr(),
-                    );
-                });
-
-                // Constraints at bits to be ignored (at the start).
-                let is_ignored_start =
-                    not::expr(meta.query_advice(config.until_end, Rotation::cur()));
-                cb.condition(is_ignored_start, |cb| {
-                    cb.require_zero(
-                        "while until_end == 0: bitstring_len == 0",
-                        meta.query_advice(config.bitstring_len, Rotation::cur()),
-                    );
-                    cb.require_zero(
-                        "while until_end == 0: bitstring_value_acc == 0",
-                        meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
-                    );
-                });
-
-                // Constraints at bits to be ignored (towards the end).
-                let is_ignored_end =
-                    not::expr(meta.query_advice(config.from_start, Rotation::cur()));
-                cb.condition(is_ignored_end, |cb| {
-                    cb.require_equal(
-                        "bitstring_len unchanged at the last ignored bits",
-                        meta.query_advice(config.bitstring_len, Rotation::cur()),
-                        meta.query_advice(config.bitstring_len, Rotation::prev()),
-                    );
-                    cb.require_equal(
-                        "bitstring_value_acc unchanged at the last ignored bits",
-                        meta.query_advice(config.bitstring_value_acc, Rotation::cur()),
-                        meta.query_advice(config.bitstring_value_acc, Rotation::prev()),
-                    );
-                });
-
-                cb.gate(condition)
-            },
-        );
+            cb.gate(condition)
+        });
 
         meta.create_gate("BitstringTable: first row", |meta| {
             let condition = meta.query_fixed(config.q_first, Rotation::cur());
@@ -378,23 +384,53 @@ impl BitstringTable {
             cb.gate(condition)
         });
 
-        meta.create_gate("BitstringAccumulationTable: padding", |meta| {
+        meta.create_gate("BitstringTable: padding", |meta| {
             let condition = not::expr(meta.query_fixed(config.q_first, Rotation::cur()));
 
             let mut cb = BaseConstraintBuilder::default();
 
-            // padding is boolean
-            cb.require_boolean(
-                "is_padding is boolean",
+            let (is_padding_curr, is_padding_prev) = (
                 meta.query_advice(config.is_padding, Rotation::cur()),
+                meta.query_advice(config.is_padding, Rotation::prev()),
             );
 
+            // padding is boolean
+            cb.require_boolean("is_padding is boolean", is_padding_curr.expr());
+
             // padding transitions from 0 to 1 only once.
-            let delta = meta.query_advice(config.is_padding, Rotation::cur())
-                - meta.query_advice(config.is_padding, Rotation::prev());
+            let delta = is_padding_curr - is_padding_prev;
             cb.require_boolean("is_padding delta is boolean", delta);
 
             cb.gate(condition)
+        });
+
+        // For every bitstring accumulation, the byte indices must be in the order in which
+        // they appear in the rows assigned to the DecoderConfig. Which means:
+        // - byte_idx_2 at the most increments by 1 compared to byte_idx_1.
+        // - byte_idx_3 at the most increments by 1 compared to byte_idx_2.
+        //
+        // We indirectly validate this part through the lookup from DecoderConfig to the
+        // BitstringTable, that includes the byte indices.
+        //
+        // However, we still want to make sure subsequent bitstring accumulation happens in
+        // increasing order of byte indices, to avoid malicious assignments for an older byte
+        // index. We need this check only for subsequent bitstrings after q_first=true.
+        //
+        // TODO: for a multi-block setup, the difference may be greater than 255.
+        meta.lookup("BitstringTable: byte_idx_1 is increasing", |meta| {
+            let condition = and::expr([
+                meta.query_fixed(config.q_start, Rotation::cur()),
+                not::expr(meta.query_fixed(config.q_first, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
+            ]);
+
+            let (byte_idx_1_curr, byte_idx_1_prev) = (
+                meta.query_advice(config.byte_idx_1, Rotation::cur()),
+                meta.query_advice(config.byte_idx_1, Rotation::prev()),
+            );
+            let byte_idx_delta = byte_idx_1_curr - byte_idx_1_prev;
+
+            vec![(condition * byte_idx_delta, u8_table.into())]
         });
 
         debug_assert!(meta.degree() <= 9);

--- a/aggregator/src/aggregation/decoder/tables/literals_header.rs
+++ b/aggregator/src/aggregation/decoder/tables/literals_header.rs
@@ -112,35 +112,48 @@ impl LiteralsHeaderTable {
                 meta.query_advice(config.regen_size, Rotation::cur()),
             );
 
-            // TODO: byte_offset should be strictly increasing.
-
             cb.gate(condition)
         });
 
-        meta.create_gate("LiteralsHeaderTable: padding check", |meta| {
-            let condition = not::expr(meta.query_fixed(config.q_first, Rotation::cur()));
+        meta.create_gate(
+            "LiteralsHeaderTable: subsequent rows after q_first=true",
+            |meta| {
+                let condition = not::expr(meta.query_fixed(config.q_first, Rotation::cur()));
 
-            let mut cb = BaseConstraintBuilder::default();
+                let mut cb = BaseConstraintBuilder::default();
 
-            // padding transitions from 0 -> 1 only once.
-            let is_padding_cur = meta.query_advice(config.is_padding, Rotation::cur());
-            let is_padding_prev = meta.query_advice(config.is_padding, Rotation::prev());
-            let is_padding_delta = is_padding_cur.expr() - is_padding_prev;
+                // padding transitions from 0 -> 1 only once.
+                let is_padding_cur = meta.query_advice(config.is_padding, Rotation::cur());
+                let is_padding_prev = meta.query_advice(config.is_padding, Rotation::prev());
+                let is_padding_delta = is_padding_cur.expr() - is_padding_prev;
 
-            cb.require_boolean("is_padding is boolean", is_padding_cur.expr());
-            cb.require_boolean("is_padding delta is boolean", is_padding_delta);
+                cb.require_boolean("is_padding is boolean", is_padding_cur.expr());
+                cb.require_boolean("is_padding delta is boolean", is_padding_delta);
 
-            // if this is not a padding row, then block_idx has incremented.
-            cb.condition(not::expr(is_padding_cur), |cb| {
-                cb.require_equal(
-                    "block_idx increments by 1",
-                    meta.query_advice(config.block_idx, Rotation::cur()),
-                    meta.query_advice(config.block_idx, Rotation::prev()) + 1.expr(),
-                );
-            });
+                // if this is not a padding row, then block_idx has incremented.
+                cb.condition(not::expr(is_padding_cur.expr()), |cb| {
+                    cb.require_equal(
+                        "block_idx increments by 1",
+                        meta.query_advice(config.block_idx, Rotation::cur()),
+                        meta.query_advice(config.block_idx, Rotation::prev()) + 1.expr(),
+                    );
+                });
 
-            cb.gate(condition)
-        });
+                // block_idx increments.
+                //
+                // This also ensures that we are not populating conflicting literal headers for the
+                // same block_idx in this layout.
+                cb.condition(not::expr(is_padding_cur), |cb| {
+                    cb.require_equal(
+                        "block_idx increments",
+                        meta.query_advice(config.block_idx, Rotation::cur()),
+                        meta.query_advice(config.block_idx, Rotation::prev()) + 1.expr(),
+                    );
+                });
+
+                cb.gate(condition)
+            },
+        );
 
         meta.lookup("LiteralsHeaderTable: byte0 >> 3", |meta| {
             let condition = 1.expr();

--- a/gadgets/src/comparator.rs
+++ b/gadgets/src/comparator.rs
@@ -35,18 +35,25 @@ pub struct ComparatorConfig<F, const N_BYTES: usize> {
 }
 
 impl<F: Field, const N_BYTES: usize> ComparatorConfig<F, N_BYTES> {
-    /// Returns (lt, eq) for a comparison between lhs and rhs.
-    pub fn expr(
+    /// Returns (lt, eq) for a comparison between lhs and rhs at the current rotation.
+    pub fn expr(&self, meta: &mut VirtualCells<F>) -> (Expression<F>, Expression<F>) {
+        (
+            self.lt_chip.config.is_lt(meta, Rotation::cur()),
+            self.eq_chip.config.is_equal_expression.clone(),
+        )
+    }
+
+    /// Returns (lt, eq) for a comparison between lhs and rhs at a given rotation
+    pub fn expr_at(
         &self,
         meta: &mut VirtualCells<F>,
-        rotation: Option<Rotation>,
+        at: Rotation,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
     ) -> (Expression<F>, Expression<F>) {
-        let rotation_is_cur = rotation.map_or(true, |r| r == Rotation::cur());
-        assert!(rotation_is_cur);
-
         (
-            self.lt_chip.config.is_lt(meta, rotation),
-            self.eq_chip.config.is_equal_expression.clone(),
+            self.lt_chip.config.is_lt(meta, at),
+            self.eq_chip.config.expr_at(meta, at, lhs, rhs),
         )
     }
 }

--- a/gadgets/src/less_than.rs
+++ b/gadgets/src/less_than.rs
@@ -44,13 +44,12 @@ pub struct LtConfig<F, const N_BYTES: usize> {
 
 impl<F: Field, const N_BYTES: usize> LtConfig<F, N_BYTES> {
     /// Returns an expression that denotes whether lhs < rhs, or not.
-    pub fn is_lt(&self, meta: &mut VirtualCells<F>, rotation: Option<Rotation>) -> Expression<F> {
-        meta.query_advice(self.lt, rotation.unwrap_or_else(Rotation::cur))
+    pub fn is_lt(&self, meta: &mut VirtualCells<F>, rotation: Rotation) -> Expression<F> {
+        meta.query_advice(self.lt, rotation)
     }
 
     /// Returns an expression representing the difference between LHS and RHS.
-    pub fn diff(&self, meta: &mut VirtualCells<F>, rotation: Option<Rotation>) -> Expression<F> {
-        let rotation = rotation.unwrap_or_else(Rotation::cur);
+    pub fn diff(&self, meta: &mut VirtualCells<F>, rotation: Rotation) -> Expression<F> {
         sum::expr(self.diff.iter().map(|c| meta.query_advice(*c, rotation)))
     }
 }
@@ -288,7 +287,7 @@ mod test {
                     // This verifies lt(value::cur, value::next) is calculated correctly
                     let check = meta.query_advice(config.check, Rotation::cur());
 
-                    vec![q_enable * (config.lt.is_lt(meta, None) - check)]
+                    vec![q_enable * (config.lt.is_lt(meta, Rotation::cur()) - check)]
                 });
 
                 config
@@ -413,7 +412,7 @@ mod test {
                     // This verifies lt(lhs, rhs) is calculated correctly
                     let check = meta.query_advice(config.check, Rotation::cur());
 
-                    vec![q_enable * (config.lt.is_lt(meta, None) - check)]
+                    vec![q_enable * (config.lt.is_lt(meta, Rotation::cur()) - check)]
                 });
 
                 config

--- a/zkevm-circuits/src/rlp_circuit_fsm.rs
+++ b/zkevm-circuits/src/rlp_circuit_fsm.rs
@@ -904,8 +904,8 @@ impl<F: Field> RlpCircuitConfig<F> {
         meta.create_gate("booleans for reducing degree (part one)", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (bv_gt_0xc0, bv_eq_0xc0) = byte_value_gte_0xc0.expr(meta, None);
-            let (bv_lt_0xf8, _) = byte_value_lte_0xf8.expr(meta, None);
+            let (bv_gt_0xc0, bv_eq_0xc0) = byte_value_gte_0xc0.expr(meta);
+            let (bv_lt_0xf8, _) = byte_value_lte_0xf8.expr(meta);
 
             // use sum instead of or because is_tag_* cannot be true at the same time
             cb.require_equal(
@@ -1038,7 +1038,7 @@ impl<F: Field> RlpCircuitConfig<F> {
                 let tag_expr = tag_expr(meta);
                 let byte_value_expr = byte_value_expr(meta);
 
-                let (bv_lt_0x80, bv_eq_0x80) = byte_value_lte_0x80.expr(meta, None);
+                let (bv_lt_0x80, bv_eq_0x80) = byte_value_lte_0x80.expr(meta);
 
                 // case 1: 0x00 <= byte_value < 0x80
                 let case_1 = and::expr([bv_lt_0x80, not::expr(is_tag_end_expr(meta))]);
@@ -1204,8 +1204,8 @@ impl<F: Field> RlpCircuitConfig<F> {
         meta.create_gate("state transition: DecodeTagStart => Bytes", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (bv_gt_0x80, _) = byte_value_gte_0x80.expr(meta, None);
-            let (bv_lt_0xb8, _) = byte_value_lte_0xb8.expr(meta, None);
+            let (bv_gt_0x80, _) = byte_value_gte_0x80.expr(meta);
+            let (bv_lt_0xb8, _) = byte_value_lte_0xb8.expr(meta);
 
             // condition.
             cb.condition(and::expr([
@@ -1239,8 +1239,8 @@ impl<F: Field> RlpCircuitConfig<F> {
         meta.create_gate("state transition: Bytes", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (tidx_lt_tlen, tidx_eq_tlen) = tidx_lte_tlength.expr(meta, None);
-            let (mlen_lt_0x20, mlen_eq_0x20) = mlength_lte_0x20.expr(meta, None);
+            let (tidx_lt_tlen, tidx_eq_tlen) = tidx_lte_tlength.expr(meta);
+            let (mlen_lt_0x20, mlen_eq_0x20) = mlength_lte_0x20.expr(meta);
 
             let b = select::expr(
                 mlen_lt_0x20,
@@ -1268,7 +1268,7 @@ impl<F: Field> RlpCircuitConfig<F> {
             // Bytes => DecodeTagStart
             cb.condition(tidx_eq_tlen, |cb| {
                 // assertions
-                let (lt, eq) = tlength_lte_mlength.expr(meta, Some(Rotation::cur()));
+                let (lt, eq) = tlength_lte_mlength.expr(meta);
                 cb.require_equal(
                     "tag_length <= max_length",
                     // we can use `sum` instead of `or` for two reasons
@@ -1300,8 +1300,8 @@ impl<F: Field> RlpCircuitConfig<F> {
         meta.create_gate("state transition: DecodeTagStart => LongBytes", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (bv_gt_0xb8, bv_eq_0xb8) = byte_value_gte_0xb8.expr(meta, None);
-            let (bv_lt_0xc0, _) = byte_value_lte_0xc0.expr(meta, None);
+            let (bv_gt_0xb8, bv_eq_0xb8) = byte_value_gte_0xb8.expr(meta);
+            let (bv_lt_0xc0, _) = byte_value_lte_0xc0.expr(meta);
 
             // condition: "0xb8 <= byte_value < 0xc0"
             cb.condition(and::expr([
@@ -1334,7 +1334,7 @@ impl<F: Field> RlpCircuitConfig<F> {
         meta.create_gate("state transition: LongBytes", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (tidx_lt_tlen, tidx_eq_tlen) = tidx_lte_tlength.expr(meta, None);
+            let (tidx_lt_tlen, tidx_eq_tlen) = tidx_lte_tlength.expr(meta);
 
             // LongBytes => LongBytes
             cb.condition(tidx_lt_tlen, |cb| {
@@ -1378,7 +1378,7 @@ impl<F: Field> RlpCircuitConfig<F> {
         meta.create_gate("state transition: DecodeTagStart => LongList", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (bv_gt_0xf8, bv_eq_0xf8) = byte_value_gte_0xf8.expr(meta, None);
+            let (bv_gt_0xf8, bv_eq_0xf8) = byte_value_gte_0xf8.expr(meta);
 
             let cond = and::expr([
                 sum::expr([bv_gt_0xf8, bv_eq_0xf8]),
@@ -1409,7 +1409,7 @@ impl<F: Field> RlpCircuitConfig<F> {
         meta.create_gate("state transition: LongList", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (tidx_lt_tlen, tidx_eq_tlen) = tidx_lte_tlength.expr(meta, None);
+            let (tidx_lt_tlen, tidx_eq_tlen) = tidx_lte_tlength.expr(meta);
 
             // LongList => LongList
             cb.condition(tidx_lt_tlen, |cb| {
@@ -1433,7 +1433,7 @@ impl<F: Field> RlpCircuitConfig<F> {
             // LongList => DecodeTagStart
             cb.condition(tidx_eq_tlen.expr(), |cb| {
                 // assertions
-                let (lt, eq) = tlength_lte_mlength.expr(meta, Some(Rotation::cur()));
+                let (lt, eq) = tlength_lte_mlength.expr(meta);
                 cb.require_equal("tag_length <= max_length", sum::expr([lt, eq]), true.expr());
 
                 // state transitions

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -1315,7 +1315,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
         meta.create_gate("tx_id <= cum_num_txs", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let (lt_expr, eq_expr) = tx_id_cmp_cum_num_txs.expr(meta, None);
+            let (lt_expr, eq_expr) = tx_id_cmp_cum_num_txs.expr(meta);
             cb.condition(is_block_num(meta), |cb| {
                 cb.require_equal("lt or eq", sum::expr([lt_expr, eq_expr]), true.expr());
             });


### PR DESCRIPTION
- [x] `LiteralsHeaderTable` constrains `block_idx` transition
- [x] `BitstringTable` constrains `byte_idx` to be increasing
- [x] `tag=ZstdBlockSequencesData`'s last row is constrained
- [x] `tag=ZstdBlockSequencesFseCode`'s last row is constrained
- [x] `tag=BlockHeader` following the end of the previous block, is constrained
- [x] `tag=Null` (the end of encoded bytes) is constrained