### PR TITLE
Fix: Update tx_circuit.rs MAX_AGG_SNARKS

### DIFF
--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -104,7 +104,7 @@ pub const HASH_RLC_OFFSET: usize = 20;
 // CHUNK_TXBYTES_BLOB_LIMIT =
 //      (BLOB_WIDTH * N_BYTES_31) - (N_ROWS_NUM_CHUNKS + N_ROWS_CHUNK_SIZES)
 // N_ROWS_CHUNK_SIZES = MAX_AGG_SNARKS * 4
-const CHUNK_TXBYTES_BLOB_LIMIT: usize = (4096 * 31) - (2 + 15 * 4);
+const CHUNK_TXBYTES_BLOB_LIMIT: usize = (4096 * 31) - (2 + 45 * 4);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 enum LookupCondition {


### PR DESCRIPTION
### Description

This PR fix the MAX_AGG_SNARKS in zkevm-circuits/src/tx.circuit.rs related to https://github.com/scroll-tech/zkevm-circuits/pull/1311.

When the aggregated snarks is greater than 15 and smaller than 45, bugs may be triggered in a real test and not be triggered in mock chunk and aggregation unit test.

may be we should finish TODO: Constants from aggregator shouldn't be manually copied to fix the problem better If MAX_AGG_SNARKS will change frequently in the future.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update






