### PR TITLE
Import zstd from da-codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "bitstream-io",
  "c-kzg",
  "csv",
+ "encoder",
  "env_logger",
  "eth-types",
  "ethers-core",
@@ -68,7 +69,6 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "zkevm-circuits",
- "zstd 0.13.0",
 ]
 
 [[package]]
@@ -1308,6 +1308,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoder"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/da-codec.git?branch=induce_zstd#580397f473750cf256fbae463a5dcf9b28c565aa"
+dependencies = [
+ "bitstream-io",
+ "zstd 0.13.0",
+]
 
 [[package]]
 name = "encoding_rs"

--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -36,7 +36,8 @@ num-bigint.workspace = true
 
 # da-compression
 bitstream-io = "2.2.0"
-zstd = { git = "https://github.com/scroll-tech/zstd-rs", branch = "hack/mul-block", features = ["experimental"]}
+#zstd = { git = "https://github.com/scroll-tech/zstd-rs", branch = "hack/mul-block", features = ["experimental"]}
+zstd-encoder = { package = "encoder", git = "https://github.com/scroll-tech/da-codec.git", branch = "induce_zstd" }
 
 [dev-dependencies]
 

--- a/aggregator/src/aggregation/decoder/witgen/params.rs
+++ b/aggregator/src/aggregation/decoder/witgen/params.rs
@@ -13,49 +13,14 @@ pub const N_BITS_ZSTD_TAG: usize = 4;
 /// Number of bits in the repeat bits that follow value=1 in reconstructing FSE table.
 pub const N_BITS_REPEAT_FLAG: usize = 2;
 
-// we use offset window no more than = 17
-// TODO: use for multi-block zstd.
-#[allow(dead_code)]
-pub const CL_WINDOW_LIMIT: usize = 17;
+/// re-export constants in zstd-encoder
+pub use zstd_encoder::{N_BLOCK_SIZE_TARGET, N_MAX_BLOCKS};
 
-/// zstd block size target.
-pub const N_BLOCK_SIZE_TARGET: u32 = 124 * 1024;
-
-/// Maximum number of blocks that we can expect in the encoded data.
-pub const N_MAX_BLOCKS: u64 = 10;
+use zstd_encoder::{init_zstd_encoder as init_zstd_encoder_n, zstd};
 
 /// Zstd encoder configuration
 pub fn init_zstd_encoder(
     target_block_size: Option<u32>,
 ) -> zstd::stream::Encoder<'static, Vec<u8>> {
-    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).expect("infallible");
-
-    // disable compression of literals, i.e. literals will be raw bytes.
-    encoder
-        .set_parameter(zstd::stream::raw::CParameter::LiteralCompressionMode(
-            zstd::zstd_safe::ParamSwitch::Disable,
-        ))
-        .expect("infallible");
-    // with a hack in zstd we can set window log <= 17 with single segment kept
-    encoder
-        .set_parameter(zstd::stream::raw::CParameter::WindowLog(17))
-        .expect("infallible");
-    // set target block size to fit within a single block.
-    encoder
-        .set_parameter(zstd::stream::raw::CParameter::TargetCBlockSize(
-            target_block_size.unwrap_or(N_BLOCK_SIZE_TARGET),
-        ))
-        .expect("infallible");
-    // do not include the checksum at the end of the encoded data.
-    encoder.include_checksum(false).expect("infallible");
-    // do not include magic bytes at the start of the frame since we will have a single
-    // frame.
-    encoder.include_magicbytes(false).expect("infallible");
-    // do not include dictionary id so we have more simple content
-    encoder.include_dictid(false).expect("infallible");
-    // include the content size to know at decode time the expected size of decoded
-    // data.
-    encoder.include_contentsize(true).expect("infallible");
-
-    encoder
+    init_zstd_encoder_n(target_block_size.unwrap_or(N_BLOCK_SIZE_TARGET))
 }


### PR DESCRIPTION
Now we have move the zstd-related parameters into [da-codec project](https://github.com/scroll-tech/da-codec) and aggregator would use zstd and the parametered encoder from there. So we could maintain the unify encoding parameters with a more convenient route.