### PR TITLE
[Feat] Optimize zktrieState with flatten proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5559,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "zktrie"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#13792d9d2dfbc8f40f9ee9dec8ce254abefdb6e4"
+source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#966b79453043e3a05a67701dd0db86a1431fa356"
 dependencies = [
  "gobuild",
  "zktrie_rust",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "zktrie_rust"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#13792d9d2dfbc8f40f9ee9dec8ce254abefdb6e4"
+source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#966b79453043e3a05a67701dd0db86a1431fa356"
 dependencies = [
  "hex",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5559,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "zktrie"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#966b79453043e3a05a67701dd0db86a1431fa356"
+source = "git+https://github.com/scroll-tech/zktrie.git?branch=main#49e0f027d12abf7f2049c2cf1034128fc14f47dd"
 dependencies = [
  "gobuild",
  "zktrie_rust",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "zktrie_rust"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#966b79453043e3a05a67701dd0db86a1431fa356"
+source = "git+https://github.com/scroll-tech/zktrie.git?branch=main#49e0f027d12abf7f2049c2cf1034128fc14f47dd"
 dependencies = [
  "hex",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5559,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "zktrie"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=main#2a19ee2155ecb959ba518384e448a638ae9858f2"
+source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#13792d9d2dfbc8f40f9ee9dec8ce254abefdb6e4"
 dependencies = [
  "gobuild",
  "zktrie_rust",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "zktrie_rust"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=main#2a19ee2155ecb959ba518384e448a638ae9858f2"
+source = "git+https://github.com/scroll-tech/zktrie.git?branch=feat/node_key_importing#13792d9d2dfbc8f40f9ee9dec8ce254abefdb6e4"
 dependencies = [
  "hex",
  "lazy_static",

--- a/bus-mapping/src/circuit_input_builder/l2.rs
+++ b/bus-mapping/src/circuit_input_builder/l2.rs
@@ -184,6 +184,7 @@ impl CircuitInputBuilder {
                     log::trace!("sdb trace[query mode] {:?} {:?}", addr, acc);
                     sdb.set_account(&addr, state_db::Account::from(&acc));
                 } else {
+                    log::trace!("sdb trace[query mode] {:?} for zero account", addr);
                     sdb.set_account(&addr, state_db::Account::zero());
                 }
             }
@@ -301,9 +302,7 @@ impl CircuitInputBuilder {
             zk_state
                 .query_accounts(filtered_accounts.map(|(addr, _)| addr))
                 .fold(HashMap::new(), |mut m, (addr, acc)| {
-                    if let Some(acc) = acc {
-                        m.insert(addr, acc);
-                    }
+                    m.insert(addr, acc.unwrap_or_default());
                     m
                 })
         } else {
@@ -334,6 +333,8 @@ impl CircuitInputBuilder {
                 .fold(HashMap::new(), |mut m, ((addr, key), val)| {
                     if let Some(val) = val {
                         m.insert((addr, key.to_word()), val.into());
+                    } else {
+                        m.insert((addr, key.to_word()), Default::default());
                     }
                     m
                 })

--- a/bus-mapping/src/circuit_input_builder/l2.rs
+++ b/bus-mapping/src/circuit_input_builder/l2.rs
@@ -146,6 +146,11 @@ impl CircuitInputBuilder {
                     .map(|(k, v)| (k.as_bytes(), v.as_bytes())),
             );
 
+            log::debug!(
+                "building partial ZktrieState done from new trace, root {}",
+                hex::encode(state.root())
+            );
+
             Some(state)
         } else if !light_mode {
             let mpt_init_state = ZktrieState::from_trace_with_additional(
@@ -179,7 +184,7 @@ impl CircuitInputBuilder {
                     log::trace!("sdb trace[query mode] {:?} {:?}", addr, acc);
                     sdb.set_account(&addr, state_db::Account::from(&acc));
                 } else {
-                    log::warn!("can not query account with addr {:?}", addr);
+                    sdb.set_account(&addr, state_db::Account::zero());
                 }
             }
 

--- a/eth-types/src/l2_types.rs
+++ b/eth-types/src/l2_types.rs
@@ -451,6 +451,9 @@ pub struct StorageTrace {
     #[serde(rename = "deletionProofs", default)]
     /// additional deletion proofs
     pub deletion_proofs: Vec<Bytes>,
+    #[serde(rename = "flattenProofs", default)]
+    ///
+    pub flatten_proofs: HashMap<H256, Bytes>,
 }
 
 /// extension of `GethExecTrace`, with compatible serialize form

--- a/eth-types/src/l2_types.rs
+++ b/eth-types/src/l2_types.rs
@@ -454,6 +454,12 @@ pub struct StorageTrace {
     #[serde(rename = "flattenProofs", default)]
     ///
     pub flatten_proofs: HashMap<H256, Bytes>,
+    #[serde(rename = "addressHashes", default)]
+    ///
+    pub address_hashes: HashMap<Address, Hash>,
+    #[serde(rename = "storeKeyHashes", default)]
+    ///
+    pub store_key_hashes: HashMap<H256, Hash>,
 }
 
 /// extension of `GethExecTrace`, with compatible serialize form

--- a/integration-tests/tests/l2_trace.rs
+++ b/integration-tests/tests/l2_trace.rs
@@ -1,0 +1,51 @@
+#![feature(lazy_cell)]
+#![cfg(feature = "scroll")]
+
+use bus_mapping::{
+    circuit_input_builder::{CircuitInputBuilder, CircuitsParams},
+    util::read_env_var,
+};
+use eth_types::l2_types::BlockTrace;
+use integration_tests::log_init;
+use std::fs::File;
+use zkevm_circuits::witness;
+
+fn test_circuit_input_builder_l2block(block_trace: BlockTrace) {
+    let params = CircuitsParams {
+        max_rws: 4_000_000,
+        max_copy_rows: 0, // dynamic
+        max_txs: read_env_var("MAX_TXS", 128),
+        max_calldata: 2_000_000,
+        max_inner_blocks: 64,
+        max_bytecode: 3_000_000,
+        max_mpt_rows: 2_000_000,
+        max_poseidon_rows: 4_000_000,
+        max_keccak_rows: 0,
+        max_exp_steps: 100_000,
+        max_evm_rows: 0,
+        max_rlp_rows: 2_070_000,
+        ..Default::default()
+    };
+
+    let mut builder = CircuitInputBuilder::new_from_l2_trace(params, block_trace, false)
+        .expect("could not handle block tx");
+
+    builder
+        .finalize_building()
+        .expect("could not finalize building block");
+
+    log::trace!("CircuitInputBuilder: {:#?}", builder);
+
+    let mut block = witness::block_convert(&builder.block, &builder.code_db).unwrap();
+    block.apply_mpt_updates(&builder.mpt_init_state.unwrap());
+}
+
+#[test]
+fn local_l2_trace() {
+    log_init();
+    let file_path = read_env_var("TRACE_FILE", "dump.json".to_string());
+    let fd = File::open(file_path).unwrap();
+    let trace: BlockTrace = serde_json::from_reader(fd).unwrap();
+
+    test_circuit_input_builder_l2block(trace);
+}

--- a/prover/src/zkevm/circuit/builder.rs
+++ b/prover/src/zkevm/circuit/builder.rs
@@ -167,7 +167,7 @@ pub fn finalize_builder(builder: &mut CircuitInputBuilder) -> Result<Block> {
     if let Some(state) = &mut builder.mpt_init_state {
         if *state.root() != [0u8; 32] {
             log::debug!("apply_mpt_updates");
-            witness_block.apply_mpt_updates(state);
+            witness_block.apply_mpt_updates_and_update_mpt_state(state);
             log::debug!("apply_mpt_updates done");
         } else {
             // Empty state root means circuit capacity checking, or dummy witness block for key gen?

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -120,6 +120,17 @@ impl Block {
     pub fn apply_mpt_updates(&mut self, mpt_state: &MptState) {
         self.mpt_updates.fill_state_roots(mpt_state);
     }
+
+    /// Replay mpt updates to generate mpt witness, also update the mpt state with
+    /// calculated mpt updatings
+    pub fn apply_mpt_updates_and_update_mpt_state(&mut self, mpt_state: &mut MptState) {
+        let updated_tries = self
+            .mpt_updates
+            .fill_state_roots(mpt_state)
+            .into_updated_trie();
+        mpt_state.updated_with_trie(updated_tries);
+    }
+
     /// For each tx, for each step, print the rwc at the beginning of the step,
     /// and all the rw operations of the step.
     pub(crate) fn debug_print_txs_steps_rw_ops(&self) {

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -173,7 +173,7 @@ impl MptUpdates {
         self.pretty_print();
     }
 
-    pub(crate) fn fill_state_roots(&mut self, init_trie: &ZktrieState) {
+    pub(crate) fn fill_state_roots(&mut self, init_trie: &ZktrieState) -> WitnessGenerator {
         let root_pair = (self.old_root, self.new_root);
         self.old_root = init_trie.root().into();
         log::trace!("fill_state_roots init {:?}", self.old_root);
@@ -223,6 +223,7 @@ impl MptUpdates {
         }
         log::debug!("fill_state_roots done");
         self.pretty_print();
+        wit_gen
     }
 
     fn fill_state_roots_from_generator(

--- a/zkevm-circuits/src/witness/mpt/witness.rs
+++ b/zkevm-circuits/src/witness/mpt/witness.rs
@@ -9,9 +9,9 @@ use mpt_circuits::{
 };
 use mpt_zktrie::{
     extend_address_to_h256, state::StorageData, AccountData, BytesArray, CanRead, TrieProof,
-    ZkTrie, ZkTrieNode, ZktrieState, SECURE_HASH_DOMAIN,
+    ZkMemoryDb, ZkTrie, ZkTrieNode, ZktrieState, SECURE_HASH_DOMAIN,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, rc::Rc};
 
 use num_bigint::BigUint;
 use std::{
@@ -40,13 +40,15 @@ fn to_smt_account(acc: AccountData) -> SMTAccount {
 pub struct WitnessGenerator {
     trie: ZkTrie,
     storages_cache: HashMap<Address, ZkTrie>,
+    ref_db: Rc<ZkMemoryDb>,
 }
 
 impl From<&ZktrieState> for WitnessGenerator {
     fn from(state: &ZktrieState) -> Self {
         Self {
-            trie: state.zk_db.borrow_mut().new_trie(&state.trie_root).unwrap(),
+            trie: state.zk_db.new_trie(&state.trie_root).unwrap(),
             storages_cache: HashMap::new(),
+            ref_db: state.zk_db.clone(),
         }
     }
 }
@@ -74,17 +76,18 @@ impl WitnessGenerator {
             HexBytes(word_buf)
         };
 
-        self.storages_cache
-            .get(&address)
-            .map(Clone::clone)
-            .or_else(|| {
-                self.trie
-                    .get_account(address.as_bytes())
-                    .map(AccountData::from)
-                    .and_then(|account| self.trie.get_db().new_trie(&account.storage_root.0))
-            })
-            .and_then(|trie| trie.prove(key.as_ref()).ok())
-            .unwrap_or_default()
+        if let Some(trie) = self.storages_cache.get(&address) {
+            // trie is under updating
+            trie.prove(key.as_ref()).ok()
+        } else {
+            // create a temporary trie and prove it
+            self.trie
+                .get_account(address.as_bytes())
+                .map(AccountData::from)
+                .and_then(|account| self.ref_db.new_trie(&account.storage_root.0))
+                .and_then(|trie| trie.prove(key.as_ref()).ok())
+        }
+        .unwrap_or_default()
     }
     fn fetch_storage_cache(&mut self, address: Address) -> Option<&mut ZkTrie> {
         let cache_entry = self.storages_cache.entry(address);
@@ -95,8 +98,7 @@ impl WitnessGenerator {
                     .map(AccountData::from)
                     .and_then(|acc_data| {
                         // all trie share the same underlay db, so we can create new trie here
-                        let zk_db = self.trie.get_db();
-                        zk_db.new_trie(&acc_data.storage_root.0)
+                        self.ref_db.new_trie(&acc_data.storage_root.0)
                     })
                     .map(|trie| entry.insert(trie))
             }

--- a/zkevm-circuits/src/witness/mpt/witness.rs
+++ b/zkevm-circuits/src/witness/mpt/witness.rs
@@ -54,6 +54,11 @@ impl From<&ZktrieState> for WitnessGenerator {
 }
 
 impl WitnessGenerator {
+    /// output all updated ZkTrie
+    pub fn into_updated_trie(self) -> impl Iterator<Item = ZkTrie> {
+        std::iter::once(self.trie).chain(self.storages_cache.into_values())
+    }
+
     /// dump inner data for debugging
     pub fn dump<'a>(&self, addrs: impl Iterator<Item = &'a Address>) {
         for addr in addrs {

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 halo2curves.workspace = true
-zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "main", features= ["rs_zktrie"] }
+zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "feat/node_key_importing", features= ["rs_zktrie"] }
 poseidon-base.workspace = true
 eth-types = { path = "../eth-types" }
 num-bigint.workspace = true

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 halo2curves.workspace = true
-zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "feat/node_key_importing", features= ["rs_zktrie"] }
+zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "main", features= ["rs_zktrie"] }
 poseidon-base.workspace = true
 eth-types = { path = "../eth-types" }
 num-bigint.workspace = true

--- a/zktrie/src/lib.rs
+++ b/zktrie/src/lib.rs
@@ -5,9 +5,8 @@
 
 /// the state modules include structures represent zktrie and helpers
 pub mod state;
-pub use crate::state::ZktrieState;
 pub use state::builder::{
     self, extend_address_to_h256, AccountData, AccountProof, BytesArray, CanRead, StorageProof,
     TrieProof, SECURE_HASH_DOMAIN,
 };
-pub use zktrie::{ZkTrie, ZkTrieNode};
+pub use state::{ZkMemoryDb, ZkTrie, ZkTrieNode, ZktrieState};

--- a/zktrie/src/state.rs
+++ b/zktrie/src/state.rs
@@ -184,7 +184,7 @@ impl ZktrieState {
             .chain(additional_proofs);
         let mut zk_db = self.zk_db.borrow_mut();
         for bytes in proofs {
-            zk_db.add_node_bytes(bytes).unwrap();
+            zk_db.add_node_data(bytes).unwrap();
         }
     }
 

--- a/zktrie/src/state.rs
+++ b/zktrie/src/state.rs
@@ -2,18 +2,21 @@
 use eth_types::{Address, Hash, H256};
 
 use std::{collections::HashSet, io::Error};
-pub use zktrie::{Hash as ZkTrieHash, ZkMemoryDb, ZkTrie, ZkTrieNode};
+pub use zktrie::{Hash as ZkTrieHash, ZkMemoryDb, ZkTrieNode};
+use zktrie::{UpdateDb, ZkTrie as ZktrieT};
+/// export updatable type of zktrie
+pub type ZkTrie = ZktrieT<UpdateDb>;
 
 pub mod builder;
 pub use builder::{AccountData, StorageData};
 
-use std::{cell::RefCell, fmt, rc::Rc};
+use std::{fmt, rc::Rc};
 
 /// represent a storage state being applied in specified block
 #[derive(Clone)]
 pub struct ZktrieState {
     /// The underlying db
-    pub zk_db: RefCell<Rc<ZkMemoryDb>>,
+    pub zk_db: Rc<ZkMemoryDb>,
     /// Trie root
     pub trie_root: ZkTrieHash,
     addr_cache: HashSet<Address>,
@@ -49,11 +52,16 @@ impl ZktrieState {
         builder::init_hash_scheme();
 
         Self {
-            zk_db: RefCell::new(ZkMemoryDb::new()),
+            zk_db: Rc::new(ZkMemoryDb::new()),
             trie_root: state_root.0,
             addr_cache: HashSet::new(),
             storage_cache: HashSet::new(),
         }
+    }
+
+    /// expose writable db, has to be used when no trie is created
+    pub fn expose_db(&mut self) -> &mut ZkMemoryDb {
+        Rc::get_mut(&mut self.zk_db).expect("no extra reference")
     }
 
     /// prepare to switch to another root state (trie snapshot)
@@ -72,7 +80,7 @@ impl ZktrieState {
     /// new snapshot since we consider it is not need to send more nodes data
     /// from storage trace for the updated leaves
     pub fn switch_to(&mut self, new_root: ZkTrieHash) -> bool {
-        let test_trie = self.zk_db.borrow_mut().new_trie(&new_root);
+        let test_trie = self.zk_db.new_trie(&new_root);
         if test_trie.is_none() {
             return false;
         }
@@ -85,7 +93,7 @@ impl ZktrieState {
         &self,
         accounts: impl Iterator<Item = &'a Address> + 'd,
     ) -> impl Iterator<Item = (Address, Option<AccountData>)> + 'a {
-        let trie = self.zk_db.borrow_mut().new_trie(&self.trie_root).unwrap();
+        let trie = self.zk_db.new_ref_trie(&self.trie_root).unwrap();
         accounts.map(move |&addr| {
             let account = trie.get_account(addr.as_bytes()).map(AccountData::from);
             (addr, account)
@@ -98,9 +106,9 @@ impl ZktrieState {
         storages: impl Iterator<Item = (&'a Address, &'a H256)> + 'd,
     ) -> impl Iterator<Item = ((Address, H256), Option<StorageData>)> + 'a {
         use std::collections::{hash_map::Entry::*, HashMap};
-        let zk_db = self.zk_db.borrow().clone();
-        let account_trie = zk_db.new_trie(&self.trie_root).unwrap();
-        let mut trie_cache: HashMap<Address, ZkTrie> = HashMap::new();
+        let zk_db = self.zk_db.clone();
+        let account_trie = zk_db.new_ref_trie(&self.trie_root).unwrap();
+        let mut trie_cache = HashMap::new();
         storages.map(move |(&addr, &key)| {
             let store_val = match trie_cache.entry(addr) {
                 Occupied(entry) => Some(entry.into_mut()),
@@ -109,7 +117,7 @@ impl ZktrieState {
                     .map(AccountData::from)
                     .and_then(|account| {
                         zk_db
-                            .new_trie(&account.storage_root.0)
+                            .new_ref_trie(&account.storage_root.0)
                             .map(|tr| entry.insert(tr))
                     }),
             }
@@ -182,7 +190,7 @@ impl ZktrieState {
                     .flat_map(|(_, _, bytes)| bytes),
             )
             .chain(additional_proofs);
-        let mut zk_db = self.zk_db.borrow_mut();
+        let zk_db = Rc::get_mut(&mut self.zk_db).expect("no extra reference");
         for bytes in proofs {
             zk_db.add_node_data(bytes).unwrap();
         }
@@ -210,6 +218,6 @@ impl ZktrieState {
 
     /// get the inner zk memory db
     pub fn into_inner(self) -> Rc<ZkMemoryDb> {
-        self.zk_db.into_inner()
+        self.zk_db
     }
 }


### PR DESCRIPTION
This PR make use of the new "flatten proof" in `l2trace` to optimize the construction of zktrie state.

With flatten proof and key hashes, no poseidon calculation would be required in constructing the initial zktrie state.

~~DO NOT MERGE unti following tasks are completed~~

- [x] The dependency of `zktrie` has been merged tagged
- [x] Test against with enough blocks of mainnet
- [x] Test against with enough chunks of mainnet
- [x] Regression tests for compatible with old `l2trace`
~~usage of `txStorageTrace` has been proven to be correct~~