### PR TITLE
Auditing improvement: Asserting assumptions about equal gas costs

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -139,14 +139,23 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
         );
 
-        // constaint of four opcode's constant gas cost is indeed the same.  
-        // in case some constant gas cost of them changes in the future.
-        cb.require_equal("Constant gas cost is same for CALLDATACOPY, CODECOPY", OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
-        OpcodeId::CODECOPY.constant_gas_cost().expr());
-        cb.require_equal("Constant gas cost is same for CALLDATACOPY, RETURNDATACOPY", OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
-        OpcodeId::RETURNDATACOPY.constant_gas_cost().expr());
-        cb.require_equal("Constant gas cost is same for CALLDATACOPY, MCOPY", OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
-        OpcodeId::MCOPY.constant_gas_cost().expr());
+        // constraint of four opcodes' (CALLDATACOPY, CODECOPY, RETURNDATACOPY and MCOPY) constant
+        // gas cost is the same. in case some of them changes in the future.
+        cb.require_equal(
+            "Constant gas cost is same for CALLDATACOPY, CODECOPY",
+            OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
+            OpcodeId::CODECOPY.constant_gas_cost().expr(),
+        );
+        cb.require_equal(
+            "Constant gas cost is same for CALLDATACOPY, RETURNDATACOPY",
+            OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
+            OpcodeId::RETURNDATACOPY.constant_gas_cost().expr(),
+        );
+        cb.require_equal(
+            "Constant gas cost is same for CALLDATACOPY, MCOPY",
+            OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
+            OpcodeId::MCOPY.constant_gas_cost().expr(),
+        );
 
         let insufficient_gas = LtGadget::construct(
             cb,

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -135,9 +135,18 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
                 GasCost::WARM_ACCESS.expr(),
                 GasCost::COLD_ACCOUNT_ACCESS.expr(),
             ),
-            // Constant gas cost is same for CALLDATACOPY, CODECOPY，RETURNDATACOPY and mcopy.
+            // Constant gas cost is same for CALLDATACOPY, CODECOPY, RETURNDATACOPY and MCOPY.
             OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
         );
+
+        // constaint of four opcode's constant gas cost is indeed the same.  
+        // in case some constant gas cost of them changes in the future.
+        cb.require_equal("Constant gas cost is same for CALLDATACOPY, CODECOPY", OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
+        OpcodeId::CODECOPY.constant_gas_cost().expr());
+        cb.require_equal("Constant gas cost is same for CALLDATACOPY, RETURNDATACOPY", OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
+        OpcodeId::RETURNDATACOPY.constant_gas_cost().expr());
+        cb.require_equal("Constant gas cost is same for CALLDATACOPY, MCOPY", OpcodeId::CALLDATACOPY.constant_gas_cost().expr(),
+        OpcodeId::MCOPY.constant_gas_cost().expr());
 
         let insufficient_gas = LtGadget::construct(
             cb,


### PR DESCRIPTION
### Description

add constraint to ensure those opcodes' (CALLDATACOPY, CODECOPY, RETURNDATACOPY and MCOPY) constant gas cost is same,  in case some of them diff in the future, can detect that in time.

### Issue Link

[_link issue here_]

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents
