### PR TITLE
DA-Compression (Missing Pieces for single encoded batch)

### DIFF
--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -1004,7 +1004,7 @@ impl DecoderConfig {
         let sequences_data_decoder = SequencesDataDecoder::configure(meta);
         let sequence_execution_config = SequenceExecutionConfig::configure(
             meta,
-            challenges,
+            challenges.keccak_input(),
             &LiteralTable::construct([
                 q_enable.into(),
                 tag_config.tag.into(),
@@ -4203,7 +4203,7 @@ impl DecoderConfig {
         )?;
         let (exported_len, exported_rlc) = self.sequence_execution_config.assign(
             layouter,
-            challenges,
+            challenges.keccak_input(),
             literal_datas
                 .iter()
                 .zip(&sequence_info_arr)

--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -1911,7 +1911,7 @@ impl DecoderConfig {
                     0.expr(),
                 );
                 let byte2 = select::expr(
-                    size_format_bit1.expr() * size_format_bit1.expr(),
+                    size_format_bit0.expr() * size_format_bit1.expr(),
                     meta.query_advice(config.byte, Rotation(2)),
                     0.expr(),
                 );
@@ -1923,7 +1923,7 @@ impl DecoderConfig {
                     size_format_bit0.expr() * not::expr(size_format_bit1.expr()),
                     meta.query_advice(config.tag_config.tag_len, Rotation(2)),
                     select::expr(
-                        size_format_bit1.expr() * size_format_bit0.expr(),
+                        size_format_bit0.expr() * size_format_bit1.expr(),
                         meta.query_advice(config.tag_config.tag_len, Rotation(3)),
                         meta.query_advice(config.tag_config.tag_len, Rotation(1)),
                     ),
@@ -5066,7 +5066,7 @@ mod tests {
             .map(|data| hex::decode(data.trim_end()).expect("Failed to decode hex data"))
             .collect::<Vec<Vec<u8>>>();
 
-        let raw = batches[0].clone();
+        let raw = batches[127].clone();
         let compressed = {
             // compression level = 0 defaults to using level=3, which is zstd's default.
             let mut encoder =
@@ -5104,6 +5104,7 @@ mod tests {
             encoder.finish().expect("Encoder success")
         };
 
+        println!("len(encoded)={:6}\tlen(decoded)={:6}", compressed.len(), raw.len());
         let k = 18;
         let decoder_config_tester = DecoderConfigTester { raw, compressed, k };
         let mock_prover = MockProver::<Fr>::run(k, &decoder_config_tester, vec![]).unwrap();

--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -2591,13 +2591,17 @@ impl DecoderConfig {
                     1.expr(),
                     value_decoded - 1.expr(),
                 );
+                let is_predefined_mode =
+                    config
+                        .block_config
+                        .is_predefined(meta, &config.fse_decoder, Rotation::cur());
 
                 [
                     0.expr(), // skip first row
                     block_idx,
                     fse_table_kind,
                     fse_table_size,
-                    0.expr(), // is_predefined
+                    is_predefined_mode,
                     fse_symbol,
                     norm_prob.expr(),
                     norm_prob.expr(),
@@ -5104,7 +5108,11 @@ mod tests {
             encoder.finish().expect("Encoder success")
         };
 
-        println!("len(encoded)={:6}\tlen(decoded)={:6}", compressed.len(), raw.len());
+        println!(
+            "len(encoded)={:6}\tlen(decoded)={:6}",
+            compressed.len(),
+            raw.len()
+        );
         let k = 18;
         let decoder_config_tester = DecoderConfigTester { raw, compressed, k };
         let mock_prover = MockProver::<Fr>::run(k, &decoder_config_tester, vec![]).unwrap();

--- a/aggregator/src/aggregation/decoder/seq_exec.rs
+++ b/aggregator/src/aggregation/decoder/seq_exec.rs
@@ -814,6 +814,8 @@ impl<F: Field> SeqExecConfig<F> {
                     (true, r.clone())
                 }
                 SequenceExecInfo::BackRef(r) => (false, r.clone()),
+                // TODO(VF): Add support for repeated match byte slice
+                SequenceExecInfo::BackRefRepeated(r, l) => (false, r.clone()),
             };
 
             for (i, pos) in r.clone().enumerate() {

--- a/aggregator/src/aggregation/decoder/seq_exec.rs
+++ b/aggregator/src/aggregation/decoder/seq_exec.rs
@@ -814,8 +814,6 @@ impl<F: Field> SeqExecConfig<F> {
                     (true, r.clone())
                 }
                 SequenceExecInfo::BackRef(r) => (false, r.clone()),
-                // TODO(VF): Add support for repeated match byte slice
-                SequenceExecInfo::BackRefRepeated(r, l) => (false, r.clone()),
             };
 
             for (i, pos) in r.clone().enumerate() {
@@ -1096,8 +1094,9 @@ mod tests {
                         inst.instruction_idx as usize,
                         SequenceExecInfo::BackRef(r.clone()),
                     ));
-                    let matched_bytes = Vec::from(&outputs[r]);
-                    outputs.extend(matched_bytes);
+                    for ref_pos in r {
+                        outputs.push(outputs[ref_pos]);
+                    }
                 }
                 current_literal_pos = new_literal_pos;
             }

--- a/aggregator/src/aggregation/decoder/seq_exec.rs
+++ b/aggregator/src/aggregation/decoder/seq_exec.rs
@@ -1160,7 +1160,13 @@ mod tests {
             let chng_mock = MockChallenges::construct(meta);
             let chng = chng_mock.exprs(meta);
 
-            let config = SeqExecConfig::configure(meta, chng.keccak_input(), &literal_tbl, &inst_tbl, &seq_cfg);
+            let config = SeqExecConfig::configure(
+                meta,
+                chng.keccak_input(),
+                &literal_tbl,
+                &inst_tbl,
+                &seq_cfg,
+            );
 
             Self::Config {
                 config,

--- a/aggregator/src/aggregation/decoder/seq_exec.rs
+++ b/aggregator/src/aggregation/decoder/seq_exec.rs
@@ -12,10 +12,7 @@ use halo2_proofs::{
 use itertools::Itertools;
 use tables::SeqInstTable;
 use witgen::{SequenceExec, SequenceExecInfo, SequenceInfo, ZstdTag};
-use zkevm_circuits::{
-    evm_circuit::{BaseConstraintBuilder, ConstrainBuilderCommon},
-    util::Challenges,
-};
+use zkevm_circuits::evm_circuit::{BaseConstraintBuilder, ConstrainBuilderCommon};
 
 /// TODO: This is in fact part of the `BlockConfig` in
 /// Decoder, we can use BlockConfig if it is decoupled
@@ -296,7 +293,7 @@ impl<F: Field> SeqExecConfig<F> {
     /// the maxium rotation is prev(2), next(1)
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
-        challenges: &Challenges<Expression<F>>,
+        challenges: Expression<F>,
         literal_table: &LiteralTable,
         inst_table: &SeqInstTable<F>,
         seq_config: &SequenceConfig,
@@ -545,7 +542,7 @@ impl<F: Field> SeqExecConfig<F> {
                 decoded_rlc_prev.expr()
                     * select::expr(
                         decoded_len.expr() - decoded_len_prev.expr(),
-                        challenges.evm_word(),
+                        challenges,
                         1.expr(),
                     )
                     + decoded_byte.expr(),
@@ -950,7 +947,7 @@ impl<F: Field> SeqExecConfig<F> {
     pub fn assign<'a>(
         &self,
         layouter: &mut impl Layouter<F>,
-        chng: &Challenges<Value<F>>,
+        chng: Value<F>,
         // per-block inputs: (literal, seq_info, seq_exec_trace)
         per_blk_inputs: impl IntoIterator<Item = (&'a [u64], &'a SequenceInfo, &'a [SequenceExec])>
             + Clone,
@@ -969,7 +966,7 @@ impl<F: Field> SeqExecConfig<F> {
                     blk_ind = seq_info.block_idx;
                     (offset, decoded_len, decoded_rlc) = self.assign_block(
                         &mut region,
-                        chng.evm_word(),
+                        chng,
                         offset,
                         decoded_len,
                         decoded_rlc,
@@ -997,7 +994,7 @@ impl<F: Field> SeqExecConfig<F> {
     pub fn mock_assign(
         &self,
         layouter: &mut impl Layouter<F>,
-        chng: &Challenges<Value<F>>,
+        chng: Value<F>,
         n_seq: usize,
         seq_exec_infos: &[SequenceExec],
         literals: &[u8],
@@ -1017,7 +1014,7 @@ impl<F: Field> SeqExecConfig<F> {
                 let offset = self.init_top_row(&mut region, None)?;
                 let (offset, decoded_len, decoded_rlc) = self.assign_block(
                     &mut region,
-                    chng.evm_word(),
+                    chng,
                     offset,
                     0,
                     Value::known(F::zero()),
@@ -1163,7 +1160,7 @@ mod tests {
             let chng_mock = MockChallenges::construct(meta);
             let chng = chng_mock.exprs(meta);
 
-            let config = SeqExecConfig::configure(meta, &chng, &literal_tbl, &inst_tbl, &seq_cfg);
+            let config = SeqExecConfig::configure(meta, chng.keccak_input(), &literal_tbl, &inst_tbl, &seq_cfg);
 
             Self::Config {
                 config,
@@ -1199,7 +1196,7 @@ mod tests {
 
             config.config.mock_assign(
                 &mut layouter,
-                &chng_val,
+                chng_val.keccak_input(),
                 self.insts.len(),
                 &self.exec_trace,
                 &self.literals,

--- a/aggregator/src/aggregation/decoder/tables/fixed/tag_transition.rs
+++ b/aggregator/src/aggregation/decoder/tables/fixed/tag_transition.rs
@@ -41,6 +41,7 @@ impl FixedLookupValues for RomTagTransition {
             (ZstdBlockSequenceFseCode, ZstdBlockSequenceFseCode),
             (ZstdBlockSequenceFseCode, ZstdBlockSequenceData),
             (ZstdBlockSequenceData, Null),
+            (Null, Null),
         ]
         .map(|(tag, tag_next)| {
             [

--- a/aggregator/src/aggregation/decoder/tables/fse.rs
+++ b/aggregator/src/aggregation/decoder/tables/fse.rs
@@ -430,6 +430,16 @@ impl FseTable {
                 );
             });
 
+            // is the first symbol if:
+            // - prev row was prob=-1
+            let is_first_symbol = meta.query_advice(config.is_prob_less_than1, Rotation::prev());
+            cb.condition(is_first_symbol, |cb| {
+                cb.require_zero(
+                    "first symbol (prob >= 1): state == 0",
+                    meta.query_advice(config.state, Rotation::cur()),
+                );
+            });
+
             cb.gate(condition)
         });
 
@@ -686,6 +696,7 @@ impl FseTable {
                 not::expr(meta.query_fixed(config.sorted_table.q_first, Rotation::cur())),
                 not::expr(meta.query_fixed(config.sorted_table.q_start, Rotation::cur())),
                 not::expr(meta.query_advice(config.is_prob_less_than1, Rotation::cur())),
+                not::expr(meta.query_advice(config.is_prob_less_than1, Rotation::prev())),
                 not::expr(meta.query_advice(config.is_padding, Rotation::cur())),
             ]);
 

--- a/aggregator/src/aggregation/decoder/tables/fse.rs
+++ b/aggregator/src/aggregation/decoder/tables/fse.rs
@@ -634,9 +634,9 @@ impl FseTable {
 
             // The symbol_count_acc inits at 1.
             cb.require_equal(
-                "symbol_count_acc inits at 1",
+                "symbol_count_acc inits at 1 if not skipped state",
                 meta.query_advice(config.symbol_count_acc, Rotation::cur()),
-                1.expr(),
+                not::expr(meta.query_advice(config.is_skipped_state, Rotation::cur())),
             );
 
             cb.gate(condition)
@@ -749,7 +749,7 @@ impl FseTable {
                                                                     // Assign q_start
 
                     let states_to_symbol = table.parse_state_table();
-                    let mut state_idx: usize = 1;
+                    let mut state_idx: usize = 0;
 
                     // Assign the symbols with negative normalised probability
                     let tail_states_count = table
@@ -762,6 +762,7 @@ impl FseTable {
                             ..=(table.table_size - 1))
                             .rev()
                         {
+                            state_idx += 1;
                             region.assign_advice(
                                 || "state",
                                 self.state,
@@ -820,7 +821,7 @@ impl FseTable {
                                 || "is_skipped_state",
                                 self.is_skipped_state,
                                 fse_offset,
-                                || Value::known(Fr::one()),
+                                || Value::known(Fr::zero()),
                             )?;
                             region.assign_advice(
                                 || "symbol_count",
@@ -847,7 +848,6 @@ impl FseTable {
                                 || Value::known(Fr::from(table.table_size >> 3)),
                             )?;
 
-                            state_idx += 1;
                             fse_offset += 1;
                         }
                     }
@@ -860,11 +860,15 @@ impl FseTable {
                         .filter(|(_sym, w)| *w > 0)
                         .collect::<Vec<(u64, i32)>>();
                     for (sym, _c) in regular_symbols.clone().into_iter() {
-                        let mut sym_acc: usize = 1;
+                        let mut sym_acc: usize = 0;
                         let sym_rows = table.sym_to_states.get(&sym).expect("symbol exists.");
                         let sym_count = sym_rows.iter().filter(|r| !r.is_state_skipped).count();
 
-                        for fse_row in sym_rows {
+                        for (j, fse_row) in sym_rows.iter().enumerate() {
+                            if !fse_row.is_state_skipped {
+                                state_idx += 1;
+                                sym_acc += 1;
+                            }
                             region.assign_advice(
                                 || "state",
                                 self.state,
@@ -899,7 +903,7 @@ impl FseTable {
                                 || "is_new_symbol",
                                 self.is_new_symbol,
                                 fse_offset,
-                                || Value::known(Fr::from((sym_acc == 1) as u64)),
+                                || Value::known(Fr::from((j == 0) as u64)),
                             )?;
                             region.assign_advice(
                                 || "is_prob_less_than1",
@@ -939,18 +943,14 @@ impl FseTable {
                             )?;
 
                             fse_offset += 1;
-                            if !fse_row.is_state_skipped {
-                                state_idx += 1;
-                                sym_acc += 1;
-                            }
                         }
                     }
 
                     // witgen_debug
-                    // assert!(
-                    //     state_idx as u64 == table.table_size,
-                    //     "Last state should correspond to end of table"
-                    // );
+                    assert!(
+                        state_idx as u64 == table.table_size,
+                        "Last state should correspond to end of table"
+                    );
 
                     // Assign the symbols with positive probability in sorted table
                     for (sym, _c) in regular_symbols.into_iter() {
@@ -973,6 +973,10 @@ impl FseTable {
                             as u64;
 
                         for fse_row in sym_rows {
+                            assert!(
+                                !fse_row.is_state_skipped,
+                                "sorted state rows cannot be skipped states"
+                            );
                             if !fse_row.is_state_skipped {
                                 region.assign_advice(
                                     || "sorted_table.block_idx",
@@ -1123,9 +1127,7 @@ impl FseTable {
                             || "idx",
                             self.idx,
                             offset,
-                            // We incremented state_idx after the last valid symbol's last state.
-                            // So we less 1 here.
-                            || Value::known(Fr::from(state_idx as u64 - 1)),
+                            || Value::known(Fr::from(state_idx as u64)),
                         )?;
                     }
                     for offset in sorted_offset..target_end_offset {

--- a/aggregator/src/aggregation/decoder/tables/literals_header.rs
+++ b/aggregator/src/aggregation/decoder/tables/literals_header.rs
@@ -243,7 +243,7 @@ impl LiteralsHeaderTable {
                         ),
                         (
                             self.size_format_bit1,
-                            (size_format & 2) as u64,
+                            ((size_format & 2) >> 1) as u64,
                             "size_format_bit1",
                         ),
                         (self.byte0_rs_3, byte0 >> 3, "byte0_rs_3"),

--- a/aggregator/src/aggregation/decoder/witgen.rs
+++ b/aggregator/src/aggregation/decoder/witgen.rs
@@ -2179,10 +2179,11 @@ mod tests {
             write!(handle, "=> batch_idx: {:?}", batch_idx).unwrap();
             writeln!(handle).unwrap();
 
-            assert!(raw_input_bytes == decoded_bytes);
             // witgen_debug
             // write!(handle, "=> decoded: {:?}", decoded_bytes).unwrap();
             // writeln!(handle).unwrap();
+
+            assert!(raw_input_bytes == decoded_bytes);
         }
 
         Ok(())

--- a/aggregator/src/aggregation/decoder/witgen.rs
+++ b/aggregator/src/aggregation/decoder/witgen.rs
@@ -1739,8 +1739,8 @@ fn process_sequences<F: Field>(
     let mut handle = stdout.lock();
 
     // witgen_debug
-    write!(handle, "=> decoded: {:?}", recovered_inputs).unwrap();
-    writeln!(handle).unwrap();
+    // write!(handle, "=> decoded: {:?}", recovered_inputs).unwrap();
+    // writeln!(handle).unwrap();
 
     (
         end_offset,
@@ -2027,6 +2027,7 @@ mod tests {
     // use bitstream_io::write;
     // use halo2_proofs::halo2curves::bn256::Fr;
     // use serde_json::from_str;
+    use std::fs;
 
     // witgen_debug
     use std::io::Write;
@@ -2108,52 +2109,81 @@ mod tests {
     // }
 
     #[test]
-    fn batch_compression_zstd() -> Result<(), std::io::Error> {
-        use halo2_proofs::halo2curves::bn256::Fr;
-        // witgen_debug
-        // use hex::FromHex;
-
+    fn test_zstd_witness_processing_batch_data() -> Result<(), std::io::Error> {
         use super::*;
-        // let raw = <Vec<u8>>::from_hex(r#"0100000000000231fb0000000064e588f7000000000000000000000000000000000000000000000000000000000000000000000000007a12000006000000000219f90216038510229a150083039bd49417afd0263d6909ba1f9a8eac697f76532365fb95880234e1a857498000b901a45ae401dc0000000000000000000000000000000000000000000000000000000064e58a1400000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e404e45aaf0000000000000000000000005300000000000000000000000000000000000004000000000000000000000000d9692f1748afee00face2da35242417dd05a86150000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000c3100d07a5997a7f9f9cdde967d396f9a2aed6a60000000000000000000000000000000000000000000000000234e1a8574980000000000000000000000000000000000000000000000000049032ac61d5dce9e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000083104ec1a053077484b4d7a88434c2d03c30c3c55bd3a82b259f339f1c0e1e1244189009c5a01c915dd14aed1b824bf610a95560e380ea3213f0bf345df3bddff1acaf7da84d000002d8f902d5068510229a1500830992fd94bbad0e891922a8a4a7e9c39d4cc0559117016fec87082b6be7f5b757b90264ac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000164883164560000000000000000000000005300000000000000000000000000000000000004000000000000000000000000ffd2ece82f7959ae184d10fe17865d27b4f0fb9400000000000000000000000000000000000000000000000000000000000001f4fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffce9f6fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcea0a00000000000000000000000000000000000000000000000000082b6be7f5b75700000000000000000000000000000000000000000000000000000000004c4b40000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006aea61ea08dd6e4834cd43a257ed52d9a31dd3b90000000000000000000000000000000000000000000000000000000064e58a1400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000412210e8a0000000000000000000000000000000000000000000000000000000083104ec2a0bc501c59bceb707d958423bad14c0d0daec84ad067f7e42209ad2cb8d904a55da00a04de4c79ed24b7a82d523b5de63c7ff68a3b7bb519546b3fe4ba8bc90a396600000137f9013480850f7eb06980830317329446ce46951d12710d85bc4fe10bb29c6ea501207787019945ca262000b8c4b2dd898a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000065e4e8d7bd50191abfee6e5bcdc4d16ddfe9975e000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000083104ec2a037979a5225dd156f51abf9a8601e9156e1b1308c0474d69af98c55627886232ea048ac197295187e7ad48aa34cc37c2625434fa812449337732d8522014f4eacfc00000137f9013480850f7eb06980830317329446ce46951d12710d85bc4fe10bb29c6ea501207787019945ca262000b8c4b2dd898a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000065e4e8d7bd50191abfee6e5bcdc4d16ddfe9975e000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000083104ec1a087269dbb9e987e5d58ecd3bcb724cbc4e6c843eb9095de16a25263aebfe06f5aa07f3ac49b6847ba51c5319174e51e088117742240f8555c5c1d77108cf0df90d700000137f9013480850f7eb06980830317329446ce46951d12710d85bc4fe10bb29c6ea501207787019945ca262000b8c4b2dd898a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000065e4e8d7bd50191abfee6e5bcdc4d16ddfe9975e000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000083104ec1a04abdb8572dcabf1996825de6f753124eed41c1292fcfdc4d9a90cb4f8a0f8ff1a06ef25857e2cc9d0fa8b6ecc03b4ba6ef6f3ec1515d570fcc9102e2aa653f347a00000137f9013480850f7eb06980830317329446ce46951d12710d85bc4fe10bb29c6ea501207787019945ca262000b8c4b2dd898a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000065e4e8d7bd50191abfee6e5bcdc4d16ddfe9975e000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000083104ec2a0882202163cbb9a299709b443b663fbab459440deabfbe183e999c98c00ea80c2a010ecb1e5196f0b1ee3d067d9a158b47b1376706e42ce2e769cf8e986935781dd"#)
-        //     .expect("FromHex failure");
+        use halo2_proofs::halo2curves::bn256::Fr;
 
         // witgen_debug
-        let raw: Vec<u8> = String::from("Romeo and Juliet@Excerpt from Act 2, Scene 2@@JULIET@O Romeo, Romeo! wherefore art thou Romeo?@Deny thy father and refuse thy name;@Or, if thou wilt not, be but sworn my love,@And I'll no longer be a Capulet.@@ROMEO@[Aside] Shall I hear more, or shall I speak at this?@@JULIET@'Tis but thy name that is my enemy;@Thou art thyself, though not a Montague.@What's Montague? it is nor hand, nor foot,@Nor arm, nor face, nor any other part@Belonging to a man. O, be some other name!@What's in a name? that which we call a rose@By any other name would smell as sweet;@So Romeo would, were he not Romeo call'd,@Retain that dear perfection which he owes@Without that title. Romeo, doff thy name,@And for that name which is no part of thee@Take all myself.@@ROMEO@I take thee at thy word:@Call me but love, and I'll be new baptized;@Henceforth I never will be Romeo.@@JULIET@What man art thou that thus bescreen'd in night@So stumblest on my counsel?").as_bytes().to_vec();
+        let stdout = io::stdout();
+        let mut handle = stdout.lock();
 
-        let compressed = {
-            // compression level = 0 defaults to using level=3, which is zstd's default.
-            let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0)?;
+        let mut batch_files = fs::read_dir("./data")?
+            .map(|entry| entry.map(|e| e.path()))
+            .collect::<Result<Vec<_>, std::io::Error>>()?;
+            batch_files.sort();
+        let batches = batch_files
+            .iter()
+            .map(fs::read_to_string)
+            .filter_map(|data| data.ok())
+            .map(|data| hex::decode(data.trim_end()).expect("Failed to decode hex data"))
+            .collect::<Vec<Vec<u8>>>();
 
-            // disable compression of literals, i.e. literals will be raw bytes.
-            encoder.set_parameter(zstd::stream::raw::CParameter::LiteralCompressionMode(
-                zstd::zstd_safe::ParamSwitch::Disable,
-            ))?;
-            // set target block size to fit within a single block.
-            encoder.set_parameter(zstd::stream::raw::CParameter::TargetCBlockSize(124 * 1024))?;
-            // do not include the checksum at the end of the encoded data.
-            encoder.include_checksum(false)?;
-            // do not include magic bytes at the start of the frame since we will have a single
-            // frame.
-            encoder.include_magicbytes(false)?;
-            // set source length, which will be reflected in the frame header.
-            encoder.set_pledged_src_size(Some(raw.len() as u64))?;
-            // include the content size to know at decode time the expected size of decoded data.
-            encoder.include_contentsize(true)?;
+        for (batch_idx, raw_input_bytes) in batches.into_iter().enumerate() {
+            // witgen_debug
+            if batch_idx == 127 {
+                continue;
+            }
 
-            encoder.write_all(&raw)?;
-            encoder.finish()?
-        };
+            let compressed = {
+                // compression level = 0 defaults to using level=3, which is zstd's default.
+                let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0)?;
+    
+                // disable compression of literals, i.e. literals will be raw bytes.
+                encoder.set_parameter(zstd::stream::raw::CParameter::LiteralCompressionMode(
+                    zstd::zstd_safe::ParamSwitch::Disable,
+                ))?;
+                // set target block size to fit within a single block.
+                encoder.set_parameter(zstd::stream::raw::CParameter::TargetCBlockSize(124 * 1024))?;
+                // do not include the checksum at the end of the encoded data.
+                encoder.include_checksum(false)?;
+                // do not include magic bytes at the start of the frame since we will have a single
+                // frame.
+                encoder.include_magicbytes(false)?;
+                // set source length, which will be reflected in the frame header.
+                encoder.set_pledged_src_size(Some(raw_input_bytes.len() as u64))?;
+                // include the content size to know at decode time the expected size of decoded data.
+                encoder.include_contentsize(true)?;
+    
+                encoder.write_all(&raw_input_bytes)?;
+                encoder.finish()?
+            };
 
-        let (
-            _witness_rows,
-            _decoded_literals,
-            _aux_data,
-            _fse_aux_tables,
-            _block_info_arr,
-            _sequence_info_arr,
-            _,
-            _,
-        ) = process::<Fr>(&compressed, Value::known(Fr::from(123456789)));
+            // witgen_debug
+            // write!(handle, "=> compressed: {:?}", compressed).unwrap();
+            // writeln!(handle).unwrap();
+
+            let (
+                _witness_rows,
+                _decoded_literals,
+                _aux_data,
+                _fse_aux_tables,
+                _block_info_arr,
+                _sequence_info_arr,
+                _,
+                sequence_exec_result,
+            ) = process::<Fr>(&compressed, Value::known(Fr::from(123456789)));
+
+            let decoded_bytes = sequence_exec_result.into_iter().flat_map(|r| r.recovered_bytes).collect::<Vec<u8>>();
+
+            // witgen_debug
+            write!(handle, "=> batch_idx: {:?}", batch_idx).unwrap();
+            writeln!(handle).unwrap();
+
+            assert!(raw_input_bytes == decoded_bytes);
+            // witgen_debug
+            // write!(handle, "=> decoded: {:?}", decoded_bytes).unwrap();
+            // writeln!(handle).unwrap();
+        }
 
         Ok(())
     }

--- a/aggregator/src/aggregation/decoder/witgen.rs
+++ b/aggregator/src/aggregation/decoder/witgen.rs
@@ -1711,7 +1711,8 @@ fn process_sequences<F: Field>(
                     SequenceExecInfo::BackRefRepeated(r.clone(), l.clone()),
                 ));
                 let matched_bytes = Vec::from(&recovered_inputs[r]);
-                let total_matched_bytes: Vec<u8> = matched_bytes.iter().cycle().take(l).copied().collect();
+                let total_matched_bytes: Vec<u8> =
+                    matched_bytes.iter().cycle().take(l).copied().collect();
                 recovered_inputs.extend_from_slice(total_matched_bytes.as_slice());
             }
         }
@@ -2120,7 +2121,7 @@ mod tests {
         let mut batch_files = fs::read_dir("./data")?
             .map(|entry| entry.map(|e| e.path()))
             .collect::<Result<Vec<_>, std::io::Error>>()?;
-            batch_files.sort();
+        batch_files.sort();
         let batches = batch_files
             .iter()
             .map(fs::read_to_string)
@@ -2137,13 +2138,14 @@ mod tests {
             let compressed = {
                 // compression level = 0 defaults to using level=3, which is zstd's default.
                 let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0)?;
-    
+
                 // disable compression of literals, i.e. literals will be raw bytes.
                 encoder.set_parameter(zstd::stream::raw::CParameter::LiteralCompressionMode(
                     zstd::zstd_safe::ParamSwitch::Disable,
                 ))?;
                 // set target block size to fit within a single block.
-                encoder.set_parameter(zstd::stream::raw::CParameter::TargetCBlockSize(124 * 1024))?;
+                encoder
+                    .set_parameter(zstd::stream::raw::CParameter::TargetCBlockSize(124 * 1024))?;
                 // do not include the checksum at the end of the encoded data.
                 encoder.include_checksum(false)?;
                 // do not include magic bytes at the start of the frame since we will have a single
@@ -2151,9 +2153,10 @@ mod tests {
                 encoder.include_magicbytes(false)?;
                 // set source length, which will be reflected in the frame header.
                 encoder.set_pledged_src_size(Some(raw_input_bytes.len() as u64))?;
-                // include the content size to know at decode time the expected size of decoded data.
+                // include the content size to know at decode time the expected size of decoded
+                // data.
                 encoder.include_contentsize(true)?;
-    
+
                 encoder.write_all(&raw_input_bytes)?;
                 encoder.finish()?
             };
@@ -2173,7 +2176,10 @@ mod tests {
                 sequence_exec_result,
             ) = process::<Fr>(&compressed, Value::known(Fr::from(123456789)));
 
-            let decoded_bytes = sequence_exec_result.into_iter().flat_map(|r| r.recovered_bytes).collect::<Vec<u8>>();
+            let decoded_bytes = sequence_exec_result
+                .into_iter()
+                .flat_map(|r| r.recovered_bytes)
+                .collect::<Vec<u8>>();
 
             // witgen_debug
             write!(handle, "=> batch_idx: {:?}", batch_idx).unwrap();

--- a/aggregator/src/aggregation/decoder/witgen.rs
+++ b/aggregator/src/aggregation/decoder/witgen.rs
@@ -667,7 +667,7 @@ fn process_sequences<F: Field>(
                     tag: ZstdTag::ZstdBlockSequenceHeader,
                     tag_next: if is_all_predefined_fse {
                         ZstdTag::ZstdBlockSequenceData
-                    } else { 
+                    } else {
                         ZstdTag::ZstdBlockSequenceFseCode
                     },
                     block_idx,
@@ -785,7 +785,7 @@ fn process_sequences<F: Field>(
             bit_boundaries_llt,
             n_fse_bytes_llt as u64,
             &table_llt,
-            match_lengths_mode + offsets_mode < 1,
+            offsets_mode + match_lengths_mode < 1,
         ),
         (
             1usize,
@@ -794,7 +794,7 @@ fn process_sequences<F: Field>(
             bit_boundaries_cmot,
             n_fse_bytes_cmot as u64,
             &table_cmot,
-            offsets_mode < 1,
+            match_lengths_mode < 1,
         ),
         (
             2usize,

--- a/aggregator/src/aggregation/decoder/witgen.rs
+++ b/aggregator/src/aggregation/decoder/witgen.rs
@@ -1465,6 +1465,11 @@ fn process_sequences<F: Field>(
                 // write!(handle, "current_byte_idx: {:?}, from_bit_idx: {:?}, to_bit_idx: {:?}, nb: {:?}, is_nil: {:?}, is_zero_read: {:?}", byte_offset + current_byte_idx, 0, 0, 7, true, false).unwrap();
                 // writeln!(handle).unwrap();
 
+                let wrap_by = match to_bit_idx {
+                    15 => 8,
+                    16..=23 => 16,
+                    _ => unreachable!(),
+                };
                 witness_rows.push(ZstdWitnessRow {
                     state: ZstdState {
                         tag: ZstdTag::ZstdBlockSequenceData,
@@ -1504,8 +1509,8 @@ fn process_sequences<F: Field>(
                         aux_2: Value::known(F::zero()),
                     },
                     bitstream_read_data: BitstreamReadRow {
-                        bit_start_idx: 7,
-                        bit_end_idx: 7,
+                        bit_start_idx: to_bit_idx - wrap_by,
+                        bit_end_idx: to_bit_idx - wrap_by,
                         bit_value: 0,
                         is_zero_bit_read: false,
                         is_seq_init: false,

--- a/aggregator/src/aggregation/decoder/witgen/types.rs
+++ b/aggregator/src/aggregation/decoder/witgen/types.rs
@@ -109,8 +109,6 @@ pub struct SequenceInfo {
 pub enum SequenceExecInfo {
     LiteralCopy(std::ops::Range<usize>),
     BackRef(std::ops::Range<usize>),
-    // TODO(VF): Add support for repeated match byte slice
-    BackRefRepeated(std::ops::Range<usize>, usize),
 }
 
 /// The type to describe an execution: (instruction_id, exec_info)

--- a/aggregator/src/aggregation/decoder/witgen/types.rs
+++ b/aggregator/src/aggregation/decoder/witgen/types.rs
@@ -109,6 +109,8 @@ pub struct SequenceInfo {
 pub enum SequenceExecInfo {
     LiteralCopy(std::ops::Range<usize>),
     BackRef(std::ops::Range<usize>),
+    // TODO(VF): Add support for repeated match byte slice
+    BackRefRepeated(std::ops::Range<usize>, usize),
 }
 
 /// The type to describe an execution: (instruction_id, exec_info)


### PR DESCRIPTION
### Description

A special case for sequence instruction execution is discovered.
When `match_length` is greater than `match_offset`, the matched byte slice has to be repeated to reach desired length. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor (no updates to logic)
