### PR TITLE
`AggregationCircuit` Variadic tests and fix for permutation check not done on fixed rows

### DIFF
--- a/aggregator/src/aggregation/blob_data.rs
+++ b/aggregator/src/aggregation/blob_data.rs
@@ -204,7 +204,7 @@ impl<const N_SNARKS: usize> BlobDataConfig<N_SNARKS> {
                 Some(region.assign_advice(|| "bytes_rlc", self.bytes_rlc, i + 1, || bytes_rlc)?);
         }
 
-        let last_bytes_rlc = last_bytes_rlc.expect("at least 1 byte guaranteed");
+        let mut last_bytes_rlc = last_bytes_rlc.expect("at least 1 byte guaranteed");
         for i in blob_bytes.len()..N_BLOB_BYTES {
             assigned_bytes.push(region.assign_advice(
                 || "byte",
@@ -218,7 +218,7 @@ impl<const N_SNARKS: usize> BlobDataConfig<N_SNARKS> {
                 i + 1,
                 || Value::known(Fr::one()),
             )?;
-            region.assign_advice(
+            last_bytes_rlc = region.assign_advice(
                 || "bytes_rlc",
                 self.bytes_rlc,
                 i + 1,

--- a/aggregator/src/tests/aggregation.rs
+++ b/aggregator/src/tests/aggregation.rs
@@ -111,6 +111,22 @@ fn test_aggregation_circuit_full() {
     log::trace!("finished verification for circuit");
 }
 
+#[test]
+fn test_aggregation_circuit_variadic() {
+    let k = 20;
+
+    let circuit1: AggregationCircuit<MAX_AGG_SNARKS> = build_new_aggregation_circuit(5, k);
+    let instance1 = circuit1.instances();
+    let prover1 = MockProver::<Fr>::run(k, &circuit1, instance1).unwrap();
+
+    let circuit2: AggregationCircuit<MAX_AGG_SNARKS> = build_new_aggregation_circuit(10, k);
+    let instance2 = circuit2.instances();
+    let prover2 = MockProver::<Fr>::run(k, &circuit2, instance2).unwrap();
+
+    assert_eq!(prover1.fixed(), prover2.fixed());
+    assert_eq!(prover1.permutation(), prover2.permutation());
+}
+
 fn build_new_aggregation_circuit<const N_SNARKS: usize>(
     num_real_chunks: usize,
     _k: u32,

--- a/aggregator/src/tests/aggregation.rs
+++ b/aggregator/src/tests/aggregation.rs
@@ -112,6 +112,7 @@ fn test_aggregation_circuit_full() {
 }
 
 #[test]
+#[ignore = "it takes too much time"]
 fn test_aggregation_circuit_variadic() {
     let k = 20;
 


### PR DESCRIPTION
Different instances of aggregation circuit did not have the same permutation checks, i.e. the VK was not the same.

The bug was in `BlobDataConfig`'s exports, whereby, the `bytes_rlc` cell from the "last unpadded row" was being exported instead of the cell from "last row".