### PR TITLE
fix: equality constraints for len(bytes) for both blob and batch

### DIFF
--- a/aggregator/src/aggregation/batch_data.rs
+++ b/aggregator/src/aggregation/batch_data.rs
@@ -58,6 +58,7 @@ pub struct BatchDataConfig<const N_SNARKS: usize> {
 
 pub struct AssignedBatchDataExport {
     pub num_valid_chunks: AssignedCell<Fr, Fr>,
+    pub batch_data_len: AssignedCell<Fr, Fr>,
     pub versioned_hash: Vec<AssignedCell<Fr, Fr>>,
     pub chunk_data_digests: Vec<Vec<AssignedCell<Fr, Fr>>>,
     pub bytes_rlc: AssignedCell<Fr, Fr>,
@@ -551,6 +552,12 @@ impl<const N_SNARKS: usize> BatchDataConfig<N_SNARKS> {
             region.constrain_equal(one.cell(), one_cell)?;
             one
         };
+        let four = {
+            let four = rlc_config.load_private(region, &Fr::from(4), &mut rlc_config_offset)?;
+            let four_cell = rlc_config.four_cell(four.cell().region_index);
+            region.constrain_equal(four.cell(), four_cell)?;
+            four
+        };
         let fixed_chunk_indices = {
             let mut fixed_chunk_indices = vec![one.clone()];
             for i in 2..=N_SNARKS {
@@ -564,6 +571,8 @@ impl<const N_SNARKS: usize> BatchDataConfig<N_SNARKS> {
             }
             fixed_chunk_indices
         };
+        let two = fixed_chunk_indices.get(1).expect("N_SNARKS >= 2");
+        let n_snarks = fixed_chunk_indices.last().expect("N_SNARKS >= 2");
         let pows_of_256 = {
             let mut pows_of_256 = vec![one.clone()];
             for (exponent, pow_of_256) in (1..=POWS_OF_256).zip_eq(
@@ -632,6 +641,9 @@ impl<const N_SNARKS: usize> BatchDataConfig<N_SNARKS> {
         let mut num_nonempty_chunks = zero.clone();
         let mut is_empty_chunks = Vec::with_capacity(N_SNARKS);
         let mut chunk_sizes = Vec::with_capacity(N_SNARKS);
+        // init: batch_data_len = 4 * N_SNARKS + 2 (metadata).
+        let mut batch_data_len =
+            rlc_config.mul_add(region, &four, n_snarks, two, &mut rlc_config_offset)?;
         for (i, is_padded_chunk) in chunks_are_padding.iter().enumerate() {
             let rows = assigned_rows
                 .iter()
@@ -679,6 +691,8 @@ impl<const N_SNARKS: usize> BatchDataConfig<N_SNARKS> {
                 &num_nonempty_chunks,
                 &mut rlc_config_offset,
             )?;
+            batch_data_len =
+                rlc_config.add(region, &batch_data_len, &chunk_size, &mut rlc_config_offset)?;
 
             is_empty_chunks.push(is_empty_chunk);
             chunk_sizes.push(chunk_size);
@@ -940,6 +954,7 @@ impl<const N_SNARKS: usize> BatchDataConfig<N_SNARKS> {
             .collect::<Vec<AssignedCell<Fr, Fr>>>();
         let export = AssignedBatchDataExport {
             num_valid_chunks,
+            batch_data_len,
             versioned_hash: assigned_rows
                 .iter()
                 .rev()

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -27,6 +27,7 @@ use snark_verifier_sdk::{CircuitExt, Snark, SnarkWitness};
 use zkevm_circuits::util::Challenges;
 
 use crate::{
+    aggregation::witgen::process,
     batch::BatchHash,
     constants::{ACC_LEN, DIGEST_LEN},
     core::{assign_batch_hashes, extract_proof_and_instances_with_pairing_check},
@@ -456,10 +457,7 @@ impl<const N_SNARKS: usize> Circuit<Fr> for AggregationCircuit<N_SNARKS> {
                 sequence_info_arr,
                 address_table_arr,
                 sequence_exec_result,
-            ) = crate::aggregation::decoder::witgen::process(
-                &encoded_batch_bytes,
-                challenges.keccak_input(),
-            );
+            ) = process(&encoded_batch_bytes, challenges.keccak_input());
 
             // sanity check:
             let (recovered_bytes, sequence_exec_info_arr) = sequence_exec_result.into_iter().fold(
@@ -492,7 +490,7 @@ impl<const N_SNARKS: usize> Circuit<Fr> for AggregationCircuit<N_SNARKS> {
             )?;
 
             layouter.assign_region(
-                || "batch checks",
+                || "consistency checks",
                 |mut region| -> Result<(), Error> {
                     region.constrain_equal(
                         assigned_batch_hash.num_valid_snarks.cell(),
@@ -543,10 +541,20 @@ impl<const N_SNARKS: usize> Circuit<Fr> for AggregationCircuit<N_SNARKS> {
                         blob_data_exports.bytes_rlc.cell(),
                         decoder_exports.encoded_rlc.cell(),
                     )?;
+                    // equate len(blob_bytes) with decoder's encoded_len
+                    region.constrain_equal(
+                        blob_data_exports.bytes_len.cell(),
+                        decoder_exports.encoded_len.cell(),
+                    )?;
                     // equate rlc (from batch data) with decoder's decoded_rlc
                     region.constrain_equal(
                         batch_data_exports.bytes_rlc.cell(),
                         decoder_exports.decoded_rlc.cell(),
+                    )?;
+                    // equate len(batch_data) with decoder's decoded_len
+                    region.constrain_equal(
+                        batch_data_exports.batch_data_len.cell(),
+                        decoder_exports.decoded_len.cell(),
                     )?;
 
                     Ok(())

--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -457,7 +457,7 @@ impl<const N_SNARKS: usize> Circuit<Fr> for AggregationCircuit<N_SNARKS> {
                 sequence_info_arr,
                 address_table_rows: address_table_arr,
                 sequence_exec_results,
-            } = = process(&encoded_batch_bytes, challenges.keccak_input());
+            } = process(&encoded_batch_bytes, challenges.keccak_input());
 
             // sanity check:
             let (recovered_bytes, sequence_exec_info_arr) = sequence_exec_results.into_iter().fold(

--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -1218,6 +1218,7 @@ impl<const L: usize, const R: usize> DecoderConfig<L, R> {
 
         meta.enable_equality(config.decoded_len);
         meta.enable_equality(config.encoded_rlc);
+        meta.enable_equality(config.byte_idx);
 
         macro_rules! is_tag {
             ($var:ident, $tag_variant:ident) => {
@@ -5405,7 +5406,7 @@ impl<const L: usize, const R: usize> DecoderConfig<L, R> {
                     )?;
                 }
 
-                // dbg: decoded length from SeqExecConfig and decoder config must match.
+                // decoded length from SeqExecConfig and decoder config must match.
                 region.constrain_equal(exported_len.cell(), decoded_len_cell.unwrap().cell())?;
 
                 Ok(AssignedDecoderConfigExports {

--- a/aggregator/src/aggregation/rlc/gates.rs
+++ b/aggregator/src/aggregation/rlc/gates.rs
@@ -122,6 +122,15 @@ impl RlcConfig {
     }
 
     #[inline]
+    pub(crate) fn four_cell(&self, region_index: RegionIndex) -> Cell {
+        Cell {
+            region_index,
+            row_offset: 4,
+            column: self.fixed.into(),
+        }
+    }
+
+    #[inline]
     pub(crate) fn fixed_up_to_max_agg_snarks_cell(
         &self,
         region_index: RegionIndex,


### PR DESCRIPTION
equality constraints for:
- len(blobBytes) == decoder::encoded_len
- len(batchData) == decoder::decoded_len