### PR TITLE
[fix] typo in seq exec

### DIFF
--- a/aggregator/src/aggregation/decoder/seq_exec.rs
+++ b/aggregator/src/aggregation/decoder/seq_exec.rs
@@ -398,7 +398,7 @@ impl<F: Field> SeqExecConfig<F> {
                 |cb| {
                     cb.require_equal(
                         "inside a inst, backref phase keep 1 once it changed to 1",
-                        s_back_ref_phase_prev.expr(),
+                        s_back_ref_phase.expr(),
                         1.expr(),
                     );
                 },


### PR DESCRIPTION
This PR fixed a typo reported by ToB's code review in week 3