### PR TITLE
Post curie sanity

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -858,7 +858,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         //          if scroll:
         //              KeccakCodeHash
         // else:
-        //      3 or 6 l1 fee rw
+        //      6 l1 fee rw
         // RwCounterEndOfReversion
         // IsPersistent
         // IsSuccess


### PR DESCRIPTION
The `CurieGadget` and `is_curie` related constraints were removed as of #1415 , however, no associated changes were made in `bus-mapping` assuming that test traces would be post-curie.

A better approach is to add a sanity check to disallow pre-curie blocks as witness.