### PR TITLE
chore: change ethers imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,6 @@ version = "2.0.7"
 source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7#e32dfd62e7cdec31160b91c5a646883594a586ba"
 dependencies = [
  "ethers-core",
- "ethers-solc",
  "reqwest",
  "semver 1.0.22",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_stacker = "0.1"
 sha3 = "0.10"
-snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop" }
+snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features = false }
 snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features = false, features = [
     "loader_halo2",
     "loader_evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
     "mock",
     "testool",
     "aggregator",
-    "prover"
+    "prover",
 ]
 resolver = "2"
 
@@ -27,17 +27,25 @@ ark-std = "0.3"
 base64 = "0.13.0"
 ctor = "0.1"
 env_logger = "0.10"
-ethers = { version = "=2.0.7", features = ["ethers-solc"] }
-ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7", features = ["scroll"] }
-ethers-providers = "=2.0.7"
-ethers-signers = "=2.0.7"
+ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
+ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7", features = [
+    "scroll",
+] }
+ethers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
+ethers-signers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ff = "0.13"
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "v1.1" }
-halo2curves = { version = "0.1.0", features = [ "derive_serde" ] }
+halo2curves = { version = "0.1.0", features = ["derive_serde"] }
 poseidon-base = { package = "poseidon-base", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "main" }
 hash-circuit = { package = "poseidon-circuit", git = "https://github.com/scroll-tech/poseidon-circuit.git", branch = "main" }
-halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", default-features=false, features=["halo2-pse","display"] }
-halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", default-features=false, features=["halo2-pse","display"] }
+halo2-base = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", default-features = false, features = [
+    "halo2-pse",
+    "display",
+] }
+halo2-ecc = { git = "https://github.com/scroll-tech/halo2-lib", branch = "develop", default-features = false, features = [
+    "halo2-pse",
+    "display",
+] }
 hex = "0.4"
 itertools = "0.11"
 libsecp256k1 = "0.7"
@@ -52,19 +60,27 @@ rand_chacha = "0.3"
 rand_xorshift = "0.3"
 rayon = "1.5"
 regex = "1.5"
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_stacker = "0.1"
 sha3 = "0.10"
 snark-verifier = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop" }
-snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features = false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
+snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features = false, features = [
+    "loader_halo2",
+    "loader_evm",
+    "halo2-pse",
+] }
 strum = "0.25"
 strum_macros = "0.25"
 subtle = "2.4"
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 url = "2.2"
-revm-precompile = { git = "https://github.com/scroll-tech/revm", branch = "scroll-evm-executor/v40", default-features = false, features = ["std"] } # v40
-revm-primitives = { git = "https://github.com/scroll-tech/revm", branch = "scroll-evm-executor/v40", default-features = false, features = ["std"] } # v40
+revm-precompile = { git = "https://github.com/scroll-tech/revm", branch = "scroll-evm-executor/v40", default-features = false, features = [
+    "std",
+] } # v40
+revm-primitives = { git = "https://github.com/scroll-tech/revm", branch = "scroll-evm-executor/v40", default-features = false, features = [
+    "std",
+] } # v40
 c-kzg = "1.0.2"
 
 [patch.crates-io]
@@ -72,7 +88,7 @@ ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "
 ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers-etherscan = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
+ethers-signers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 gobuild = { git = "https://github.com/scroll-tech/gobuild.git" }
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves", branch = "v0.1.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,7 @@ base64 = "0.13.0"
 ctor = "0.1"
 env_logger = "0.10"
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7", features = [
-    "scroll",
-] }
+ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers-signers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ff = "0.13"


### PR DESCRIPTION
Change the `ethers` imports directly in Cargo.toml instead of patching. Otherwise a package that imports this one cannot use a different version of `ethers` and it leads to nasty dependency issues.