### PR TITLE
(v0.12.2) Move params out of prover/verifier

### DIFF
--- a/prover/src/aggregator/prover.rs
+++ b/prover/src/aggregator/prover.rs
@@ -1,14 +1,15 @@
-use std::{env, iter::repeat};
+use std::{collections::BTreeMap, env, iter::repeat};
 
 use aggregator::{BatchHash, BatchHeader, ChunkInfo, MAX_AGG_SNARKS};
 use anyhow::{bail, Result};
 use eth_types::H256;
+use halo2_proofs::{halo2curves::bn256::Bn256, poly::kzg::commitment::ParamsKZG};
 use sha2::{Digest, Sha256};
 use snark_verifier_sdk::Snark;
 
 use crate::{
     common,
-    config::{LayerId, AGG_DEGREES},
+    config::LayerId,
     consts::{BATCH_KECCAK_ROW, BATCH_VK_FILENAME, BUNDLE_VK_FILENAME, CHUNK_PROTOCOL_FILENAME},
     io::{force_to_read, try_to_read},
     proof::BundleProof,
@@ -17,20 +18,23 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct Prover {
+pub struct Prover<'params> {
     // Make it public for testing with inner functions (unnecessary for FFI).
-    pub prover_impl: common::Prover,
+    pub prover_impl: common::Prover<'params>,
     pub chunk_protocol: Vec<u8>,
     raw_vk_batch: Option<Vec<u8>>,
     raw_vk_bundle: Option<Vec<u8>>,
 }
 
-impl Prover {
-    pub fn from_dirs(params_dir: &str, assets_dir: &str) -> Self {
+impl<'params> Prover<'params> {
+    pub fn from_dirs(
+        params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
+        assets_dir: &str,
+    ) -> Self {
         log::debug!("set env KECCAK_ROWS={}", BATCH_KECCAK_ROW.to_string());
         env::set_var("KECCAK_ROWS", BATCH_KECCAK_ROW.to_string());
 
-        let prover_impl = common::Prover::from_params_dir(params_dir, &AGG_DEGREES);
+        let prover_impl = common::Prover::from_params(params_map);
         let chunk_protocol = force_to_read(assets_dir, &CHUNK_PROTOCOL_FILENAME);
 
         let raw_vk_batch = try_to_read(assets_dir, &BATCH_VK_FILENAME);

--- a/prover/src/aggregator/prover.rs
+++ b/prover/src/aggregator/prover.rs
@@ -9,7 +9,7 @@ use snark_verifier_sdk::Snark;
 
 use crate::{
     common,
-    config::{LayerId, AGG_DEGREES},
+    config::LayerId,
     consts::{BATCH_KECCAK_ROW, BATCH_VK_FILENAME, BUNDLE_VK_FILENAME, CHUNK_PROTOCOL_FILENAME},
     io::{force_to_read, try_to_read},
     proof::BundleProof,
@@ -27,9 +27,6 @@ pub struct Prover<'params> {
 }
 
 impl<'params> Prover<'params> {
-    pub fn degrees() -> Vec<u32> {
-        (*AGG_DEGREES).clone()
-    }
     pub fn from_params_and_assets(
         params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
         assets_dir: &str,

--- a/prover/src/aggregator/prover.rs
+++ b/prover/src/aggregator/prover.rs
@@ -9,7 +9,7 @@ use snark_verifier_sdk::Snark;
 
 use crate::{
     common,
-    config::LayerId,
+    config::{LayerId, AGG_DEGREES},
     consts::{BATCH_KECCAK_ROW, BATCH_VK_FILENAME, BUNDLE_VK_FILENAME, CHUNK_PROTOCOL_FILENAME},
     io::{force_to_read, try_to_read},
     proof::BundleProof,
@@ -27,14 +27,17 @@ pub struct Prover<'params> {
 }
 
 impl<'params> Prover<'params> {
-    pub fn from_dirs(
+    pub fn degrees() -> Vec<u32> {
+        (*AGG_DEGREES).clone()
+    }
+    pub fn from_params_and_assets(
         params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
         assets_dir: &str,
     ) -> Self {
         log::debug!("set env KECCAK_ROWS={}", BATCH_KECCAK_ROW.to_string());
         env::set_var("KECCAK_ROWS", BATCH_KECCAK_ROW.to_string());
 
-        let prover_impl = common::Prover::from_params(params_map);
+        let prover_impl = common::Prover::from_params_map(params_map);
         let chunk_protocol = force_to_read(assets_dir, &CHUNK_PROTOCOL_FILENAME);
 
         let raw_vk_batch = try_to_read(assets_dir, &BATCH_VK_FILENAME);

--- a/prover/src/aggregator/verifier.rs
+++ b/prover/src/aggregator/verifier.rs
@@ -36,7 +36,7 @@ impl<'params> Verifier<'params> {
         }
     }
 
-    pub fn from_params_map(
+    pub fn from_params_and_assets(
         params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
         assets_dir: &str,
     ) -> Self {

--- a/prover/src/common/prover.rs
+++ b/prover/src/common/prover.rs
@@ -18,13 +18,13 @@ mod utils;
 #[derive(Debug)]
 pub struct Prover<'params> {
     // degree -> params (use BTreeMap to find proper degree for params downsize)
-    pub(crate) params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
+    pub params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
     // Cached id -> pk
     pk_map: HashMap<String, ProvingKey<G1Affine>>,
 }
 
 impl<'params> Prover<'params> {
-    pub fn from_params(params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>) -> Self {
+    pub fn from_params_map(params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>) -> Self {
         Self {
             params_map,
             pk_map: HashMap::new(),

--- a/prover/src/common/prover.rs
+++ b/prover/src/common/prover.rs
@@ -16,22 +16,22 @@ mod recursion;
 mod utils;
 
 #[derive(Debug)]
-pub struct Prover {
+pub struct Prover<'params> {
     // degree -> params (use BTreeMap to find proper degree for params downsize)
-    params_map: BTreeMap<u32, ParamsKZG<Bn256>>,
+    pub(crate) params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
     // Cached id -> pk
     pk_map: HashMap<String, ProvingKey<G1Affine>>,
 }
 
-impl Prover {
-    pub fn from_params(params_map: BTreeMap<u32, ParamsKZG<Bn256>>) -> Self {
+impl<'params> Prover<'params> {
+    pub fn from_params(params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>) -> Self {
         Self {
             params_map,
             pk_map: HashMap::new(),
         }
     }
 
-    pub fn from_params_dir(params_dir: &str, degrees: &[u32]) -> Self {
+    pub fn load_params_map(params_dir: &str, degrees: &[u32]) -> BTreeMap<u32, ParamsKZG<Bn256>> {
         let degrees = BTreeSet::from_iter(degrees);
         let max_degree = **degrees.last().unwrap();
 
@@ -63,9 +63,6 @@ impl Prover {
             params_map.insert(*d, params);
         }
 
-        Self {
-            params_map,
-            pk_map: HashMap::new(),
-        }
+        params_map
     }
 }

--- a/prover/src/common/prover/aggregation.rs
+++ b/prover/src/common/prover/aggregation.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use snark_verifier_sdk::Snark;
 use std::env;
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn gen_agg_snark<const N_SNARKS: usize>(
         &mut self,
         id: &str,

--- a/prover/src/common/prover/chunk.rs
+++ b/prover/src/common/prover/chunk.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use snark_verifier_sdk::Snark;
 use zkevm_circuits::evm_circuit::witness::Block;
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn load_or_gen_final_chunk_snark(
         &mut self,
         name: &str,

--- a/prover/src/common/prover/compression.rs
+++ b/prover/src/common/prover/compression.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use snark_verifier_sdk::Snark;
 use std::env;
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn gen_comp_snark(
         &mut self,
         id: &str,

--- a/prover/src/common/prover/evm.rs
+++ b/prover/src/common/prover/evm.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 use snark_verifier_sdk::{gen_evm_proof_shplonk, CircuitExt, Snark};
 use std::env;
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn load_or_gen_comp_evm_proof(
         &mut self,
         name: &str,

--- a/prover/src/common/prover/inner.rs
+++ b/prover/src/common/prover/inner.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use snark_verifier_sdk::{gen_snark_shplonk, Snark};
 use zkevm_circuits::evm_circuit::witness::Block;
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn gen_inner_snark<C: TargetCircuit>(
         &mut self,
         id: &str,

--- a/prover/src/common/prover/mock.rs
+++ b/prover/src/common/prover/mock.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 pub static MOCK_PROVE: LazyLock<bool> = LazyLock::new(|| read_env_var("MOCK_PROVE", false));
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn assert_if_mock_prover<C: CircuitExt<Fr>>(id: &str, degree: u32, circuit: &C) {
         if !*MOCK_PROVE {
             return;

--- a/prover/src/common/prover/recursion.rs
+++ b/prover/src/common/prover/recursion.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::Prover;
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn gen_recursion_snark(
         &mut self,
         id: &str,

--- a/prover/src/common/prover/utils.rs
+++ b/prover/src/common/prover/utils.rs
@@ -4,12 +4,12 @@ use anyhow::Result;
 use halo2_proofs::{
     halo2curves::bn256::{Bn256, Fr, G1Affine},
     plonk::{keygen_pk2, Circuit, ProvingKey},
-    poly::{commitment::Params, kzg::commitment::ParamsKZG},
+    poly::kzg::commitment::ParamsKZG,
 };
 use rand::Rng;
 use snark_verifier_sdk::{gen_snark_shplonk, CircuitExt, Snark};
 
-impl Prover {
+impl<'params> Prover<'params> {
     pub fn gen_snark<C: CircuitExt<Fr>>(
         &mut self,
         id: &str,
@@ -32,25 +32,7 @@ impl Prover {
         Ok(snark)
     }
 
-    pub fn params(&mut self, degree: u32) -> &ParamsKZG<Bn256> {
-        if self.params_map.contains_key(&degree) {
-            return &self.params_map[&degree];
-        }
-
-        log::warn!("Optimization: download params{degree} to params dir");
-
-        log::info!("Before generate params of {degree}");
-        let mut new_params = self
-            .params_map
-            .range(degree..)
-            .next()
-            .unwrap_or_else(|| panic!("Must have params of degree-{degree}"))
-            .1
-            .clone();
-        new_params.downsize(degree);
-        log::info!("After generate params of {degree}");
-
-        self.params_map.insert(degree, new_params);
+    pub fn params(&self, degree: u32) -> &ParamsKZG<Bn256> {
         &self.params_map[&degree]
     }
 

--- a/prover/src/common/verifier.rs
+++ b/prover/src/common/verifier.rs
@@ -1,4 +1,4 @@
-use crate::{io::deserialize_vk, utils::load_params};
+use crate::io::deserialize_vk;
 use halo2_proofs::{
     halo2curves::bn256::{Bn256, Fr, G1Affine},
     plonk::VerifyingKey,
@@ -11,14 +11,14 @@ mod evm;
 mod utils;
 
 #[derive(Debug)]
-pub struct Verifier<C: CircuitExt<Fr>> {
-    params: ParamsKZG<Bn256>,
+pub struct Verifier<'params, C: CircuitExt<Fr>> {
+    params: &'params ParamsKZG<Bn256>,
     vk: VerifyingKey<G1Affine>,
     phantom: PhantomData<C>,
 }
 
-impl<C: CircuitExt<Fr>> Verifier<C> {
-    pub fn new(params: ParamsKZG<Bn256>, vk: VerifyingKey<G1Affine>) -> Self {
+impl<'params, C: CircuitExt<Fr>> Verifier<'params, C> {
+    pub fn new(params: &'params ParamsKZG<Bn256>, vk: VerifyingKey<G1Affine>) -> Self {
         Self {
             params,
             vk,
@@ -26,16 +26,9 @@ impl<C: CircuitExt<Fr>> Verifier<C> {
         }
     }
 
-    pub fn from_params(params: ParamsKZG<Bn256>, raw_vk: &[u8]) -> Self {
+    pub fn from_params(params: &'params ParamsKZG<Bn256>, raw_vk: &[u8]) -> Self {
         let vk = deserialize_vk::<C>(raw_vk);
-
         Self::new(params, vk)
-    }
-
-    pub fn from_params_dir(params_dir: &str, degree: u32, vk: &[u8]) -> Self {
-        let params = load_params(params_dir, degree, None).unwrap();
-
-        Self::from_params(params, vk)
     }
 
     pub fn verify_snark(&self, snark: Snark) -> bool {

--- a/prover/src/common/verifier/evm.rs
+++ b/prover/src/common/verifier/evm.rs
@@ -3,8 +3,8 @@ use crate::EvmProof;
 use halo2_proofs::halo2curves::bn256::Fr;
 use snark_verifier_sdk::CircuitExt;
 
-impl<C: CircuitExt<Fr>> Verifier<C> {
+impl<'params, C: CircuitExt<Fr>> Verifier<'params, C> {
     pub fn gen_evm_verifier(&self, evm_proof: &EvmProof, output_dir: Option<&str>) {
-        crate::evm::gen_evm_verifier::<C>(&self.params, &self.vk, evm_proof, output_dir)
+        crate::evm::gen_evm_verifier::<C>(self.params, &self.vk, evm_proof, output_dir)
     }
 }

--- a/prover/src/common/verifier/utils.rs
+++ b/prover/src/common/verifier/utils.rs
@@ -6,9 +6,9 @@ use halo2_proofs::{
 };
 use snark_verifier_sdk::CircuitExt;
 
-impl<C: CircuitExt<Fr>> Verifier<C> {
+impl<'params, C: CircuitExt<Fr>> Verifier<'params, C> {
     pub fn params(&self) -> &ParamsKZG<Bn256> {
-        &self.params
+        self.params
     }
 
     pub fn vk(&self) -> &VerifyingKey<G1Affine> {

--- a/prover/src/inner/prover.rs
+++ b/prover/src/inner/prover.rs
@@ -14,14 +14,14 @@ use std::marker::PhantomData;
 mod mock;
 
 #[derive(Debug)]
-pub struct Prover<C: TargetCircuit> {
+pub struct Prover<'params, C: TargetCircuit> {
     // Make it public for testing with inner functions (unnecessary for FFI).
-    pub prover_impl: common::Prover,
+    pub prover_impl: common::Prover<'params>,
     phantom: PhantomData<C>,
 }
 
-impl<C: TargetCircuit> From<common::Prover> for Prover<C> {
-    fn from(prover_impl: common::Prover) -> Self {
+impl<'params, C: TargetCircuit> From<common::Prover<'params>> for Prover<'params, C> {
+    fn from(prover_impl: common::Prover<'params>) -> Self {
         Self {
             prover_impl,
             phantom: PhantomData,
@@ -29,9 +29,9 @@ impl<C: TargetCircuit> From<common::Prover> for Prover<C> {
     }
 }
 
-impl<C: TargetCircuit> Prover<C> {
-    pub fn from_params_dir(params_dir: &str) -> Self {
-        common::Prover::from_params_dir(params_dir, &[*INNER_DEGREE]).into()
+impl<'params, C: TargetCircuit> Prover<'params, C> {
+    pub fn degrees() -> Vec<u32> {
+        vec![*INNER_DEGREE]
     }
 
     pub fn gen_inner_snark(&mut self, id: &str, block_traces: Vec<BlockTrace>) -> Result<Snark> {

--- a/prover/src/inner/prover/mock.rs
+++ b/prover/src/inner/prover/mock.rs
@@ -10,7 +10,7 @@ use halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
 use snark_verifier_sdk::CircuitExt;
 use zkevm_circuits::witness::Block;
 
-impl<C: TargetCircuit> Prover<C> {
+impl<'params, C: TargetCircuit> Prover<'params, C> {
     pub fn mock_prove_target_circuit(block_trace: BlockTrace) -> anyhow::Result<()> {
         Self::mock_prove_target_circuit_chunk(vec![block_trace])
     }

--- a/prover/src/inner/verifier.rs
+++ b/prover/src/inner/verifier.rs
@@ -1,35 +1,38 @@
-use crate::{
-    common, config::INNER_DEGREE, io::deserialize_vk, utils::load_params,
-    zkevm::circuit::TargetCircuit,
-};
-use halo2_proofs::plonk::keygen_vk;
+use std::collections::BTreeMap;
+
+use crate::{common, config::INNER_DEGREE, io::deserialize_vk, zkevm::circuit::TargetCircuit};
+use halo2_proofs::{halo2curves::bn256::Bn256, plonk::keygen_vk, poly::kzg::commitment::ParamsKZG};
 use snark_verifier_sdk::Snark;
 
 #[derive(Debug)]
-pub struct Verifier<C: TargetCircuit> {
+pub struct Verifier<'params, C: TargetCircuit> {
     // Make it public for testing with inner functions (unnecessary for FFI).
-    pub inner: common::Verifier<C::Inner>,
+    pub inner: common::Verifier<'params, C::Inner>,
 }
 
-impl<C: TargetCircuit> From<common::Verifier<C::Inner>> for Verifier<C> {
-    fn from(inner: common::Verifier<C::Inner>) -> Self {
+impl<'params, C: TargetCircuit> From<common::Verifier<'params, C::Inner>> for Verifier<'params, C> {
+    fn from(inner: common::Verifier<'params, C::Inner>) -> Self {
         Self { inner }
     }
 }
 
-impl<C: TargetCircuit> Verifier<C> {
-    pub fn from_params_dir(params_dir: &str, raw_vk: Option<&[u8]>) -> Self {
-        let params = load_params(params_dir, *INNER_DEGREE, None).unwrap();
+impl<'params, C: TargetCircuit> Verifier<'params, C> {
+    pub fn from_params_map(
+        params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
+        raw_vk: Option<&[u8]>,
+    ) -> Self {
+        let params = params_map.get(&*INNER_DEGREE).expect("should be loaded");
 
         let vk = raw_vk.map_or_else(
             || {
                 let dummy_circuit = C::dummy_inner_circuit().expect("gen dummy circuit");
-                keygen_vk(&params, &dummy_circuit).unwrap()
+                keygen_vk(params, &dummy_circuit).unwrap()
             },
             deserialize_vk::<C::Inner>,
         );
 
-        common::Verifier::new(params, vk).into()
+        let verifier = common::Verifier::new(params, vk);
+        verifier.into()
     }
 
     pub fn verify_inner_snark(&self, snark: Snark) -> bool {

--- a/prover/src/test/batch.rs
+++ b/prover/src/test/batch.rs
@@ -1,58 +1,60 @@
+use halo2_proofs::{halo2curves::bn256::Bn256, poly::kzg::commitment::ParamsKZG};
+
 use crate::{
     aggregator::{Prover, Verifier},
-    config::LayerId,
+    config::{LayerId, AGG_DEGREES},
     consts::DEPLOYMENT_CODE_FILENAME,
     io::force_to_read,
     types::BundleProvingTask,
     utils::read_env_var,
     BatchProvingTask,
 };
-use std::sync::{LazyLock, Mutex};
+use std::{
+    collections::BTreeMap,
+    sync::{LazyLock, Mutex},
+};
+
+static PARAMS_MAP: LazyLock<BTreeMap<u32, ParamsKZG<Bn256>>> = LazyLock::new(|| {
+    let params_dir = read_env_var("SCROLL_PROVER_PARAMS_DIR", "./test_params".to_string());
+    crate::common::Prover::load_params_map(&params_dir, &AGG_DEGREES)
+});
 
 static BATCH_PROVER: LazyLock<Mutex<Prover>> = LazyLock::new(|| {
     let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
-    let params_dir = read_env_var("SCROLL_PROVER_PARAMS_DIR", "./test_params".to_string());
 
-    let prover = Prover::from_dirs(&params_dir, &assets_dir);
+    let prover = Prover::from_dirs(&PARAMS_MAP, &assets_dir);
     log::info!("Constructed batch-prover");
 
     Mutex::new(prover)
 });
 
-static BATCH_VERIFIER: LazyLock<Mutex<Verifier>> = LazyLock::new(|| {
-    let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
-
-    let mut prover = BATCH_PROVER.lock().expect("poisoned batch-prover");
-    let params = prover.prover_impl.params(LayerId::Layer4.degree()).clone();
-
-    let deployment_code = force_to_read(&assets_dir, &DEPLOYMENT_CODE_FILENAME);
-
-    let pk = prover
-        .prover_impl
-        .pk(LayerId::Layer4.id())
-        .expect("Failed to get batch-prove PK");
-    let vk = pk.get_vk().clone();
-
-    let verifier = Verifier::new(params, vk, deployment_code);
-    log::info!("Constructed batch-verifier");
-
-    Mutex::new(verifier)
-});
-
 pub fn batch_prove(test: &str, batch: BatchProvingTask) {
     log::info!("{test}: batch-prove BEGIN");
 
-    let proof = BATCH_PROVER
-        .lock()
-        .expect("poisoned batch-prover")
+    let mut prover = BATCH_PROVER.lock().expect("poisoned batch-prover");
+    let proof = prover
         .gen_batch_proof(batch, None, None)
         .unwrap_or_else(|err| panic!("{test}: failed to generate batch proof: {err}"));
     log::info!("{test}: generated batch proof");
 
-    let verified = BATCH_VERIFIER
-        .lock()
-        .expect("poisoned batch-verifier")
-        .verify_batch_proof(&proof);
+    let verifier = {
+        let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
+
+        let params = prover.prover_impl.params(LayerId::Layer4.degree());
+
+        let deployment_code = force_to_read(&assets_dir, &DEPLOYMENT_CODE_FILENAME);
+
+        let pk = prover
+            .prover_impl
+            .pk(LayerId::Layer4.id())
+            .expect("Failed to get batch-prove PK");
+        let vk = pk.get_vk().clone();
+
+        let verifier = Verifier::new(params, vk, deployment_code);
+        log::info!("Constructed batch-verifier");
+        verifier
+    };
+    let verified = verifier.verify_batch_proof(&proof);
     assert!(verified, "{test}: failed to verify batch proof");
 
     log::info!("{test}: batch-prove END");
@@ -61,17 +63,32 @@ pub fn batch_prove(test: &str, batch: BatchProvingTask) {
 pub fn bundle_prove(test: &str, bundle: BundleProvingTask) {
     log::info!("{test}: bundle-prove BEGIN");
 
-    let proof = BATCH_PROVER
-        .lock()
-        .expect("poisoned batch-prover")
+    let mut prover = BATCH_PROVER.lock().expect("poisoned batch-prover");
+    let proof = prover
         .gen_bundle_proof(bundle, None, None)
         .unwrap_or_else(|err| panic!("{test}: failed to generate bundle proof: {err}"));
     log::info!("{test}: generated bundle proof");
 
-    let verified = BATCH_VERIFIER
-        .lock()
-        .expect("poisoned batch-verifier")
-        .verify_bundle_proof(proof);
+    // FIXME: clean redundant code
+    let verifier = {
+        let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
+
+        let params = prover.prover_impl.params(LayerId::Layer4.degree());
+
+        let deployment_code = force_to_read(&assets_dir, &DEPLOYMENT_CODE_FILENAME);
+
+        let pk = prover
+            .prover_impl
+            .pk(LayerId::Layer4.id())
+            .expect("Failed to get batch-prove PK");
+        let vk = pk.get_vk().clone();
+
+        let verifier = Verifier::new(params, vk, deployment_code);
+        log::info!("Constructed batch-verifier");
+        verifier
+    };
+
+    let verified = verifier.verify_bundle_proof(proof);
     assert!(verified, "{test}: failed to verify bundle proof");
 
     log::info!("{test}: bundle-prove END");

--- a/prover/src/test/batch.rs
+++ b/prover/src/test/batch.rs
@@ -22,7 +22,7 @@ static PARAMS_MAP: LazyLock<BTreeMap<u32, ParamsKZG<Bn256>>> = LazyLock::new(|| 
 static BATCH_PROVER: LazyLock<Mutex<Prover>> = LazyLock::new(|| {
     let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
 
-    let prover = Prover::from_dirs(&PARAMS_MAP, &assets_dir);
+    let prover = Prover::from_params_and_assets(&PARAMS_MAP, &assets_dir);
     log::info!("Constructed batch-prover");
 
     Mutex::new(prover)

--- a/prover/src/test/chunk.rs
+++ b/prover/src/test/chunk.rs
@@ -18,7 +18,7 @@ static PARAMS_MAP: LazyLock<BTreeMap<u32, ParamsKZG<Bn256>>> = LazyLock::new(|| 
 
 static CHUNK_PROVER: LazyLock<Mutex<Prover>> = LazyLock::new(|| {
     let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
-    let prover = Prover::from_params_map(&PARAMS_MAP, &assets_dir);
+    let prover = Prover::from_params_and_assets(&PARAMS_MAP, &assets_dir);
     log::info!("Constructed chunk-prover");
 
     Mutex::new(prover)
@@ -36,7 +36,7 @@ pub fn chunk_prove(desc: &str, chunk: ChunkProvingTask) -> ChunkProof {
 
     let verifier = {
         let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
-        let verifier = Verifier::from_params_map(prover.prover_impl.params_map, &assets_dir);
+        let verifier = Verifier::from_params_and_assets(prover.prover_impl.params_map, &assets_dir);
         log::info!("Constructed chunk-verifier");
         verifier
     };

--- a/prover/src/test/chunk.rs
+++ b/prover/src/test/chunk.rs
@@ -1,27 +1,27 @@
+use halo2_proofs::{halo2curves::bn256::Bn256, poly::kzg::commitment::ParamsKZG};
+
 use crate::{
+    config::ZKEVM_DEGREES,
     utils::read_env_var,
     zkevm::{Prover, Verifier},
     ChunkProof, ChunkProvingTask,
 };
-use std::sync::{LazyLock, Mutex};
+use std::{
+    collections::BTreeMap,
+    sync::{LazyLock, Mutex},
+};
+
+static PARAMS_MAP: LazyLock<BTreeMap<u32, ParamsKZG<Bn256>>> = LazyLock::new(|| {
+    let params_dir = read_env_var("SCROLL_PROVER_PARAMS_DIR", "./test_params".to_string());
+    crate::common::Prover::load_params_map(&params_dir, &ZKEVM_DEGREES)
+});
 
 static CHUNK_PROVER: LazyLock<Mutex<Prover>> = LazyLock::new(|| {
-    let params_dir = read_env_var("SCROLL_PROVER_PARAMS_DIR", "./test_params".to_string());
     let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
-    let prover = Prover::from_dirs(&params_dir, &assets_dir);
+    let prover = Prover::from_params_map(&PARAMS_MAP, &assets_dir);
     log::info!("Constructed chunk-prover");
 
     Mutex::new(prover)
-});
-
-static CHUNK_VERIFIER: LazyLock<Mutex<Verifier>> = LazyLock::new(|| {
-    let params_dir = read_env_var("SCROLL_PROVER_PARAMS_DIR", "./test_params".to_string());
-    let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
-
-    let verifier = Verifier::from_dirs(&params_dir, &assets_dir);
-    log::info!("Constructed chunk-verifier");
-
-    Mutex::new(verifier)
 });
 
 pub fn chunk_prove(desc: &str, chunk: ChunkProvingTask) -> ChunkProof {
@@ -34,7 +34,12 @@ pub fn chunk_prove(desc: &str, chunk: ChunkProvingTask) -> ChunkProof {
         .unwrap_or_else(|err| panic!("{desc}: failed to generate chunk snark: {err}"));
     log::info!("{desc}: generated chunk proof");
 
-    let verifier = CHUNK_VERIFIER.lock().expect("poisoned chunk-verifier");
+    let verifier = {
+        let assets_dir = read_env_var("SCROLL_PROVER_ASSETS_DIR", "./test_assets".to_string());
+        let verifier = Verifier::from_params_map(prover.prover_impl.params_map, &assets_dir);
+        log::info!("Constructed chunk-verifier");
+        verifier
+    };
 
     let verified = verifier.verify_chunk_proof(proof.clone());
     assert!(verified, "{desc}: failed to verify chunk snark");

--- a/prover/src/test/inner.rs
+++ b/prover/src/test/inner.rs
@@ -1,3 +1,5 @@
+use halo2_proofs::{halo2curves::bn256::Bn256, poly::kzg::commitment::ParamsKZG};
+
 use crate::{
     common::{Prover, Verifier},
     config::{LayerId, INNER_DEGREE},
@@ -5,30 +7,22 @@ use crate::{
     zkevm::circuit::{SuperCircuit, TargetCircuit},
     WitnessBlock,
 };
-use std::sync::{LazyLock, Mutex};
+use std::{
+    collections::BTreeMap,
+    sync::{LazyLock, Mutex},
+};
+
+static PARAMS_MAP: LazyLock<BTreeMap<u32, ParamsKZG<Bn256>>> = LazyLock::new(|| {
+    let params_dir = read_env_var("SCROLL_PROVER_PARAMS_DIR", "./test_params".to_string());
+    crate::common::Prover::load_params_map(&params_dir, &[*INNER_DEGREE])
+});
 
 static INNER_PROVER: LazyLock<Mutex<Prover>> = LazyLock::new(|| {
-    let params_dir = read_env_var("SCROLL_PROVER_PARAMS_DIR", "./test_params".to_string());
-    let prover = Prover::from_params_dir(&params_dir, &[*INNER_DEGREE]);
+    let prover = Prover::from_params(&PARAMS_MAP);
     log::info!("Constructed inner-prover");
 
     Mutex::new(prover)
 });
-
-static INNER_VERIFIER: LazyLock<Mutex<Verifier<<SuperCircuit as TargetCircuit>::Inner>>> =
-    LazyLock::new(|| {
-        let mut prover = INNER_PROVER.lock().expect("poisoned inner-prover");
-        let params = prover.params(*INNER_DEGREE).clone();
-
-        let inner_id = LayerId::Inner.id().to_string();
-        let pk = prover.pk(&inner_id).expect("Failed to get inner-prove PK");
-        let vk = pk.get_vk().clone();
-
-        let verifier = Verifier::new(params, vk);
-        log::info!("Constructed inner-verifier");
-
-        Mutex::new(verifier)
-    });
 
 pub fn inner_prove(test: &str, witness_block: &WitnessBlock) {
     log::info!("{test}: inner-prove BEGIN");
@@ -41,7 +35,17 @@ pub fn inner_prove(test: &str, witness_block: &WitnessBlock) {
         .unwrap_or_else(|err| panic!("{test}: failed to generate inner snark: {err}"));
     log::info!("{test}: generated inner snark");
 
-    let verifier = INNER_VERIFIER.lock().expect("poisoned inner-verifier");
+    let verifier: Verifier<'_, <SuperCircuit as TargetCircuit>::Inner> = {
+        let params = prover.params(*INNER_DEGREE);
+
+        let inner_id = LayerId::Inner.id().to_string();
+        let pk = prover.pk(&inner_id).expect("Failed to get inner-prove PK");
+        let vk = pk.get_vk().clone();
+
+        let verifier = Verifier::new(params, vk);
+        log::info!("Constructed inner-verifier");
+        verifier
+    };
 
     let verified = verifier.verify_snark(snark);
     assert!(verified, "{test}: failed to verify inner snark");

--- a/prover/src/test/inner.rs
+++ b/prover/src/test/inner.rs
@@ -18,7 +18,7 @@ static PARAMS_MAP: LazyLock<BTreeMap<u32, ParamsKZG<Bn256>>> = LazyLock::new(|| 
 });
 
 static INNER_PROVER: LazyLock<Mutex<Prover>> = LazyLock::new(|| {
-    let prover = Prover::from_params(&PARAMS_MAP);
+    let prover = Prover::from_params_map(&PARAMS_MAP);
     log::info!("Constructed inner-prover");
 
     Mutex::new(prover)

--- a/prover/src/zkevm/prover.rs
+++ b/prover/src/zkevm/prover.rs
@@ -1,15 +1,9 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    common,
-    config::{LayerId, ZKEVM_DEGREES},
-    consts::CHUNK_VK_FILENAME,
-    io::try_to_read,
-    proof::compare_chunk_info,
-    types::ChunkProvingTask,
-    utils::chunk_trace_to_witness_block,
-    zkevm::circuit::calculate_row_usage_of_witness_block,
-    ChunkProof,
+    common, config::LayerId, consts::CHUNK_VK_FILENAME, io::try_to_read, proof::compare_chunk_info,
+    types::ChunkProvingTask, utils::chunk_trace_to_witness_block,
+    zkevm::circuit::calculate_row_usage_of_witness_block, ChunkProof,
 };
 use aggregator::ChunkInfo;
 use anyhow::Result;
@@ -24,9 +18,6 @@ pub struct Prover<'params> {
 }
 
 impl<'params> Prover<'params> {
-    pub fn degrees() -> Vec<u32> {
-        (*ZKEVM_DEGREES).clone()
-    }
     pub fn from_params_and_assets(
         params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
         assets_dir: &str,

--- a/prover/src/zkevm/prover.rs
+++ b/prover/src/zkevm/prover.rs
@@ -27,14 +27,14 @@ impl<'params> Prover<'params> {
     pub fn degrees() -> Vec<u32> {
         (*ZKEVM_DEGREES).clone()
     }
-    pub fn from_params_map(
+    pub fn from_params_and_assets(
         params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
         assets_dir: &str,
     ) -> Self {
-        let prover_impl = common::Prover::from_params(params_map);
+        let prover_impl = common::Prover::from_params_map(params_map);
 
         let raw_vk = try_to_read(assets_dir, &CHUNK_VK_FILENAME);
-        let _verifier = if raw_vk.is_none() {
+        let verifier = if raw_vk.is_none() {
             log::warn!(
                 "zkevm-prover: {} doesn't exist in {}",
                 *CHUNK_VK_FILENAME,
@@ -42,7 +42,7 @@ impl<'params> Prover<'params> {
             );
             None
         } else {
-            Some(super::verifier::Verifier::from_params_map(
+            Some(super::verifier::Verifier::from_params_and_assets(
                 prover_impl.params_map,
                 assets_dir,
             ))
@@ -50,7 +50,7 @@ impl<'params> Prover<'params> {
         Self {
             prover_impl,
             raw_vk,
-            verifier: None,
+            verifier,
         }
     }
 

--- a/prover/src/zkevm/prover.rs
+++ b/prover/src/zkevm/prover.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use crate::{
     common,
     config::{LayerId, ZKEVM_DEGREES},
@@ -11,21 +13,28 @@ use crate::{
 };
 use aggregator::ChunkInfo;
 use anyhow::Result;
+use halo2_proofs::{halo2curves::bn256::Bn256, poly::kzg::commitment::ParamsKZG};
 
 #[derive(Debug)]
-pub struct Prover {
+pub struct Prover<'params> {
     // Make it public for testing with inner functions (unnecessary for FFI).
-    pub prover_impl: common::Prover,
-    verifier: Option<super::verifier::Verifier>,
+    pub prover_impl: common::Prover<'params>,
+    verifier: Option<super::verifier::Verifier<'params>>,
     raw_vk: Option<Vec<u8>>,
 }
 
-impl Prover {
-    pub fn from_dirs(params_dir: &str, assets_dir: &str) -> Self {
-        let prover_impl = common::Prover::from_params_dir(params_dir, &ZKEVM_DEGREES);
+impl<'params> Prover<'params> {
+    pub fn degrees() -> Vec<u32> {
+        (*ZKEVM_DEGREES).clone()
+    }
+    pub fn from_params_map(
+        params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
+        assets_dir: &str,
+    ) -> Self {
+        let prover_impl = common::Prover::from_params(params_map);
 
         let raw_vk = try_to_read(assets_dir, &CHUNK_VK_FILENAME);
-        let verifier = if raw_vk.is_none() {
+        let _verifier = if raw_vk.is_none() {
             log::warn!(
                 "zkevm-prover: {} doesn't exist in {}",
                 *CHUNK_VK_FILENAME,
@@ -33,13 +42,15 @@ impl Prover {
             );
             None
         } else {
-            Some(super::verifier::Verifier::from_dirs(params_dir, assets_dir))
+            Some(super::verifier::Verifier::from_params_map(
+                prover_impl.params_map,
+                assets_dir,
+            ))
         };
-
         Self {
             prover_impl,
             raw_vk,
-            verifier,
+            verifier: None,
         }
     }
 

--- a/prover/src/zkevm/verifier.rs
+++ b/prover/src/zkevm/verifier.rs
@@ -11,30 +11,34 @@ use halo2_proofs::{
     plonk::VerifyingKey,
     poly::kzg::commitment::ParamsKZG,
 };
-use std::env;
+use std::{collections::BTreeMap, env};
 
 #[derive(Debug)]
-pub struct Verifier {
+pub struct Verifier<'params> {
     // Make it public for testing with inner functions (unnecessary for FFI).
-    pub inner: common::Verifier<CompressionCircuit>,
+    pub inner: common::Verifier<'params, CompressionCircuit>,
 }
 
-impl From<common::Verifier<CompressionCircuit>> for Verifier {
-    fn from(inner: common::Verifier<CompressionCircuit>) -> Self {
+impl<'params> From<common::Verifier<'params, CompressionCircuit>> for Verifier<'params> {
+    fn from(inner: common::Verifier<'params, CompressionCircuit>) -> Self {
         Self { inner }
     }
 }
 
-impl Verifier {
-    pub fn new(params: ParamsKZG<Bn256>, vk: VerifyingKey<G1Affine>) -> Self {
+impl<'params> Verifier<'params> {
+    pub fn new(params: &'params ParamsKZG<Bn256>, vk: VerifyingKey<G1Affine>) -> Self {
         common::Verifier::new(params, vk).into()
     }
 
-    pub fn from_dirs(params_dir: &str, assets_dir: &str) -> Self {
+    pub fn from_params_map(
+        params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
+        assets_dir: &str,
+    ) -> Self {
         let raw_vk = force_to_read(assets_dir, &chunk_vk_filename());
-
         env::set_var("COMPRESSION_CONFIG", &*LAYER2_CONFIG_PATH);
-        common::Verifier::from_params_dir(params_dir, *LAYER2_DEGREE, &raw_vk).into()
+        let params = params_map.get(&*LAYER2_DEGREE).expect("should be loaded");
+        let verifier = common::Verifier::from_params(params, &raw_vk);
+        verifier.into()
     }
 
     pub fn verify_chunk_proof(&self, proof: ChunkProof) -> bool {

--- a/prover/src/zkevm/verifier.rs
+++ b/prover/src/zkevm/verifier.rs
@@ -30,7 +30,7 @@ impl<'params> Verifier<'params> {
         common::Verifier::new(params, vk).into()
     }
 
-    pub fn from_params_map(
+    pub fn from_params_and_assets(
         params_map: &'params BTreeMap<u32, ParamsKZG<Bn256>>,
         assets_dir: &str,
     ) -> Self {


### PR DESCRIPTION
same with https://github.com/scroll-tech/zkevm-circuits/pull/1405

to update, we need to first push to this branch, then merge into v0.13