### PR TITLE
Explicitly specify mainnet env for evm

### DIFF
--- a/prover/src/utils/evm.rs
+++ b/prover/src/utils/evm.rs
@@ -6,7 +6,7 @@ use halo2_proofs::{
     poly::kzg::commitment::ParamsKZG,
 };
 use revm::{
-    primitives::{self, Env, ExecutionResult, Output, SpecId, TxEnv, TxKind},
+    primitives::{self, Env, ExecutionResult, Output, TxEnv, TxKind},
     Evm, Handler, InMemoryDB,
 };
 
@@ -94,9 +94,9 @@ pub fn deploy_and_call(deployment_code: Vec<u8>, calldata: Vec<u8>) -> Result<u6
         ..Default::default()
     };
     let mut evm = Evm::builder()
-        .with_spec_id(SpecId::CANCUN)
         .with_db(&mut db)
-        .with_env(env)
+        .with_env(env.clone())
+        .with_handler(Handler::mainnet::<primitives::CancunSpec>())
         .build();
     let result = evm.transact_commit().unwrap();
     match result {

--- a/prover/src/utils/evm.rs
+++ b/prover/src/utils/evm.rs
@@ -6,8 +6,8 @@ use halo2_proofs::{
     poly::kzg::commitment::ParamsKZG,
 };
 use revm::{
-    primitives::{Env, ExecutionResult, Output, SpecId, TxEnv, TxKind},
-    Evm, InMemoryDB,
+    primitives::{self, Env, ExecutionResult, Output, SpecId, TxEnv, TxKind},
+    Evm, Handler, InMemoryDB,
 };
 
 use snark_verifier::pcs::kzg::{Bdfg21, Kzg};
@@ -63,9 +63,9 @@ pub fn deploy_and_call(deployment_code: Vec<u8>, calldata: Vec<u8>) -> Result<u6
     };
     let mut db = InMemoryDB::default();
     let mut evm = Evm::builder()
-        .with_spec_id(SpecId::CANCUN)
         .with_db(&mut db)
         .with_env(env.clone())
+        .with_handler(Handler::mainnet::<primitives::CancunSpec>())
         .build();
     let result = evm.transact_commit().unwrap();
     let contract = match result {


### PR DESCRIPTION
For `prover`, this PR would specify a mainnet env when calling `deploy_and_call` utility to test contracts, regardless which feature (op / scroll) is enabled.