### PR TITLE
Standalone BatchHeader Constructor

### DIFF
--- a/aggregator/src/aggregation/circuit.rs
+++ b/aggregator/src/aggregation/circuit.rs
@@ -506,21 +506,20 @@ impl<const N_SNARKS: usize> Circuit<Fr> for BatchCircuit<N_SNARKS> {
                 "original and recovered bytes mismatch"
             );
 
-            // batch_circuit_debug
-            // let decoder_exports = config.decoder_config.assign(
-            //     &mut layouter,
-            //     &batch_bytes,
-            //     &encoded_batch_bytes,
-            //     witness_rows,
-            //     decoded_literals,
-            //     fse_aux_tables,
-            //     block_info_arr,
-            //     sequence_info_arr,
-            //     address_table_arr,
-            //     sequence_exec_info_arr,
-            //     &challenges,
-            //     LOG_DEGREE, // TODO: configure k for batch circuit instead of hard-coded here.
-            // )?;
+            let decoder_exports = config.decoder_config.assign(
+                &mut layouter,
+                &batch_bytes,
+                &encoded_batch_bytes,
+                witness_rows,
+                decoded_literals,
+                fse_aux_tables,
+                block_info_arr,
+                sequence_info_arr,
+                address_table_arr,
+                sequence_exec_info_arr,
+                &challenges,
+                LOG_DEGREE, // TODO: configure k for batch circuit instead of hard-coded here.
+            )?;
 
             layouter.assign_region(
                 || "consistency checks",
@@ -569,27 +568,26 @@ impl<const N_SNARKS: usize> Circuit<Fr> for BatchCircuit<N_SNARKS> {
                         region.constrain_equal(c.cell(), ec.cell())?;
                     }
 
-                    // batch_circuit_debug
-                    // // equate rlc (from blob data) with decoder's encoded_rlc
-                    // region.constrain_equal(
-                    //     blob_data_exports.bytes_rlc.cell(),
-                    //     decoder_exports.encoded_rlc.cell(),
-                    // )?;
-                    // // equate len(blob_bytes) with decoder's encoded_len
-                    // region.constrain_equal(
-                    //     blob_data_exports.bytes_len.cell(),
-                    //     decoder_exports.encoded_len.cell(),
-                    // )?;
-                    // // equate rlc (from batch data) with decoder's decoded_rlc
-                    // region.constrain_equal(
-                    //     batch_data_exports.bytes_rlc.cell(),
-                    //     decoder_exports.decoded_rlc.cell(),
-                    // )?;
-                    // // equate len(batch_data) with decoder's decoded_len
-                    // region.constrain_equal(
-                    //     batch_data_exports.batch_data_len.cell(),
-                    //     decoder_exports.decoded_len.cell(),
-                    // )?;
+                    // equate rlc (from blob data) with decoder's encoded_rlc
+                    region.constrain_equal(
+                        blob_data_exports.bytes_rlc.cell(),
+                        decoder_exports.encoded_rlc.cell(),
+                    )?;
+                    // equate len(blob_bytes) with decoder's encoded_len
+                    region.constrain_equal(
+                        blob_data_exports.bytes_len.cell(),
+                        decoder_exports.encoded_len.cell(),
+                    )?;
+                    // equate rlc (from batch data) with decoder's decoded_rlc
+                    region.constrain_equal(
+                        batch_data_exports.bytes_rlc.cell(),
+                        decoder_exports.decoded_rlc.cell(),
+                    )?;
+                    // equate len(batch_data) with decoder's decoded_len
+                    region.constrain_equal(
+                        batch_data_exports.batch_data_len.cell(),
+                        decoder_exports.decoded_len.cell(),
+                    )?;
 
                     Ok(())
                 },

--- a/aggregator/src/aggregation/config.rs
+++ b/aggregator/src/aggregation/config.rs
@@ -38,9 +38,8 @@ pub struct BatchCircuitConfig<const N_SNARKS: usize> {
     pub blob_data_config: BlobDataConfig<N_SNARKS>,
     /// The batch data's config.
     pub batch_data_config: BatchDataConfig<N_SNARKS>,
-    // batch_circuit_debug
-    // /// The zstd decoder's config.
-    // pub decoder_config: DecoderConfig<1024, 512>,
+    /// The zstd decoder's config.
+    pub decoder_config: DecoderConfig<1024, 512>,
     /// Config to do the barycentric evaluation on blob polynomial.
     pub barycentric: BarycentricEvaluationConfig,
     /// Instance for public input; stores
@@ -131,30 +130,29 @@ impl<const N_SNARKS: usize> BatchCircuitConfig<N_SNARKS> {
         );
 
         // Zstd decoder.
-        // batch_circuit_debug
-        // let pow_rand_table = PowOfRandTable::construct(meta, &challenges_expr);
+        let pow_rand_table = PowOfRandTable::construct(meta, &challenges_expr);
 
-        // let pow2_table = Pow2Table::construct(meta);
-        // let range8 = RangeTable::construct(meta);
-        // let range16 = RangeTable::construct(meta);
-        // let range512 = RangeTable::construct(meta);
-        // let range_block_len = RangeTable::construct(meta);
-        // let bitwise_op_table = BitwiseOpTable::construct(meta);
+        let pow2_table = Pow2Table::construct(meta);
+        let range8 = RangeTable::construct(meta);
+        let range16 = RangeTable::construct(meta);
+        let range512 = RangeTable::construct(meta);
+        let range_block_len = RangeTable::construct(meta);
+        let bitwise_op_table = BitwiseOpTable::construct(meta);
 
-        // let decoder_config = DecoderConfig::configure(
-        //     meta,
-        //     &challenges_expr,
-        //     DecoderConfigArgs {
-        //         pow_rand_table,
-        //         pow2_table,
-        //         u8_table,
-        //         range8,
-        //         range16,
-        //         range512,
-        //         range_block_len,
-        //         bitwise_op_table,
-        //     },
-        // );
+        let decoder_config = DecoderConfig::configure(
+            meta,
+            &challenges_expr,
+            DecoderConfigArgs {
+                pow_rand_table,
+                pow2_table,
+                u8_table,
+                range8,
+                range16,
+                range512,
+                range_block_len,
+                bitwise_op_table,
+            },
+        );
 
         // Instance column stores public input column
         // the public instance for this circuit consists of
@@ -179,8 +177,7 @@ impl<const N_SNARKS: usize> BatchCircuitConfig<N_SNARKS> {
             instance,
             barycentric,
             batch_data_config,
-            // batch_circuit_debug
-            // decoder_config,
+            decoder_config,
         }
     }
 

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -14,7 +14,7 @@ use crate::{
 /// Batch header provides additional fields from the context (within recursion)
 /// for constructing the preimage of the batch hash.
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct BatchHeader {
+pub struct BatchHeader<const N_SNARKS: usize> {
     /// the batch version
     pub version: u8,
     /// the index of the batch
@@ -35,7 +35,65 @@ pub struct BatchHeader {
     pub blob_data_proof: [H256; 2],
 }
 
-impl BatchHeader {
+impl<const N_SNARKS: usize> BatchHeader<N_SNARKS> {
+    /// Constructs the correct batch header from chunks data and context variables
+    pub fn construct_from_chunks(
+        version: u8,
+        batch_index: u64,
+        l1_message_popped: u64,
+        total_l1_message_popped: u64,
+        parent_batch_hash: H256,
+        last_block_timestamp: u64,
+        chunks: &[ChunkInfo]
+    ) -> Self {
+        assert_ne!(chunks.len(), 0);
+        assert!(chunks.len() <= N_SNARKS);
+
+        let mut chunks_with_padding = chunks.to_vec();
+        if chunks.len() < N_SNARKS {
+            let last_chunk = chunks.last().unwrap();
+            let mut padding_chunk = last_chunk.clone();
+            padding_chunk.is_padding = true;
+            chunks_with_padding
+                .extend(std::iter::repeat(padding_chunk).take(N_SNARKS - chunks.len()));
+        }
+
+        let number_of_valid_chunks = match chunks_with_padding
+            .iter()
+            .enumerate()
+            .find(|(_index, chunk)| chunk.is_padding)
+        {
+            Some((index, _)) => index,
+            None => N_SNARKS,
+        };
+
+        let batch_data_hash_preimage = chunks_with_padding
+            .iter()
+            .take(number_of_valid_chunks)
+            .flat_map(|chunk_info| chunk_info.data_hash.0.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        let batch_data_hash = keccak256(batch_data_hash_preimage);
+
+        let batch_data = BatchData::<N_SNARKS>::new(number_of_valid_chunks, &chunks_with_padding);
+        let point_evaluation_assignments = PointEvaluationAssignments::from(&batch_data);
+
+        Self {
+            version,
+            batch_index,
+            l1_message_popped,
+            total_l1_message_popped,
+            parent_batch_hash,
+            last_block_timestamp,
+            data_hash: batch_data_hash.into(),
+            blob_versioned_hash: batch_data.get_versioned_hash(),
+            blob_data_proof: [
+                H256::from_slice(&point_evaluation_assignments.challenge.to_be_bytes()),
+                H256::from_slice(&point_evaluation_assignments.evaluation.to_be_bytes())
+            ]
+        }
+    }
+
     /// Returns the batch hash as per BatchHeaderV3.
     pub fn batch_hash(&self) -> H256 {
         // the current batch hash is build as
@@ -107,12 +165,12 @@ pub struct BatchHash<const N_SNARKS: usize> {
     /// The 4844 versioned hash for the blob.
     pub(crate) versioned_hash: H256,
     /// The context batch header
-    pub(crate) batch_header: BatchHeader,
+    pub(crate) batch_header: BatchHeader<N_SNARKS>,
 }
 
 impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
     /// Build Batch hash from an ordered list of chunks. Will pad if needed
-    pub fn construct_with_unpadded(chunks: &[ChunkInfo], batch_header: BatchHeader) -> Self {
+    pub fn construct_with_unpadded(chunks: &[ChunkInfo], batch_header: BatchHeader<N_SNARKS>) -> Self {
         assert_ne!(chunks.len(), 0);
         assert!(chunks.len() <= N_SNARKS);
         let mut chunks_with_padding = chunks.to_vec();
@@ -132,14 +190,12 @@ impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
     }
 
     /// Build Batch hash from an ordered list of #N_SNARKS of chunks.
-    pub fn construct(chunks_with_padding: &[ChunkInfo], batch_header: BatchHeader) -> Self {
+    pub fn construct(chunks_with_padding: &[ChunkInfo], batch_header: BatchHeader<N_SNARKS>) -> Self {
         assert_eq!(
             chunks_with_padding.len(),
             N_SNARKS,
             "input chunk slice does not match N_SNARKS"
         );
-
-        let mut export_batch_header = batch_header;
 
         let number_of_valid_chunks = match chunks_with_padding
             .iter()
@@ -209,24 +265,35 @@ impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
             .collect::<Vec<_>>();
         let batch_data_hash = keccak256(preimage);
 
-        // Update export value
-        export_batch_header.data_hash = batch_data_hash.into();
+        assert_eq!(
+            batch_header.data_hash, 
+            H256::from_slice(&batch_data_hash), 
+            "Expect provided BatchHeader's data_hash field to be correct"
+        );
 
         let batch_data = BatchData::<N_SNARKS>::new(number_of_valid_chunks, chunks_with_padding);
         let point_evaluation_assignments = PointEvaluationAssignments::from(&batch_data);
 
-        // Update export value
-        export_batch_header.blob_data_proof[0] =
-            H256::from_slice(&point_evaluation_assignments.challenge.to_be_bytes());
-        export_batch_header.blob_data_proof[1] =
-            H256::from_slice(&point_evaluation_assignments.evaluation.to_be_bytes());
+        assert_eq!(
+            batch_header.blob_data_proof[0], 
+            H256::from_slice(&point_evaluation_assignments.challenge.to_be_bytes()), 
+            "Expect provided BatchHeader's blob_data_proof field 0 to be correct"
+        );
+        assert_eq!(
+            batch_header.blob_data_proof[1], 
+            H256::from_slice(&point_evaluation_assignments.evaluation.to_be_bytes()), 
+            "Expect provided BatchHeader's blob_data_proof field 1 to be correct"
+        );
 
         let versioned_hash = batch_data.get_versioned_hash();
 
-        // Update export value
-        export_batch_header.blob_versioned_hash = versioned_hash;
+        assert_eq!(
+            batch_header.blob_versioned_hash, 
+            versioned_hash, 
+            "Expect provided BatchHeader's blob_versioned_hash field to be correct"
+        );
 
-        let current_batch_hash = export_batch_header.batch_hash();
+        let current_batch_hash = batch_header.batch_hash();
 
         log::info!(
             "batch hash {:?}, datahash {}, z {}, y {}, versioned hash {:x}",
@@ -248,7 +315,7 @@ impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
             number_of_valid_chunks,
             point_evaluation_assignments,
             versioned_hash,
-            batch_header: export_batch_header,
+            batch_header,
         }
     }
 
@@ -378,7 +445,7 @@ impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
     }
 
     /// ...
-    pub fn batch_header(&self) -> BatchHeader {
+    pub fn batch_header(&self) -> BatchHeader<N_SNARKS> {
         self.batch_header
     }
 }

--- a/aggregator/src/batch.rs
+++ b/aggregator/src/batch.rs
@@ -44,7 +44,7 @@ impl<const N_SNARKS: usize> BatchHeader<N_SNARKS> {
         total_l1_message_popped: u64,
         parent_batch_hash: H256,
         last_block_timestamp: u64,
-        chunks: &[ChunkInfo]
+        chunks: &[ChunkInfo],
     ) -> Self {
         assert_ne!(chunks.len(), 0);
         assert!(chunks.len() <= N_SNARKS);
@@ -89,8 +89,8 @@ impl<const N_SNARKS: usize> BatchHeader<N_SNARKS> {
             blob_versioned_hash: batch_data.get_versioned_hash(),
             blob_data_proof: [
                 H256::from_slice(&point_evaluation_assignments.challenge.to_be_bytes()),
-                H256::from_slice(&point_evaluation_assignments.evaluation.to_be_bytes())
-            ]
+                H256::from_slice(&point_evaluation_assignments.evaluation.to_be_bytes()),
+            ],
         }
     }
 
@@ -170,7 +170,10 @@ pub struct BatchHash<const N_SNARKS: usize> {
 
 impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
     /// Build Batch hash from an ordered list of chunks. Will pad if needed
-    pub fn construct_with_unpadded(chunks: &[ChunkInfo], batch_header: BatchHeader<N_SNARKS>) -> Self {
+    pub fn construct_with_unpadded(
+        chunks: &[ChunkInfo],
+        batch_header: BatchHeader<N_SNARKS>,
+    ) -> Self {
         assert_ne!(chunks.len(), 0);
         assert!(chunks.len() <= N_SNARKS);
         let mut chunks_with_padding = chunks.to_vec();
@@ -190,7 +193,10 @@ impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
     }
 
     /// Build Batch hash from an ordered list of #N_SNARKS of chunks.
-    pub fn construct(chunks_with_padding: &[ChunkInfo], batch_header: BatchHeader<N_SNARKS>) -> Self {
+    pub fn construct(
+        chunks_with_padding: &[ChunkInfo],
+        batch_header: BatchHeader<N_SNARKS>,
+    ) -> Self {
         assert_eq!(
             chunks_with_padding.len(),
             N_SNARKS,
@@ -266,8 +272,8 @@ impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
         let batch_data_hash = keccak256(preimage);
 
         assert_eq!(
-            batch_header.data_hash, 
-            H256::from_slice(&batch_data_hash), 
+            batch_header.data_hash,
+            H256::from_slice(&batch_data_hash),
             "Expect provided BatchHeader's data_hash field to be correct"
         );
 
@@ -275,21 +281,20 @@ impl<const N_SNARKS: usize> BatchHash<N_SNARKS> {
         let point_evaluation_assignments = PointEvaluationAssignments::from(&batch_data);
 
         assert_eq!(
-            batch_header.blob_data_proof[0], 
-            H256::from_slice(&point_evaluation_assignments.challenge.to_be_bytes()), 
+            batch_header.blob_data_proof[0],
+            H256::from_slice(&point_evaluation_assignments.challenge.to_be_bytes()),
             "Expect provided BatchHeader's blob_data_proof field 0 to be correct"
         );
         assert_eq!(
-            batch_header.blob_data_proof[1], 
-            H256::from_slice(&point_evaluation_assignments.evaluation.to_be_bytes()), 
+            batch_header.blob_data_proof[1],
+            H256::from_slice(&point_evaluation_assignments.evaluation.to_be_bytes()),
             "Expect provided BatchHeader's blob_data_proof field 1 to be correct"
         );
 
         let versioned_hash = batch_data.get_versioned_hash();
 
         assert_eq!(
-            batch_header.blob_versioned_hash, 
-            versioned_hash, 
+            batch_header.blob_versioned_hash, versioned_hash,
             "Expect provided BatchHeader's blob_versioned_hash field to be correct"
         );
 

--- a/prover/src/aggregator/verifier.rs
+++ b/prover/src/aggregator/verifier.rs
@@ -4,9 +4,7 @@ use crate::{
     consts::{batch_vk_filename, DEPLOYMENT_CODE_FILENAME},
     io::{force_to_read, try_to_read},
     proof::BundleProof,
-    BatchProof,
 };
-use snark_verifier_sdk::Snark;
 use aggregator::CompressionCircuit;
 use halo2_proofs::{
     halo2curves::bn256::{Bn256, G1Affine},
@@ -14,6 +12,7 @@ use halo2_proofs::{
     poly::kzg::commitment::ParamsKZG,
 };
 use snark_verifier_sdk::verify_evm_calldata;
+use snark_verifier_sdk::Snark;
 use std::env;
 
 #[derive(Debug)]

--- a/prover/src/proof/batch.rs
+++ b/prover/src/proof/batch.rs
@@ -1,7 +1,7 @@
 use super::{dump_as_json, dump_vk, from_json_file, Proof};
 use crate::types::base64;
-use aggregator::BatchHeader;
 use anyhow::Result;
+use eth_types::H256;
 use halo2_proofs::{halo2curves::bn256::G1Affine, plonk::ProvingKey};
 use serde_derive::{Deserialize, Serialize};
 use snark_verifier::Protocol;
@@ -13,7 +13,7 @@ pub struct BatchProof {
     pub protocol: Vec<u8>,
     #[serde(flatten)]
     proof: Proof,
-    pub batch_header: BatchHeader,
+    pub batch_hash: H256,
 }
 
 impl From<BatchProof> for Snark {
@@ -25,23 +25,19 @@ impl From<BatchProof> for Snark {
             protocol,
             proof: value.proof.proof,
             instances,
-        }        
+        }
     }
 }
 
 impl BatchProof {
-    pub fn new(
-        snark: Snark,
-        pk: Option<&ProvingKey<G1Affine>>,
-        batch_header: BatchHeader,
-    ) -> Result<Self> {
+    pub fn new(snark: Snark, pk: Option<&ProvingKey<G1Affine>>, batch_hash: H256) -> Result<Self> {
         let protocol = serde_json::to_vec(&snark.protocol)?;
         let proof = Proof::new(snark.proof, &snark.instances, pk);
 
         Ok(Self {
             protocol,
             proof,
-            batch_header,
+            batch_hash,
         })
     }
 

--- a/prover/src/proof/bundle.rs
+++ b/prover/src/proof/bundle.rs
@@ -57,7 +57,6 @@ impl From<Proof> for BundleProof {
 }
 
 impl BundleProof {
-
     /// Returns the calldata given to YUL verifier.
     /// Format: Accumulator(12x32bytes) || PI(13x32bytes) || Proof
     pub fn calldata(self) -> Vec<u8> {
@@ -73,8 +72,16 @@ impl BundleProof {
     pub fn dump(&self, dir: &str, name: &str) -> Result<()> {
         let filename = format!("bundle_{name}");
 
-        dump_data(dir, &format!("pi_{filename}.data"), &self.on_chain_proof.instances);
-        dump_data(dir, &format!("proof_{filename}.data"), &self.on_chain_proof.proof);
+        dump_data(
+            dir,
+            &format!("pi_{filename}.data"),
+            &self.on_chain_proof.instances,
+        );
+        dump_data(
+            dir,
+            &format!("proof_{filename}.data"),
+            &self.on_chain_proof.proof,
+        );
 
         dump_vk(dir, &filename, &self.on_chain_proof.vk);
 

--- a/prover/src/types.rs
+++ b/prover/src/types.rs
@@ -1,5 +1,5 @@
-use aggregator::{BatchHeader, ChunkInfo};
-use eth_types::l2_types::BlockTrace;
+use aggregator::ChunkInfo;
+use eth_types::{l2_types::BlockTrace, H256};
 use serde::{Deserialize, Serialize};
 use zkevm_circuits::evm_circuit::witness::Block;
 
@@ -43,7 +43,12 @@ impl ChunkProvingTask {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BatchProvingTask {
-    pub batch_header: BatchHeader,
+    pub version: u8,
+    pub batch_index: u64,
+    pub l1_message_popped: u64,
+    pub total_l1_message_popped: u64,
+    pub parent_batch_hash: H256,
+    pub last_block_timestamp: u64,
     pub chunk_proofs: Vec<ChunkProof>,
 }
 
@@ -67,11 +72,6 @@ pub struct BundleProvingTask {
 
 impl BundleProvingTask {
     pub fn identifier(&self) -> String {
-        self.batch_proofs
-            .last()
-            .unwrap()
-            .batch_header
-            .batch_hash()
-            .to_string()
+        self.batch_proofs.last().unwrap().batch_hash.to_string()
     }
 }


### PR DESCRIPTION
### Description

- Adds standalone constructor for struct `BatchHeader` so correct headers can be created for a chain of batches without processing them sequentially. 
- Removes the mechanism to construct a separate `BatchHeader` export.
- Recovers `DecoderConfig`, a subcomponent of `BatchCircuitConfig`. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
