### PR TITLE
`BooleanAdvice` column to avoid soundness bugs

### DIFF
--- a/aggregator/src/aggregation.rs
+++ b/aggregator/src/aggregation.rs
@@ -12,6 +12,8 @@ mod config;
 mod decoder;
 /// config for RLC circuit
 mod rlc;
+/// Utility module
+mod util;
 
 pub(crate) use barycentric::{
     interpolate, AssignedBarycentricEvaluationConfig, BarycentricEvaluationConfig, BLS_MODULUS,

--- a/aggregator/src/aggregation/decoder/witgen.rs
+++ b/aggregator/src/aggregation/decoder/witgen.rs
@@ -6,7 +6,7 @@ mod params;
 pub use params::*;
 
 mod types;
-pub use types::{ZstdTag::*, *};
+pub use types::*;
 
 pub mod util;
 use util::{be_bits_to_value, increment_idx, le_bits_to_value, value_bits_le};

--- a/aggregator/src/aggregation/util.rs
+++ b/aggregator/src/aggregation/util.rs
@@ -1,0 +1,31 @@
+use gadgets::util::Expr;
+use halo2_proofs::{
+    plonk::{Advice, Column, ConstraintSystem, Expression, VirtualCells},
+    poly::Rotation,
+};
+use zkevm_circuits::util::Field;
+
+#[derive(Clone, Copy, Debug)]
+pub struct BooleanAdvice {
+    pub column: Column<Advice>,
+}
+
+impl BooleanAdvice {
+    pub fn construct<F: Field>(
+        meta: &mut ConstraintSystem<F>,
+        enable: impl FnOnce(&mut VirtualCells<'_, F>) -> Expression<F>,
+    ) -> Self {
+        let advice = Self {
+            column: meta.advice_column(),
+        };
+        meta.create_gate("BooleanAdvice: main gate", |meta| {
+            let bool_val = meta.query_advice(advice.column, Rotation::cur());
+            vec![enable(meta) * bool_val.expr() * (1.expr() - bool_val)]
+        });
+        advice
+    }
+
+    pub fn expr_at<F: Field>(&self, meta: &mut VirtualCells<F>, at: Rotation) -> Expression<F> {
+        meta.query_advice(self.column, at)
+    }
+}


### PR DESCRIPTION
Adding a `BooleanAdvice` wrapper that can be used as such:
```rust
let bool_advice = BooleanAdvice::construct(
    meta,
    |meta| meta.query_fixed(q_enable, Rotation::cur()),
);
```

The wrapper comes with a boolean constraint on the inner contained column, to avoid potential misses in boolean constraints leading to soundness bugs.