### PR TITLE
Fix: tx circuit constraint err for access list init section

### DIFF
--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -1818,7 +1818,7 @@ impl<F: Field> SubCircuitConfig<F> for TxCircuitConfig<F> {
 
             cb.require_equal(
                 "al_idx starts with 1",
-                meta.query_advice(al_idx, Rotation::next()),
+                meta.query_advice(al_idx, Rotation::cur()),
                 1.expr(),
             );
             cb.require_zero(


### PR DESCRIPTION
### Description



### Issue Link

```
cargo run --release --features='scroll, parallel_syn' -- --suite nightly 
   --circuits sc --inspect 'intrinsic_d1(min23400)_g9_v0'
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update