### PR TITLE
fix: `TransactionTrace::to_eth_tx` does not handle `chain_id` properly

### DIFF
--- a/eth-types/src/l2_types.rs
+++ b/eth-types/src/l2_types.rs
@@ -388,7 +388,11 @@ impl TransactionTrace {
             access_list: self.access_list.as_ref().map(|al| AccessList(al.clone())),
             max_priority_fee_per_gas: self.gas_tip_cap,
             max_fee_per_gas: self.gas_fee_cap,
-            chain_id: Some(self.chain_id),
+            chain_id: if self.type_ != 0 || self.v.as_u64() >= 35 {
+                Some(self.chain_id)
+            } else {
+                None
+            },
             other: Default::default(),
         }
     }


### PR DESCRIPTION
Legacy tx doesn't include chain_id, which cause `ethers_core` calculate wrong `sig_hash` (tx_hash):

https://github.com/scroll-tech/ethers-rs/blob/90b87bd85be98caa8bb592b67f3f9acbc8a409cf/ethers-core/src/types/transaction/response.rs#L357-L362
```rust
    /// Recover the sender of the tx from signature
    pub fn recover_from(&self) -> Result<Address, SignatureError> {
        let signature = Signature { r: self.r, s: self.s, v: self.v.as_u64() };
        let typed_tx: TypedTransaction = self.into();
        signature.recover(typed_tx.sighash())
    }
```

https://github.com/scroll-tech/ethers-rs/blob/90b87bd85be98caa8bb592b67f3f9acbc8a409cf/ethers-core/src/types/transaction/eip2718.rs#L359-L363
```rust
    /// Hashes the transaction's data. Does not double-RLP encode
    pub fn sighash(&self) -> H256 {
        let encoded = self.rlp();
        keccak256(encoded).into()
    }
```

https://github.com/scroll-tech/ethers-rs/blob/90b87bd85be98caa8bb592b67f3f9acbc8a409cf/ethers-core/src/types/transaction/request.rs#L162-L175

```rust
    /// Gets the transaction's RLP encoding, prepared with the chain_id and extra fields for
    /// signing. Assumes the chainid exists.
    pub fn rlp(&self) -> Bytes {
        let mut rlp = RlpStream::new();
        if let Some(chain_id) = self.chain_id {
            rlp.begin_list(NUM_TX_FIELDS);
            self.rlp_base(&mut rlp);
            rlp.append(&chain_id);
            rlp.append(&0u8);
            rlp.append(&0u8);
        } else {
            rlp.begin_list(NUM_TX_FIELDS - 3);
            self.rlp_base(&mut rlp);
        }
        rlp.out().freeze().into()
    }
```