### PR TITLE
refactor(ccc): less magic numbers

### DIFF
--- a/prover/src/zkevm/capacity_checker.rs
+++ b/prover/src/zkevm/capacity_checker.rs
@@ -5,11 +5,13 @@ use eth_types::{
     state_db::{CodeDB, StateDB},
     ToWord, H256,
 };
+use halo2_proofs::halo2curves::bn256::Fr;
 use itertools::Itertools;
 use mpt_zktrie::state::ZktrieState;
 use serde_derive::{Deserialize, Serialize};
-use zkevm_circuits::super_circuit::params::{
-    get_sub_circuit_limit_and_confidence, get_super_circuit_params,
+use zkevm_circuits::{
+    poseidon_circuit::{Hashable, HASH_BLOCK_STEP_SIZE},
+    super_circuit::params::{get_sub_circuit_limit_and_confidence, get_super_circuit_params},
 };
 
 pub use super::SubCircuitRowUsage;
@@ -193,7 +195,7 @@ impl CircuitCapacityChecker {
                 assert_eq!(rows[2].name, "bytecode");
                 rows[2].row_number -= bytes_len + 1;
                 assert_eq!(rows[11].name, "poseidon");
-                rows[11].row_number -= bytes_len / (31 * 2) * 9;
+                rows[11].row_number -= bytes_len / HASH_BLOCK_STEP_SIZE * Fr::hash_block_size();
             }
         }
         let tx_row_usage = RowUsage::from_row_usage_details(rows);

--- a/zkevm-circuits/src/poseidon_circuit.rs
+++ b/zkevm-circuits/src/poseidon_circuit.rs
@@ -172,7 +172,10 @@ impl<F: Field> SubCircuit<F> for PoseidonCircuit<F> {
         let total_row_num = mpt_row_num + byte_row_num;
         log::debug!("poseidon circuit row num: {mpt_row_num}(mpt) + {byte_row_num}(bytecode) = {total_row_num}");
         let avg_trie_depth = after_dedup_size / block.mpt_updates.len();
-        log::debug!("avg_trie_depth {avg_trie_depth}");
+        log::debug!(
+            "avg_trie_depth {avg_trie_depth}, hash num {after_dedup_size}, mpt update num {}",
+            block.mpt_updates.len()
+        );
         (
             total_row_num,
             block.circuits_params.max_poseidon_rows.max(total_row_num),

--- a/zkevm-circuits/src/poseidon_circuit.rs
+++ b/zkevm-circuits/src/poseidon_circuit.rs
@@ -9,7 +9,8 @@ use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{Circuit, ConstraintSystem, Error},
 };
-use hash_circuit::hash::{Hashable, PoseidonHashChip, PoseidonHashConfig, PoseidonHashTable};
+pub use hash_circuit::hash::Hashable;
+use hash_circuit::hash::{PoseidonHashChip, PoseidonHashConfig, PoseidonHashTable};
 
 /// re-wrapping for mpt circuit
 #[derive(Default, Clone, Debug)]
@@ -25,7 +26,8 @@ pub struct PoseidonCircuitConfigArgs {
 #[derive(Debug, Clone)]
 pub struct PoseidonCircuitConfig<F: Field>(pub(crate) PoseidonHashConfig<F>);
 
-const HASH_BLOCK_STEP_SIZE: usize = HASHBLOCK_BYTES_IN_FIELD * PoseidonTable::INPUT_WIDTH;
+/// How many bytes a poseidon round can consume.
+pub const HASH_BLOCK_STEP_SIZE: usize = HASHBLOCK_BYTES_IN_FIELD * PoseidonTable::INPUT_WIDTH;
 
 impl<F: Field> SubCircuitConfig<F> for PoseidonCircuitConfig<F> {
     type ConfigArgs = PoseidonCircuitConfigArgs;

--- a/zkevm-circuits/src/poseidon_circuit.rs
+++ b/zkevm-circuits/src/poseidon_circuit.rs
@@ -173,8 +173,9 @@ impl<F: Field> SubCircuit<F> for PoseidonCircuit<F> {
         log::debug!("poseidon circuit row num: {mpt_row_num}(mpt) + {byte_row_num}(bytecode) = {total_row_num}");
         let mpt_circuit_rows = 3 * 32 * block.mpt_updates.len();
         let poseidon_mpt_ratio = mpt_row_num as f64 / mpt_circuit_rows as f64;
+        let avg_trie_depth = after_dedup_size / block.mpt_updates.len();
         log::debug!(
-            "poseidon_mpt_ratio {poseidon_mpt_ratio:.3}, 12x naive poseidon rows {}",
+            "avg_trie_depth {avg_trie_depth}, poseidon_mpt_ratio {poseidon_mpt_ratio:.3}, 12x naive poseidon rows {}",
             12 * mpt_circuit_rows
         );
         (

--- a/zkevm-circuits/src/poseidon_circuit.rs
+++ b/zkevm-circuits/src/poseidon_circuit.rs
@@ -171,13 +171,8 @@ impl<F: Field> SubCircuit<F> for PoseidonCircuit<F> {
             * F::hash_block_size();
         let total_row_num = mpt_row_num + byte_row_num;
         log::debug!("poseidon circuit row num: {mpt_row_num}(mpt) + {byte_row_num}(bytecode) = {total_row_num}");
-        let mpt_circuit_rows = 3 * 32 * block.mpt_updates.len();
-        let poseidon_mpt_ratio = mpt_row_num as f64 / mpt_circuit_rows as f64;
         let avg_trie_depth = after_dedup_size / block.mpt_updates.len();
-        log::debug!(
-            "avg_trie_depth {avg_trie_depth}, poseidon_mpt_ratio {poseidon_mpt_ratio:.3}, 12x naive poseidon rows {}",
-            12 * mpt_circuit_rows
-        );
+        log::debug!("avg_trie_depth {avg_trie_depth}");
         (
             total_row_num,
             block.circuits_params.max_poseidon_rows.max(total_row_num),


### PR DESCRIPTION
Remove some magic numbers.


we can update "avg_trie_depth" later.   Seems 35 even 32 would be safe enough?

```
trie_depth 22, hash num 3511, mpt update num 154
trie_depth 24, hash num 9280, mpt update num 385
trie_depth 23, hash num 6649, mpt update num 284
trie_depth 21, hash num 4629, mpt update num 212
trie_depth 25, hash num 3842, mpt update num 151
trie_depth 26, hash num 5874, mpt update num 220
trie_depth 29, hash num 7464, mpt update num 250
trie_depth 25, hash num 5036, mpt update num 195
trie_depth 24, hash num 4574, mpt update num 186
trie_depth 25, hash num 5271, mpt update num 209
trie_depth 19, hash num 5295, mpt update num 267
trie_depth 20, hash num 6442, mpt update num 311
trie_depth 26, hash num 3622, mpt update num 137
trie_depth 27, hash num 4786, mpt update num 176
trie_depth 30, hash num 3023, mpt update num 100
trie_depth 30, hash num 4349, mpt update num 141
trie_depth 24, hash num 6961, mpt update num 287
trie_depth 20, hash num 5072, mpt update num 249
trie_depth 22, hash num 5596, mpt update num 246
trie_depth 22, hash num 4962, mpt update num 216
trie_depth 23, hash num 1960, mpt update num 85
trie_depth 24, hash num 9751, mpt update num 394
trie_depth 26, hash num 5080, mpt update num 194
trie_depth 25, hash num 2292, mpt update num 90
trie_depth 25, hash num 2296, mpt update num 90
```