### PR TITLE
refactor SameContextGadget:assign_exec_step to include block, call

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
@@ -76,10 +76,11 @@ impl<F: Field> ExecutionGadget<F> for AddSubGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let opcode = step.opcode.unwrap();
         let indices = if opcode == OpcodeId::SUB {

--- a/zkevm-circuits/src/evm_circuit/execution/addmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/addmod.rs
@@ -145,10 +145,11 @@ impl<F: Field> ExecutionGadget<F> for AddModGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         // get stack values
         let [mut r, n, b, a] = [3, 2, 1, 0]

--- a/zkevm-circuits/src/evm_circuit/execution/address.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/address.rs
@@ -68,7 +68,8 @@ impl<F: Field> ExecutionGadget<F> for AddressGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let address = block.rws[step.rw_indices[1]].stack_value();
         debug_assert_eq!(call.callee_address, address.to_address());

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -107,7 +107,8 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let address = block.rws[step.rw_indices[0]].stack_value();
         self.address_word

--- a/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
@@ -83,10 +83,11 @@ impl<F: Field> ExecutionGadget<F> for BitwiseGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [a, b, c] = [step.rw_indices[0], step.rw_indices[1], step.rw_indices[2]]
             .map(|idx| block.rws[idx].stack_value());

--- a/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
@@ -83,12 +83,12 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxU64Gadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         self.value_u64
             .same_context
-            .assign_exec_step(region, offset, step)?;
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let value = block.rws[step.rw_indices[0]].stack_value();
 
@@ -124,12 +124,12 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxU160Gadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         self.value_u160
             .same_context
-            .assign_exec_step(region, offset, step)?;
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let value = block.rws[step.rw_indices[0]].stack_value();
 
@@ -169,14 +169,14 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxU256Gadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         log::debug!("BlockCtxU256Gadget assign for {:?}", step.opcode);
 
         self.value_u256
             .same_context
-            .assign_exec_step(region, offset, step)?;
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let value = block.rws[step.rw_indices[0]].stack_value();
 
@@ -221,12 +221,13 @@ impl<F: Field> ExecutionGadget<F> for DifficultyGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        _block: &Block,
+        block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
@@ -142,10 +142,11 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
         offset: usize,
         block: &Block,
         tx: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let chain_id = block.chain_id;
         let current_block_number = block.context.ctxs[&tx.block_number].number;

--- a/zkevm-circuits/src/evm_circuit/execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/byte.rs
@@ -95,10 +95,11 @@ impl<F: Field> ExecutionGadget<F> for ByteGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         // Inputs/Outputs
         let index = block.rws[step.rw_indices[0]].stack_value().to_le_bytes();

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -178,7 +178,8 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [memory_offset, data_offset, length] =
             [step.rw_indices[0], step.rw_indices[1], step.rw_indices[2]]

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -268,7 +268,8 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         // Assign to the buffer reader gadget.
         let (src_id, call_data_offset, call_data_length) = if call.is_root {

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -65,10 +65,11 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
         offset: usize,
         block: &Block,
         _tx: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let call_data_size = block.rws[step.rw_indices[1]].stack_value();
 

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -66,10 +66,11 @@ impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let caller = block.rws[step.rw_indices[1]].stack_value();
 

--- a/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
@@ -65,10 +65,11 @@ impl<F: Field> ExecutionGadget<F> for CallValueGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let call_value = block.rws[step.rw_indices[1]].stack_value();
 

--- a/zkevm-circuits/src/evm_circuit/execution/chainid.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/chainid.rs
@@ -62,10 +62,11 @@ impl<F: Field> ExecutionGadget<F> for ChainIdGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let chain_id = block.rws[step.rw_indices[0]].stack_value().as_u64();
         self.chain_id

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -148,7 +148,8 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         // 1. `dest_offset` is the bytes offset in the memory where we start to
         // write.

--- a/zkevm-circuits/src/evm_circuit/execution/codesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codesize.rs
@@ -71,10 +71,11 @@ impl<F: Field> ExecutionGadget<F> for CodesizeGadget<F> {
         offset: usize,
         block: &Block,
         _transaction: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let codesize = block.rws[step.rw_indices[0]].stack_value().as_u64();
 

--- a/zkevm-circuits/src/evm_circuit/execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/comparator.rs
@@ -110,10 +110,11 @@ impl<F: Field> ExecutionGadget<F> for ComparatorGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let opcode = step.opcode.unwrap();
 

--- a/zkevm-circuits/src/evm_circuit/execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/dup.rs
@@ -60,10 +60,11 @@ impl<F: Field> ExecutionGadget<F> for DupGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let value = block.rws[step.rw_indices[0]].stack_value();
         self.value.assign(region, offset, region.word_rlc(value))?;

--- a/zkevm-circuits/src/evm_circuit/execution/exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/exp.rs
@@ -187,10 +187,11 @@ impl<F: Field> ExecutionGadget<F> for ExponentiationGadget<F> {
         offset: usize,
         block: &Block,
         _tx: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [base, exponent, exponentiation] =
             [step.rw_indices[0], step.rw_indices[1], step.rw_indices[2]]

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -175,7 +175,8 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [external_address, memory_offset, code_offset, memory_length] =
             [0, 1, 2, 3].map(|idx| block.rws[step.rw_indices[idx]].stack_value());

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -99,7 +99,8 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let address = block.rws[step.rw_indices[0]].stack_value();
         self.address_word

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -120,7 +120,8 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let address = block.rws[step.rw_indices[0]].stack_value();
         self.address_word

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -64,12 +64,13 @@ impl<F: Field> ExecutionGadget<F> for GasGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        _block: &Block,
+        block: &Block,
         _transaction: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         // The GAS opcode takes into account the reduction of gas available due
         // to the instruction itself.

--- a/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
@@ -68,7 +68,7 @@ impl<F: Field> ExecutionGadget<F> for GasPriceGadget<F> {
         offset: usize,
         block: &Block,
         tx: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         let gas_price = block.rws[step.rw_indices[1]].stack_value();
@@ -79,7 +79,8 @@ impl<F: Field> ExecutionGadget<F> for GasPriceGadget<F> {
         self.gas_price
             .assign(region, offset, region.word_rlc(gas_price))?;
 
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
@@ -58,10 +58,11 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let value = block.rws[step.rw_indices[0]].stack_value();
         let value = region.word_rlc(value);

--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -65,10 +65,11 @@ impl<F: Field> ExecutionGadget<F> for JumpGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let destination = block.rws[step.rw_indices[0]].stack_value();
         self.destination.assign(

--- a/zkevm-circuits/src/evm_circuit/execution/jumpdest.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpdest.rs
@@ -41,12 +41,13 @@ impl<F: Field> ExecutionGadget<F> for JumpdestGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        _: &Block,
+        block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -88,10 +88,11 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [destination, condition] =
             [step.rw_indices[0], step.rw_indices[1]].map(|idx| block.rws[idx].stack_value());

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -212,7 +212,8 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [memory_start, msize] =
             [step.rw_indices[0], step.rw_indices[1]].map(|idx| block.rws[idx].stack_value());

--- a/zkevm-circuits/src/evm_circuit/execution/mcopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mcopy.rs
@@ -143,10 +143,11 @@ impl<F: Field> ExecutionGadget<F> for MCopyGadget<F> {
         offset: usize,
         block: &Block,
         _transaction: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [dest_offset, src_offset, length] =
             [0, 1, 2].map(|idx| block.rws[step.rw_indices[idx]].stack_value());

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -165,10 +165,11 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
         offset: usize,
         block: &Block,
         _tx: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let opcode = step.opcode.unwrap();
 

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -63,12 +63,13 @@ impl<F: Field> ExecutionGadget<F> for MsizeGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        _: &Block,
+        block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
         self.value
             .assign(region, offset, Some((step.memory_size).to_le_bytes()))?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
@@ -117,10 +117,11 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
         let indices = [step.rw_indices[0], step.rw_indices[1], step.rw_indices[2]];
         let [pop1, pop2, push] = indices.map(|idx| block.rws[idx].stack_value());
         let (a, b, c, d) = match step.opcode.unwrap() {

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -111,10 +111,11 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [r, n, b, a] = [3, 2, 1, 0]
             .map(|idx| step.rw_indices[idx])

--- a/zkevm-circuits/src/evm_circuit/execution/not.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/not.rs
@@ -72,10 +72,11 @@ impl<F: Field> ExecutionGadget<F> for NotGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [input, output] =
             [step.rw_indices[0], step.rw_indices[1]].map(|idx| block.rws[idx].stack_value());

--- a/zkevm-circuits/src/evm_circuit/execution/origin.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/origin.rs
@@ -69,7 +69,7 @@ impl<F: Field> ExecutionGadget<F> for OriginGadget<F> {
         offset: usize,
         block: &Block,
         tx: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         let origin = block.rws[step.rw_indices[1]].stack_value();
@@ -90,7 +90,8 @@ impl<F: Field> ExecutionGadget<F> for OriginGadget<F> {
         )?;
 
         // Assign SameContextGadget witnesses.
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pc.rs
@@ -63,12 +63,13 @@ impl<F: Field> ExecutionGadget<F> for PcGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        _: &Block,
+        block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         self.value
             .assign(region, offset, Some(step.program_counter.to_le_bytes()))?;

--- a/zkevm-circuits/src/evm_circuit/execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pop.rs
@@ -54,10 +54,11 @@ impl<F: Field> ExecutionGadget<F> for PopGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let value = block.rws[step.rw_indices[0]].stack_value();
         self.phase2_value

--- a/zkevm-circuits/src/evm_circuit/execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push.rs
@@ -63,10 +63,11 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let opcode = step.opcode.unwrap();
         self.is_push0.assign(

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -170,10 +170,11 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
         offset: usize,
         block: &Block,
         _tx: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [dest_offset, data_offset, size] =
             [0, 1, 2].map(|i| block.rws[step.rw_indices[i as usize]].stack_value());

--- a/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
@@ -65,10 +65,11 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataSizeGadget<F> {
         offset: usize,
         block: &Block,
         _tx: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
         let return_data_size = block.rws[step.rw_indices[1]].stack_value();
         self.return_data_size.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/sar.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sar.rs
@@ -262,10 +262,11 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
         let indices = [step.rw_indices[0], step.rw_indices[1], step.rw_indices[2]];
         let [shift, a, b] = indices.map(|idx| block.rws[idx].stack_value());
 

--- a/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
@@ -146,10 +146,11 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
         let indices = [step.rw_indices[0], step.rw_indices[1], step.rw_indices[2]];
         let [pop1, pop2, push] = indices.map(|idx| block.rws[idx].stack_value());
         let pop1_abs = get_abs(pop1);

--- a/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
@@ -66,7 +66,8 @@ impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         self.callee_address.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -113,12 +113,13 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
         offset: usize,
         block: &Block,
         _tx: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         let mut rws = StepRws::new(block, step);
 
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let [memory_offset, size, sha3_output] = [(); 3].map(|_| rws.next().stack_value());
         let memory_address = self

--- a/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
@@ -159,10 +159,11 @@ impl<F: Field> ExecutionGadget<F> for ShlShrGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
         let indices = [step.rw_indices[0], step.rw_indices[1], step.rw_indices[2]];
         let [pop1, pop2, push] = indices.map(|idx| block.rws[idx].stack_value());
         let shf0 = u64::from(pop1.to_le_bytes()[0]);

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -148,10 +148,11 @@ impl<F: Field> ExecutionGadget<F> for SignedComparatorGadget<F> {
         offset: usize,
         block: &Block,
         _transaction: &Transaction,
-        _call: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         let opcode = step.opcode.unwrap();
 

--- a/zkevm-circuits/src/evm_circuit/execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signextend.rs
@@ -160,10 +160,11 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         // Inputs/Outputs
         let index = block.rws[step.rw_indices[0]].stack_value().to_le_bytes();

--- a/zkevm-circuits/src/evm_circuit/execution/sload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sload.rs
@@ -104,7 +104,8 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -172,7 +172,8 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/swap.rs
@@ -64,10 +64,11 @@ impl<F: Field> ExecutionGadget<F> for SwapGadget<F> {
         offset: usize,
         block: &Block,
         _: &Transaction,
-        _: &Call,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         for (cell, value) in self.phase2_values.iter().zip(
             [step.rw_indices[0], step.rw_indices[1]]

--- a/zkevm-circuits/src/evm_circuit/execution/tload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/tload.rs
@@ -78,7 +78,8 @@ impl<F: Field> ExecutionGadget<F> for TloadGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         self.tx_id.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/tstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/tstore.rs
@@ -98,7 +98,8 @@ impl<F: Field> ExecutionGadget<F> for TstoreGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        self.same_context.assign_exec_step(region, offset, step)?;
+        self.same_context
+            .assign_exec_step(region, offset, block, call, step)?;
 
         self.tx_id.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -97,8 +97,8 @@ impl<F: Field> SameContextGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        block: &Block,
-        call: &Call,
+        _block: &Block,
+        _call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         let opcode = step.opcode.unwrap();

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -97,6 +97,8 @@ impl<F: Field> SameContextGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
+        block: &Block,
+        call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         let opcode = step.opcode.unwrap();


### PR DESCRIPTION
### Description

this PR is part of #1368 ,  first refactor SameContextGadget:assign_exec_step to include block, call. then done more complex changes base on it in PR 1368.

