### PR TITLE
[fix] typo in seq exec

### DIFF
--- a/aggregator/src/aggregation/decoder/seq_exec.rs
+++ b/aggregator/src/aggregation/decoder/seq_exec.rs
@@ -398,7 +398,7 @@ impl<F: Field> SeqExecConfig<F> {
                 |cb| {
                     cb.require_equal(
                         "inside a inst, backref phase keep 1 once it changed to 1",
-                        s_back_ref_phase_prev.expr(),
+                        s_back_ref_phase.expr(),
                         1.expr(),
                     );
                 },


### PR DESCRIPTION
This PR fixed a typo reported by ToB's code review in week 3

I notice that this gate maybe reluctant so it is highly impossible to set up a negative test to achieve a malice attacking (wrong witness but circuit declaimed to be correct). I advice to keep it as a caution and optimize it out later when we have more confidient (that it is reluctant).

CAUTION: **It is a BREAKING CHANGE for verifier**