### PR TITLE
fix: table kind should not change over the fse code trailing bits

### DIFF
--- a/aggregator/src/aggregation/decoder.rs
+++ b/aggregator/src/aggregation/decoder.rs
@@ -2785,6 +2785,13 @@ impl<const L: usize, const R: usize> DecoderConfig<L, R> {
                     ]),
                 );
 
+                // The FSE table kind remains the same.
+                cb.require_equal(
+                    "table_kind remains the same for trailing bits in tag=FseCode",
+                    meta.query_advice(config.fse_decoder.table_kind, Rotation::cur()),
+                    meta.query_advice(config.fse_decoder.table_kind, Rotation::prev()),
+                );
+
                 cb.gate(condition)
             },
         );


### PR DESCRIPTION
`table_kind` for FSE decoder should remain the same if trailing bits row was encountered. After this trailing bits row, we might encounter another FSE table, for which the `table_kind` value is checked via FSE table transition lookup over the fixed table.