### PR TITLE
Fix: tx circuit errors

### DIFF
--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -923,17 +923,6 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
                 },
             );
 
-            // AccessListAddressLen != 0 must force AccessListRLC != 0
-            cb.condition(
-                and::expr([
-                    is_access_list_addresses_len(meta),
-                    not::expr(meta.query_advice(is_none, Rotation::cur())),
-                ]),
-                |cb| {
-                    cb.require_zero("AccessListRLC != 0", value_is_zero.expr(Rotation(2))(meta));
-                },
-            );
-
             cb.gate(meta.query_fixed(q_enable, Rotation::cur()))
         });
 

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -4323,7 +4323,7 @@ impl<F: Field> TxCircuit<F> {
                         .txs
                         .iter()
                         .skip(i + 1)
-                        .find(|tx| !tx.call_data.is_empty());
+                        .find(|tx| !tx.call_data.is_empty() || (tx.access_list.as_ref().map_or(false, |al| !al.0.is_empty())));
                     config.assign_calldata_rows(
                         &mut region,
                         &mut offset,


### PR DESCRIPTION
### Description



### Issue Link

1. The rule to find next tx in dynamic section is changed after we enable EIP2930. Previously only calldata rows are assigned in dynamic section. After EIP2930, it should be either calldata or access_list rows.
2. The requirement that
   >  if a tx's access_list_address_len != 0, then its access_list_rlc must be zero.
  is wrong. 
  
   An counterexample is like this:
   ```
   {
       "address": "0x0",
       "storage_keys": [
             "0x0",
        ]
   } 
   ```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update