### PR TITLE
Fix the wrong dockerfile command text

### DIFF
--- a/docker/testool/gpu/Dockerfile
+++ b/docker/testool/gpu/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 ADD . /src
 RUN mkdir /.cargo && echo 'paths = ["/src/halo2-gpu/halo2_proofs"]' > /.cargo/config
 RUN cargo build --features $TESTOOL_FEATURE --release
-Run cd ./target/release && find -name libzktrie.so | xargs -I {} cp {} ./
+RUN cd ./target/release && find -name libzktrie.so | xargs -I {} cp {} ./
 RUN apt update && apt install -y curl
 RUN mkdir test_assets
 RUN curl -o ./test_assets/layer1.config https://circuit-release.s3.us-west-2.amazonaws.com/release-v0.9.5/layer1.config


### PR DESCRIPTION
### Description

This PR modifies a shell command in the Dockerfile to ensure that it adheres to best practices by standardizing the command syntax. The change enhances readability and maintainability without affecting the functionality of the command.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- Modified the Docker command to standardize the syntax for copying the `libzktrie.so` library.

### Rationale

The previous command used in the Dockerfile was functional but lacked standardization in its syntax. By refining the command syntax, the code becomes cleaner and more consistent with best practices in shell scripting. This change does not introduce any functional alterations but improves the clarity and maintainability of the codebase.

### How Has This Been Tested?

The modified Docker command has been tested in a controlled development environment to ensure that the functionality remains unchanged. The command successfully locates and copies the `libzktrie.so` file as expected without any errors.