### PR TITLE
`tag=FseCode` should take into account "variable bit-packing"

### DIFF
--- a/aggregator/src/aggregation/decoder/tables/fixed.rs
+++ b/aggregator/src/aggregation/decoder/tables/fixed.rs
@@ -29,6 +29,9 @@ use seq_tag_order::RomSeqTagOrder;
 mod tag_transition;
 use tag_transition::RomTagTransition;
 
+mod variable_bit_packing;
+use variable_bit_packing::RomVariableBitPacking;
+
 pub trait FixedLookupValues {
     fn values() -> Vec<[Value<Fr>; 7]>;
 }
@@ -52,6 +55,11 @@ pub enum FixedLookupTag {
     /// Represents the FSE table reconstructed from the default distributions, i.e. Predefined FSE
     /// table.
     PredefinedFse,
+    /// Represents read and decoded values for the variable bit-packing as specified in the [zstd
+    /// comopression format][doclink]:
+    ///
+    /// doclink: https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#fse-table-description
+    VariableBitPacking,
 }
 
 impl_expr!(FixedLookupTag);
@@ -65,6 +73,7 @@ impl FixedLookupTag {
             Self::SeqCodeToValue => RomSeqCodeToValue::values(),
             Self::FseTableTransition => RomFseTableTransition::values(),
             Self::PredefinedFse => RomPredefinedFse::values(),
+            Self::VariableBitPacking => RomVariableBitPacking::values(),
         }
     }
 }

--- a/aggregator/src/aggregation/decoder/tables/fixed/variable_bit_packing.rs
+++ b/aggregator/src/aggregation/decoder/tables/fixed/variable_bit_packing.rs
@@ -1,0 +1,87 @@
+use halo2_proofs::{circuit::Value, halo2curves::bn256::Fr};
+
+use crate::aggregation::decoder::witgen::util::bit_length;
+
+use super::{FixedLookupTag, FixedLookupValues};
+
+#[derive(Clone, Debug)]
+pub struct RomVariableBitPacking {
+    range: u64,
+    value_read: u64,
+    value_decoded: u64,
+    num_bits: u64,
+}
+
+impl FixedLookupValues for RomVariableBitPacking {
+    fn values() -> Vec<[Value<Fr>; 7]> {
+        // The maximum range R we ever have is 512 (1 << 9) as the maximum possible accuracy log is
+        // 9. So we only need to support a range up to R + 1, i.e. 513.
+        let rows = (0..=513)
+            .flat_map(|range| {
+                // Get the number of bits required to represent the highest number in this range.
+                let size = bit_length(range) as u32;
+                let max = 1 << size;
+
+                // Whether ``range`` is a power of 2 minus 1, i.e. 2^k - 1. In these cases, we
+                // don't need variable bit-packing as all values in the range can be represented by
+                // the same number of bits.
+                let is_no_var = range & (range + 1) == 0;
+
+                // The value read is in fact the value decoded.
+                if is_no_var {
+                    return (0..=range)
+                        .map(|value_read| RomVariableBitPacking {
+                            range,
+                            value_read,
+                            value_decoded: value_read,
+                            num_bits: size as u64,
+                        })
+                        .collect::<Vec<_>>();
+                }
+
+                let n_total = range + 1;
+                let lo_pin = max - n_total;
+                let n_remaining = n_total - lo_pin;
+                let hi_pin_1 = lo_pin + (n_remaining / 2);
+                let hi_pin_2 = max - (n_remaining / 2);
+
+                (0..max)
+                    .map(|value_read| {
+                        // the value denoted by the low (size - 1)-bits.
+                        let lo_value = value_read & ((1 << (size - 1)) - 1);
+                        let (num_bits, value_decoded) = if (0..lo_pin).contains(&lo_value) {
+                            (size - 1, lo_value)
+                        } else if (lo_pin..hi_pin_1).contains(&value_read) {
+                            (size, value_read)
+                        } else if (hi_pin_1..hi_pin_2).contains(&value_read) {
+                            (size - 1, value_read - hi_pin_1)
+                        } else {
+                            assert!((hi_pin_2..max).contains(&value_read));
+                            (size, value_read - lo_pin)
+                        };
+                        RomVariableBitPacking {
+                            range,
+                            value_read,
+                            value_decoded,
+                            num_bits: num_bits.into(),
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        rows.iter()
+            .map(|row| {
+                [
+                    Value::known(Fr::from(FixedLookupTag::VariableBitPacking as u64)),
+                    Value::known(Fr::from(row.range)),
+                    Value::known(Fr::from(row.value_read)),
+                    Value::known(Fr::from(row.value_decoded)),
+                    Value::known(Fr::from(row.num_bits)),
+                    Value::known(Fr::zero()),
+                    Value::known(Fr::zero()),
+                ]
+            })
+            .collect()
+    }
+}

--- a/aggregator/src/aggregation/decoder/tables/fixed/variable_bit_packing.rs
+++ b/aggregator/src/aggregation/decoder/tables/fixed/variable_bit_packing.rs
@@ -16,7 +16,7 @@ impl FixedLookupValues for RomVariableBitPacking {
     fn values() -> Vec<[Value<Fr>; 7]> {
         // The maximum range R we ever have is 512 (1 << 9) as the maximum possible accuracy log is
         // 9. So we only need to support a range up to R + 1, i.e. 513.
-        let rows = (0..=513)
+        let rows = (1..=513)
             .flat_map(|range| {
                 // Get the number of bits required to represent the highest number in this range.
                 let size = bit_length(range) as u32;


### PR DESCRIPTION
Fixed:
- Added a `VariableBitPacking` type fixed lookup
- Whenever we decode an FSE symbol's normalised probability, lookup the fixed table and validate that as per variable bit-packing, the `(value read, value decoded, num bits read)` is correct for the range `R+1` that we were reading the value in, where `R` is the number of states available for the current FSE symbol. The number of states actually allocated are `value_decoded - 1`

Approach:
There is now a `value_decoded` column in the `FseDecoderConfig`. And the `value==0` and `value==1` checks are now done on this `value_decoded` instead of `bitstring_value`.
Whenever we read from the bitstream (to decode the normalised probability of an FSE symbol), the range (the number of states available to be allocated to this symbol) is `table_size - prob_acc + 1` so far, i.e. `table_size - prob_acc::prev() + 1`.
And we do a lookup to the `FixedTable::VariableBitPacking` , to know that based on the `value_read` (bitstring value from the bitstream) and the number of bits read (bitstring length), is the `value_decoded` correct as per variable bit-packing rules?