### PR TITLE
fix sig issue for 1559/2930 in tx circuit

### DIFF
--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -50,7 +50,7 @@
 //!   - [x] Tx Circuit
 //!   - [ ] MPT Circuit
 #[cfg(feature = "scroll")]
-mod eip1559_2930;
+pub(crate) mod eip1559_2930;
 pub(crate) mod precompile_block_trace;
 #[cfg(any(feature = "test", test))]
 pub(crate) mod test;

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -49,6 +49,8 @@
 //!   - [x] Bytecode Circuit
 //!   - [x] Tx Circuit
 //!   - [ ] MPT Circuit
+#[cfg(feature = "scroll")]
+mod eip1559_2930;
 pub(crate) mod precompile_block_trace;
 #[cfg(any(feature = "test", test))]
 pub(crate) mod test;

--- a/zkevm-circuits/src/super_circuit/eip1559_2930.rs
+++ b/zkevm-circuits/src/super_circuit/eip1559_2930.rs
@@ -51,7 +51,7 @@ pub(crate) fn test_circuits_params(max_txs: usize, max_calldata: usize) -> Circu
         max_evm_rows: 0,
         max_keccak_rows: 0,
         max_inner_blocks: 1,
-        max_rlp_rows: 500,
+        max_rlp_rows: 1000,
         ..Default::default()
     }
 }
@@ -92,7 +92,7 @@ pub(crate) fn test_block_2930_trace() -> BlockTrace {
                 .gas_price(gwei(2))
                 .gas(1_000_000.into())
                 .value(eth(2))
-                .transaction_type(1) // Set tx type to EIP-2930.
+                .transaction_type(1); // Set tx type to EIP-2930.
                 .access_list(test_access_list);
         },
         |block, _tx| block.number(0xcafe_u64),

--- a/zkevm-circuits/src/super_circuit/eip1559_2930.rs
+++ b/zkevm-circuits/src/super_circuit/eip1559_2930.rs
@@ -57,6 +57,7 @@ pub(crate) fn test_circuits_params(max_txs: usize, max_calldata: usize) -> Circu
 }
 
 /// Helper functions for super circuit tests of EIP-2930
+/// param `has_access_list` indicates targeting tx has access list data or not.
 pub(crate) fn test_block_2930_trace(has_access_list: bool) -> BlockTrace {
     let mut rng = ChaCha20Rng::seed_from_u64(2);
     let wallet_a = LocalWallet::new(&mut rng).with_chain_id(MOCK_CHAIN_ID);
@@ -64,7 +65,7 @@ pub(crate) fn test_block_2930_trace(has_access_list: bool) -> BlockTrace {
     let addr_a = wallet_a.address();
     let addr_b = address!("0x0000000000000000000000000000000000002930");
 
-    let test_access_list =  AccessList(vec![
+    let test_access_list = AccessList(vec![
         AccessListItem {
             address: address!("0x0000000000000000000000000000000000001111"),
             storage_keys: [10, 11].map(H256::from_low_u64_be).to_vec(),

--- a/zkevm-circuits/src/super_circuit/eip1559_2930.rs
+++ b/zkevm-circuits/src/super_circuit/eip1559_2930.rs
@@ -1,0 +1,103 @@
+//! Helper functions for super circuit tests of EIP-1559
+
+use super::CircuitsParams;
+use eth_types::{address, l2_types::BlockTrace, AccessList, AccessListItem, H256};
+use ethers_signers::{LocalWallet, Signer};
+use mock::{eth, gwei, TestContext, MOCK_CHAIN_ID};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+pub(crate) fn test_block_1559_trace() -> BlockTrace {
+    let mut rng = ChaCha20Rng::seed_from_u64(2);
+    let wallet_a = LocalWallet::new(&mut rng).with_chain_id(MOCK_CHAIN_ID);
+
+    let addr_a = wallet_a.address();
+    let addr_b = address!("0x0000000000000000000000000000000000001559");
+
+    TestContext::<2, 1>::new(
+        None,
+        |accs| {
+            accs[0].address(addr_b).balance(eth(1));
+            accs[1].address(addr_a).balance(gwei(80_000));
+        },
+        |mut txs, _accs| {
+            txs[0]
+                .from(addr_a)
+                .to(addr_b)
+                .gas_price(gwei(2))
+                .gas(30_000.into())
+                .value(gwei(20_000))
+                .max_fee_per_gas(gwei(2))
+                .max_priority_fee_per_gas(gwei(2))
+                .transaction_type(2); // Set tx type to EIP-1559.
+        },
+        |block, _tx| block.number(0xcafe_u64),
+    )
+    .unwrap()
+    .l2_trace()
+    .clone()
+}
+
+pub(crate) fn test_circuits_params(max_txs: usize, max_calldata: usize) -> CircuitsParams {
+    CircuitsParams {
+        max_txs,
+        max_calldata,
+        max_rws: 256,
+        max_copy_rows: 256,
+        max_exp_steps: 256,
+        max_bytecode: 512,
+        max_mpt_rows: 2049,
+        max_poseidon_rows: 512,
+        max_evm_rows: 0,
+        max_keccak_rows: 0,
+        max_inner_blocks: 1,
+        max_rlp_rows: 500,
+        ..Default::default()
+    }
+}
+
+/// Helper functions for super circuit tests of EIP-2930
+pub(crate) fn test_block_2930_trace() -> BlockTrace {
+    let mut rng = ChaCha20Rng::seed_from_u64(2);
+    let wallet_a = LocalWallet::new(&mut rng).with_chain_id(MOCK_CHAIN_ID);
+
+    let addr_a = wallet_a.address();
+    let addr_b = address!("0x0000000000000000000000000000000000002930");
+
+    let test_access_list = AccessList(vec![
+        AccessListItem {
+            address: address!("0x0000000000000000000000000000000000001111"),
+            storage_keys: [10, 11].map(H256::from_low_u64_be).to_vec(),
+        },
+        AccessListItem {
+            address: address!("0x0000000000000000000000000000000000002222"),
+            storage_keys: [20, 22].map(H256::from_low_u64_be).to_vec(),
+        },
+        AccessListItem {
+            address: address!("0x0000000000000000000000000000000000003333"),
+            storage_keys: [30, 33].map(H256::from_low_u64_be).to_vec(),
+        },
+    ]);
+
+    TestContext::<2, 1>::new(
+        None,
+        |accs| {
+            accs[0].address(addr_b).balance(eth(20));
+            accs[1].address(addr_a).balance(eth(20));
+        },
+        |mut txs, _accs| {
+            txs[0]
+                .from(addr_a)
+                .to(addr_b)
+                .gas_price(gwei(2))
+                .gas(1_000_000.into())
+                .value(eth(2))
+                .transaction_type(1) // Set tx type to EIP-2930.
+                .access_list(test_access_list);
+        },
+        |block, _tx| block.number(0xcafe_u64),
+    )
+    .unwrap()
+    .l2_trace()
+    .clone()
+}

--- a/zkevm-circuits/src/super_circuit/eip1559_2930.rs
+++ b/zkevm-circuits/src/super_circuit/eip1559_2930.rs
@@ -78,6 +78,11 @@ pub(crate) fn test_block_2930_trace(has_access_list: bool) -> BlockTrace {
             address: address!("0x0000000000000000000000000000000000003333"),
             storage_keys: [30, 33].map(H256::from_low_u64_be).to_vec(),
         },
+        // empty storage_keys
+        AccessListItem {
+            address: address!("0x0000000000000000000000000000000000004444"),
+            storage_keys: Vec::new(),
+        },
     ]);
 
     TestContext::<2, 1>::new(

--- a/zkevm-circuits/src/super_circuit/eip1559_2930.rs
+++ b/zkevm-circuits/src/super_circuit/eip1559_2930.rs
@@ -22,7 +22,7 @@ pub(crate) fn test_block_1559_trace() -> BlockTrace {
         },
         |mut txs, _accs| {
             txs[0]
-                .from(addr_a)
+                .from(wallet_a)
                 .to(addr_b)
                 .gas_price(gwei(2))
                 .gas(30_000.into())
@@ -87,7 +87,7 @@ pub(crate) fn test_block_2930_trace() -> BlockTrace {
         },
         |mut txs, _accs| {
             txs[0]
-                .from(addr_a)
+                .from(wallet_a)
                 .to(addr_b)
                 .gas_price(gwei(2))
                 .gas(1_000_000.into())

--- a/zkevm-circuits/src/super_circuit/eip1559_2930.rs
+++ b/zkevm-circuits/src/super_circuit/eip1559_2930.rs
@@ -57,14 +57,14 @@ pub(crate) fn test_circuits_params(max_txs: usize, max_calldata: usize) -> Circu
 }
 
 /// Helper functions for super circuit tests of EIP-2930
-pub(crate) fn test_block_2930_trace() -> BlockTrace {
+pub(crate) fn test_block_2930_trace(has_access_list: bool) -> BlockTrace {
     let mut rng = ChaCha20Rng::seed_from_u64(2);
     let wallet_a = LocalWallet::new(&mut rng).with_chain_id(MOCK_CHAIN_ID);
 
     let addr_a = wallet_a.address();
     let addr_b = address!("0x0000000000000000000000000000000000002930");
 
-    let test_access_list = AccessList(vec![
+    let test_access_list =  AccessList(vec![
         AccessListItem {
             address: address!("0x0000000000000000000000000000000000001111"),
             storage_keys: [10, 11].map(H256::from_low_u64_be).to_vec(),
@@ -93,7 +93,10 @@ pub(crate) fn test_block_2930_trace() -> BlockTrace {
                 .gas(1_000_000.into())
                 .value(eth(2))
                 .transaction_type(1); // Set tx type to EIP-2930.
-                .access_list(test_access_list);
+
+            if has_access_list {
+                txs[0].access_list(test_access_list);
+            }
         },
         |block, _tx| block.number(0xcafe_u64),
     )

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -190,54 +190,9 @@ fn block_1tx_ctx() -> TestContext<2, 1> {
     .unwrap()
 }
 
-fn block_1tx_1559_ctx() -> TestContext<2, 1> {
-    let mut rng = ChaCha20Rng::seed_from_u64(2);
-
-    let chain_id = MOCK_CHAIN_ID;
-
-    let bytecode = bytecode! {
-        GAS
-        STOP
-    };
-
-    let wallet_a = LocalWallet::new(&mut rng).with_chain_id(chain_id);
-
-    let addr_a = wallet_a.address();
-    let addr_b = address!("0x000000000000000000000000000000000000BBBB");
-
-    TestContext::new(
-        Some(vec![Word::zero()]),
-        |accs| {
-            accs[0]
-                .address(addr_b)
-                .balance(Word::from(1u64 << 20))
-                .code(bytecode);
-            accs[1].address(addr_a).balance(Word::from(1u64 << 20));
-        },
-        |mut txs, accs| {
-            txs[0]
-                .from(wallet_a)
-                .to(accs[0].address)
-                .gas(Word::from(1_000_000u64))
-                //.gas(30_000.into())
-                .value(Word::from(1_000_000u64))
-                .max_fee_per_gas(Word::from(3_000_000u64))
-                .max_priority_fee_per_gas(Word::from(2_000_000u64))
-                .transaction_type(2); // Set tx type to EIP-1559.
-        },
-        |block, _tx| block.number(0xcafeu64),
-    )
-    .unwrap()
-}
-
 #[cfg(feature = "scroll")]
 fn block_1tx_trace() -> BlockTrace {
     block_1tx_ctx().l2_trace().clone()
-}
-
-#[cfg(feature = "scroll")]
-fn block_1tx_1559_trace() -> BlockTrace {
-    block_1tx_1559_ctx().l2_trace().clone()
 }
 
 pub(crate) fn block_1tx() -> GethData {
@@ -301,35 +256,6 @@ const TEST_MOCK_RANDOMNESS: u64 = 0x100;
 #[test]
 fn serial_test_super_circuit_1tx_1max_tx() {
     let block = block_1tx_trace();
-    const MAX_TXS: usize = 1;
-    const MAX_CALLDATA: usize = 256;
-    const MAX_INNER_BLOCKS: usize = 1;
-    let circuits_params = CircuitsParams {
-        max_txs: MAX_TXS,
-        max_calldata: MAX_CALLDATA,
-        max_rws: 256,
-        max_copy_rows: 256,
-        max_exp_steps: 256,
-        max_bytecode: 512,
-        max_mpt_rows: 2049,
-        max_poseidon_rows: 512,
-        max_evm_rows: 0,
-        max_keccak_rows: 0,
-        max_inner_blocks: MAX_INNER_BLOCKS,
-        max_rlp_rows: 500,
-        ..Default::default()
-    };
-    test_super_circuit::<MAX_TXS, MAX_CALLDATA, MAX_INNER_BLOCKS, TEST_MOCK_RANDOMNESS>(
-        block,
-        circuits_params,
-    );
-}
-
-#[ignore]
-#[cfg(feature = "scroll")]
-#[test]
-fn serial_test_super_circuit_1tx_1max_tx_1559() {
-    let block = block_1tx_1559_trace();
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 256;
     const MAX_INNER_BLOCKS: usize = 1;
@@ -533,4 +459,36 @@ fn serial_test_super_circuit_precompile_sha256() {
     let circuits_params = precomiple_super_circuits_params(MAX_TXS, MAX_CALLDATA);
 
     test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(block, circuits_params);
+}
+
+#[ignore]
+#[cfg(feature = "scroll")]
+#[test]
+fn serial_test_super_circuit_eip_1559_tx() {
+    const MAX_TXS: usize = 1;
+    const MAX_CALLDATA: usize = 256;
+
+    let block_trace = eip1559::test_block_trace();
+    let circuits_params = eip1559::test_circuits_params(MAX_TXS, MAX_CALLDATA);
+
+    test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(
+        block_trace,
+        circuits_params,
+    );
+}
+
+#[ignore]
+#[cfg(feature = "scroll")]
+#[test]
+fn serial_test_super_circuit_eip_2930_tx() {
+    const MAX_TXS: usize = 1;
+    const MAX_CALLDATA: usize = 256;
+
+    let block_trace = eip2930::test_block_trace();
+    let circuits_params = eip2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
+
+    test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(
+        block_trace,
+        circuits_params,
+    );
 }

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -521,19 +521,21 @@ fn serial_test_super_circuit_eip_2930_tx_no_accesslist() {
     );
 }
 
-#[ignore]
-#[cfg(feature = "scroll")]
-#[test]
-fn serial_test_super_circuit_eip_2930_tx_accesslist() {
-    const MAX_TXS: usize = 1;
-    const MAX_CALLDATA: usize = 256;
+// TODO: disable this test for rlp issue now, will enable it after rlp issue fixed.
+// issue tracking here https://github.com/scroll-tech/zkevm-circuits/issues/1138
+// #[ignore]
+// #[cfg(feature = "scroll")]
+// #[test]
+// fn serial_test_super_circuit_eip_2930_tx_accesslist() {
+//     const MAX_TXS: usize = 1;
+//     const MAX_CALLDATA: usize = 256;
 
-    // tx with access list data
-    let block_trace = eip1559_2930::test_block_2930_trace(true);
-    let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
+//     // tx with access list data
+//     let block_trace = eip1559_2930::test_block_2930_trace(true);
+//     let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
 
-    test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(
-        block_trace,
-        circuits_params,
-    );
-}
+//     test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(
+//         block_trace,
+//         circuits_params,
+//     );
+// }

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -311,8 +311,6 @@ fn serial_test_super_circuit_1tx_deploy_2max_tx() {
     );
 }
 
-
-
 #[ignore]
 #[cfg(feature = "scroll")]
 #[test]
@@ -468,8 +466,8 @@ fn serial_test_super_circuit_eip_1559_tx() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 256;
 
-    let block_trace = eip1559::test_block_trace();
-    let circuits_params = eip1559::test_circuits_params(MAX_TXS, MAX_CALLDATA);
+    let block_trace = eip1559_2930::test_block_1559_trace();
+    let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
 
     test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(
         block_trace,
@@ -484,8 +482,8 @@ fn serial_test_super_circuit_eip_2930_tx() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 256;
 
-    let block_trace = eip2930::test_block_trace();
-    let circuits_params = eip2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
+    let block_trace = eip1559_2930::test_block_2930_trace();
+    let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
 
     test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(
         block_trace,

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -314,6 +314,35 @@ fn serial_test_super_circuit_1tx_deploy_2max_tx() {
 #[ignore]
 #[cfg(feature = "scroll")]
 #[test]
+fn serial_test_super_circuit_1tx_2max_tx() {
+    let block = block_1tx_trace();
+    const MAX_TXS: usize = 2;
+    const MAX_CALLDATA: usize = 256;
+    const MAX_INNER_BLOCKS: usize = 1;
+    let circuits_params = CircuitsParams {
+        max_txs: MAX_TXS,
+        max_calldata: MAX_CALLDATA,
+        max_rws: 256,
+        max_copy_rows: 256,
+        max_exp_steps: 256,
+        max_bytecode: 512,
+        max_mpt_rows: 2049,
+        max_poseidon_rows: 512,
+        max_evm_rows: 0,
+        max_keccak_rows: 0,
+        max_inner_blocks: MAX_INNER_BLOCKS,
+        max_rlp_rows: 500,
+        ..Default::default()
+    };
+    test_super_circuit::<MAX_TXS, MAX_CALLDATA, MAX_INNER_BLOCKS, TEST_MOCK_RANDOMNESS>(
+        block,
+        circuits_params,
+    );
+}
+
+#[ignore]
+#[cfg(feature = "scroll")]
+#[test]
 fn serial_test_super_circuit_2tx_4max_tx() {
     let block = block_2tx_trace();
     const MAX_TXS: usize = 4;

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -507,11 +507,28 @@ fn serial_test_super_circuit_eip_1559_tx() {
 #[ignore]
 #[cfg(feature = "scroll")]
 #[test]
-fn serial_test_super_circuit_eip_2930_tx() {
+fn serial_test_super_circuit_eip_2930_tx_no_accesslist() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 256;
 
-    let block_trace = eip1559_2930::test_block_2930_trace();
+    let block_trace = eip1559_2930::test_block_2930_trace(false);
+    let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
+
+    test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(
+        block_trace,
+        circuits_params,
+    );
+}
+
+
+#[ignore]
+#[cfg(feature = "scroll")]
+#[test]
+fn serial_test_super_circuit_eip_2930_tx_accesslist() {
+    const MAX_TXS: usize = 1;
+    const MAX_CALLDATA: usize = 256;
+
+    let block_trace = eip1559_2930::test_block_2930_trace(true);
     let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
 
     test_super_circuit::<MAX_TXS, MAX_CALLDATA, 1, TEST_MOCK_RANDOMNESS>(

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -511,6 +511,7 @@ fn serial_test_super_circuit_eip_2930_tx_no_accesslist() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 256;
 
+    // tx with no access list data
     let block_trace = eip1559_2930::test_block_2930_trace(false);
     let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
 
@@ -520,7 +521,6 @@ fn serial_test_super_circuit_eip_2930_tx_no_accesslist() {
     );
 }
 
-
 #[ignore]
 #[cfg(feature = "scroll")]
 #[test]
@@ -528,6 +528,7 @@ fn serial_test_super_circuit_eip_2930_tx_accesslist() {
     const MAX_TXS: usize = 1;
     const MAX_CALLDATA: usize = 256;
 
+    // tx with access list data
     let block_trace = eip1559_2930::test_block_2930_trace(true);
     let circuits_params = eip1559_2930::test_circuits_params(MAX_TXS, MAX_CALLDATA);
 

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -2883,13 +2883,12 @@ impl<F: Field> TxCircuitConfig<F> {
             let sig_s = meta.query_advice(tx_table.value, Rotation(3));
             let sv_address = meta.query_advice(sv_address, Rotation::cur());
 
+            // include eip1559 and eip2930 type tx, sig_v is 0 or 1.
 
-            // indicates tx type is eip155 or post (eip1559, eip2930).
-            
             let v = is_eip155(meta) * (sig_v.expr() - 2.expr() * chain_id - 35.expr())
-                + is_pre_eip155(meta) * (sig_v.expr() - 27.expr()) + 
-                meta.query_advice(is_eip1559, Rotation::cur()) * sig_v.expr() + 
-                meta.query_advice(is_eip2930, Rotation::cur()) * sig_v.expr();
+                + is_pre_eip155(meta) * (sig_v.expr() - 27.expr())
+                + meta.query_advice(is_eip1559, Rotation::cur()) * sig_v.expr()
+                + meta.query_advice(is_eip2930, Rotation::cur()) * sig_v.expr();
 
             let input_exprs = vec![
                 1.expr(),     // q_enable = true
@@ -4458,7 +4457,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
             })
             .collect::<Result<Vec<SignData>, Error>>()?;
 
-            println!("tx circuit:sign_datas {:?}", sign_datas);
+        println!("tx circuit:sign_datas {:?}", sign_datas);
         // check if tx.caller_address == recovered_pk
         let recovered_pks = keccak_inputs_sign_verify(&sign_datas)
             .into_iter()

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -4457,7 +4457,6 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
             })
             .collect::<Result<Vec<SignData>, Error>>()?;
 
-        println!("tx circuit:sign_datas {:?}", sign_datas);
         // check if tx.caller_address == recovered_pk
         let recovered_pks = keccak_inputs_sign_verify(&sign_datas)
             .into_iter()


### PR DESCRIPTION
### Description
tx circuit didn't handle signature data V for 1559 /2930 type tx , so test failed by lookup sig table failed.
- [x] fix sig lookup in tx circuit 
- [x] add super circuit tests for 1559
- [x] add super circuit tests for 2930 


### Issue Link

issue https://github.com/scroll-tech/zkevm-circuits/issues/1141

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
