### PR TITLE
auditing updates for some comments

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/mcopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mcopy.rs
@@ -172,10 +172,6 @@ impl<F: Field> ExecutionGadget<F> for MCopyGadget<F> {
             [src_addr, dest_addr],
         )?;
 
-        println!("cur_memory_word_size:{}, next_memory_word_size: {}, src_addr {} ,
-            dest_addr {}", step.memory_word_size(),
-            next_memory_word_size, src_addr, d);
-
         self.memory_copier_gas.assign(
             region,
             offset,
@@ -244,11 +240,9 @@ mod test {
     // tests for zero copy length
     #[test]
     fn mcopy_empty() {
-        // test_ok(Word::from("0x20"), Word::zero(), 0x0);
-        test_ok(Word::from("0x20"),  Word::from("0x60"), 0x0);
-
-        //test_ok(Word::from("0xa8"), Word::from("0x2f"), 0x0);
-        //test_ok(Word::from("0x0"), Word::from("0x600"), 0x0);
+        test_ok(Word::from("0x20"), Word::zero(), 0x0);
+        test_ok(Word::from("0xa8"), Word::from("0x2f"), 0x0);
+        test_ok(Word::from("0x0"), Word::from("0x600"), 0x0);
     }
 
     // tests for real copy

--- a/zkevm-circuits/src/evm_circuit/execution/mcopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mcopy.rs
@@ -59,16 +59,16 @@ impl<F: Field> ExecutionGadget<F> for MCopyGadget<F> {
             MemoryAddressGadget::construct(cb, dest_offset.clone(), length.clone());
 
         // if no acutal copy happens, memory_word_size doesn't change. MemoryExpansionGadget handle
-        // it with MemoryAddressGadget.
+        // memory_word_size with MemoryAddressGadget.
         // more detailed: 
         // when copy length is zero ( `length` == 0), MemoryAddressGadget set address offset to zero. in this context
         // memory_src_address and memory_dest_address are both zeros.
-        // then for `end_offset()` also return zero.
+        // then for `end_offset()` in MemoryExpansionGadget also return zero.
         // MemoryExpansionGadget compares current memory_word_size (cb.curr.state.memory_word_size) to two new addresses(    
         // memory_src_address and memory_dest_address) required word expansion, the max were selected as next memory_word_size.
         // because of zeros of new address word expansion not greater than 
         // current memory_word_size, so next memory_word_size remains the same to current memory_word_size, which means memory_word_size
-        // state of next steo doesn't change.
+        // state in next step doesn't change.
 
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
@@ -165,7 +165,7 @@ impl<F: Field> ExecutionGadget<F> for MCopyGadget<F> {
             ),
         )?;
 
-        let (next_memory_word_size, memory_expansion_gas_cost) = self.memory_expansion.assign(
+        let (_, memory_expansion_gas_cost) = self.memory_expansion.assign(
             region,
             offset,
             step.memory_word_size(),

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -799,7 +799,6 @@ impl<F: Field, const N: usize, const N_BYTES_MEMORY_WORD_SIZE: usize>
                 F::from(*memory_word_size),
             )?;
             next_memory_word_size = max.get_lower_128() as u64;
-            println!("next_memory_word_size in assign {}", next_memory_word_size);
         }
 
         // Calculate the quad gas cost for the memory size

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -699,23 +699,23 @@ impl<F: Field, const N: usize, const N_BYTES_MEMORY_WORD_SIZE: usize>
     MemoryExpansionGadget<F, N, N_BYTES_MEMORY_WORD_SIZE>
 {
     /// Input requirements:
-    /// - `curr_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
-    /// - `address < 32 * 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// - `curr_memory_word_size < 256**N_BYTES_MEMORY_WORD_SIZE`
+    /// - `address < 32 * 256** N_BYTES_MEMORY_WORD_SIZE`
     /// Output ranges:
-    /// - `next_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
-    /// - `gas_cost <= GAS_MEM*256**MAX_MEMORY_SIZE_IN_BYTES + 256**MAX_QUAD_COST_IN_BYTES`
+    /// - `next_memory_word_size < 256**N_BYTES_MEMORY_WORD_SIZE`
+    /// - `gas_cost <= GAS_MEM*256**N_BYTES_MEMORY_WORD_SIZE + 256**N_BYTES_GAS`
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
         addresses: [Expression<F>; N],
     ) -> Self {
         // Calculate the memory size of the memory access
-        // `address_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+        // `address_memory_word_size < 256**N_BYTES_MEMORY_WORD_SIZE`
         let memory_word_sizes =
             addresses.map(|address| MemoryWordSizeGadget::construct(cb, address));
 
         // The memory size needs to be updated if this memory access
         // requires expanding the memory.
-        // `next_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+        // `next_memory_word_size < 256**N_BYTES_MEMORY_WORD_SIZE`
         let curr_memory_word_size = cb.curr.state.memory_word_size.expr();
         let mut next_memory_word_size = curr_memory_word_size.clone();
         let max_memory_word_sizes = array_init(|idx| {
@@ -730,7 +730,7 @@ impl<F: Field, const N: usize, const N_BYTES_MEMORY_WORD_SIZE: usize>
 
         // Calculate the quad memory cost for the current and next memory size.
         // These quad costs will also be range limited to `<
-        // 256**MAX_QUAD_COST_IN_BYTES`.
+        // 256**N_BYTES_GAS`.
         let curr_quad_memory_cost = ConstantDivisionGadget::construct(
             cb,
             curr_memory_word_size.clone() * curr_memory_word_size.clone(),
@@ -745,7 +745,7 @@ impl<F: Field, const N: usize, const N_BYTES_MEMORY_WORD_SIZE: usize>
         // Calculate the gas cost for the memory expansion.
         // This gas cost is the difference between the next and current memory
         // costs. `gas_cost <=
-        // GAS_MEM*256**MAX_MEMORY_SIZE_IN_BYTES + 256**MAX_QUAD_COST_IN_BYTES`
+        // GAS_MEM*256**N_BYTES_MEMORY_WORD_SIZE + 256**N_BYTES_GAS`
         let gas_cost = GasCost::MEMORY_EXPANSION_LINEAR_COEFF.expr()
             * (next_memory_word_size.clone() - curr_memory_word_size)
             + (next_quad_memory_cost.quotient() - curr_quad_memory_cost.quotient());
@@ -799,6 +799,7 @@ impl<F: Field, const N: usize, const N_BYTES_MEMORY_WORD_SIZE: usize>
                 F::from(*memory_word_size),
             )?;
             next_memory_word_size = max.get_lower_128() as u64;
+            println!("next_memory_word_size in assign {}", next_memory_word_size);
         }
 
         // Calculate the quad gas cost for the memory size
@@ -838,11 +839,11 @@ impl<F: Field, const GAS_COPY: GasCost> MemoryCopierGasGadget<F, GAS_COPY> {
     pub const WORD_SIZE: u64 = 32u64;
 
     /// Input requirements:
-    /// - `curr_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
-    /// - `address < 32 * 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// - `curr_memory_size < 256**N_BYTES_MEMORY_WORD_SIZE`
+    /// - `address < 32 * 256**N_BYTES_MEMORY_WORD_SIZE`
     /// Output ranges:
-    /// - `next_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
-    /// - `gas_cost <= GAS_MEM*256**MAX_MEMORY_SIZE_IN_BYTES + 256**MAX_QUAD_COST_IN_BYTES`
+    /// - `next_memory_size < 256**N_BYTES_MEMORY_WORD_SIZE`
+    /// - `gas_cost <= GAS_MEM*256**N_BYTES_MEMORY_WORD_SIZE + 256**N_BYTES_GAS`
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
         num_bytes: Expression<F>,


### PR DESCRIPTION
### Description
auditing found some outdated comments or unclear comments 
1. update MemoryGadget outdated comments: 
```
MAX_QUAD_COST_IN_BYTES --> N_BYTES_GAS
MAX_MEMORY_SIZE_IN_BYTES --> N_BYTES_MEMORY_WORD_SIZE
```
2. add more detailed explanation for mcopy zero length case, which make new code reader easier to read & understand.

### Issue Link

[_link issue here_]

