### PR TITLE
allow up to 5x compression ratio

### DIFF
--- a/aggregator/src/blob.rs
+++ b/aggregator/src/blob.rs
@@ -41,6 +41,9 @@ pub const N_ROWS_NUM_CHUNKS: usize = 2;
 /// we explicitly set the most-significant byte to 0, effectively utilising only 31 bytes.
 pub const N_BLOB_BYTES: usize = BLOB_WIDTH * N_DATA_BYTES_PER_COEFFICIENT;
 
+/// Allow up to 5x compression via zstd encoding of the batch data.
+pub const N_BATCH_BYTES: usize = N_BLOB_BYTES * 5;
+
 /// KZG trusted setup
 pub static KZG_TRUSTED_SETUP: Lazy<Arc<c_kzg::KzgSettings>> = Lazy::new(|| {
     Arc::new(
@@ -162,12 +165,12 @@ impl<const N_SNARKS: usize> BatchData<N_SNARKS> {
 
     /// The number of rows in Blob Data config's layout to represent the "chunk data" section.
     pub const fn n_rows_data() -> usize {
-        N_BLOB_BYTES - Self::n_rows_metadata()
+        N_BATCH_BYTES - Self::n_rows_metadata()
     }
 
     /// The total number of rows used in Blob Data config's layout.
     pub const fn n_rows() -> usize {
-        N_BLOB_BYTES + Self::n_rows_digest()
+        N_BATCH_BYTES + Self::n_rows_digest()
     }
 
     pub(crate) fn new(num_valid_chunks: usize, chunks_with_padding: &[ChunkHash]) -> Self {

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -26,6 +26,7 @@ mod tests;
 
 pub use self::core::extract_proof_and_instances_with_pairing_check;
 pub use aggregation::*;
+pub use aggregation::witgen::init_zstd_encoder;
 pub use batch::BatchHash;
 pub use chunk::ChunkHash;
 pub use compression::*;

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -25,8 +25,7 @@ mod util;
 mod tests;
 
 pub use self::core::extract_proof_and_instances_with_pairing_check;
-pub use aggregation::*;
-pub use aggregation::witgen::init_zstd_encoder;
+pub use aggregation::{witgen::init_zstd_encoder, *};
 pub use batch::BatchHash;
 pub use chunk::ChunkHash;
 pub use compression::*;


### PR DESCRIPTION
`N_BLOB_BYTES` cannot be used in `n_rows_data`, as `n_rows_data` is for the "batch" (not for the "blob").

We add `N_BATCH_BYTES`, which is set to 5x of `N_BLOB_BYTES`, which allows up to 5x compression ration from the `zstd` encoding. We can even set this to 8x, because this is just the upper bound. We have sufficient number of rows to populate `n_rows_data` since with `k=20` we have `~ 1 << 20` rows.