### PR TITLE
Fix grammar in comments and documentation

### DIFF
--- a/aggregator/src/tests.rs
+++ b/aggregator/src/tests.rs
@@ -95,7 +95,7 @@ macro_rules! compression_layer_snark {
 
 #[macro_export]
 macro_rules! compression_layer_evm {
-    // generate a evm proof and verify it for compression layer
+    // generate an evm proof and verify it for compression layer
     ($previous_snark: ident, $param: ident, $degree: ident, $path: ident,$layer_index: expr) => {{
         let timer = start_timer!(|| format!("gen layer {} snark", $layer_index));
 

--- a/eth-types/src/evm_types/storage.rs
+++ b/eth-types/src/evm_types/storage.rs
@@ -47,7 +47,7 @@ impl Storage {
         Storage(HashMap::new())
     }
 
-    /// Generate an new instance of EVM storage given a `HashMap<Word, Word>`.
+    /// Generate a new instance of EVM storage given a `HashMap<Word, Word>`.
     pub fn new(map: HashMap<Word, Word>) -> Self {
         Self::from(map)
     }

--- a/eth-types/src/evm_types/transient_storage.rs
+++ b/eth-types/src/evm_types/transient_storage.rs
@@ -47,7 +47,7 @@ impl TransientStorage {
         TransientStorage(HashMap::new())
     }
 
-    /// Generate an new instance of EVM transient storage given a `HashMap<Word, Word>`.
+    /// Generate a new instance of EVM transient storage given a `HashMap<Word, Word>`.
     pub fn new(map: HashMap<Word, Word>) -> Self {
         Self::from(map)
     }

--- a/eth-types/src/geth_types.rs
+++ b/eth-types/src/geth_types.rs
@@ -389,7 +389,7 @@ impl Transaction {
     }
 }
 
-/// GethData is a type that contains all the information of a Ethereum block
+/// GethData is a type that contains all the information of an Ethereum block
 #[derive(Default, Debug, Clone)]
 pub struct GethData {
     /// chain id

--- a/integration-tests/tests/readme.md
+++ b/integration-tests/tests/readme.md
@@ -2,7 +2,7 @@
 
 ## Mainnet
 
-Testings in `mainnet.rs` enable accessing a RPC node with debug API, and test any block or single transaction from the node. Trace and block witness would be rebuilt from the input data (block or tx) and then being mocking proven by a specified circuit.
+Testings in `mainnet.rs` enable accessing an RPC node with debug API, and test any block or single transaction from the node. Trace and block witness would be rebuilt from the input data (block or tx) and then being mocking proven by a specified circuit.
 
 The running parameters are specified by environment variables:
 


### PR DESCRIPTION
This pull request corrects grammatical errors in comments and documentation files across multiple modules. Specifically, it replaces instances of "a" with "an" where appropriate (e.g., before words starting with a vowel sound). The changes improve the readability and professionalism of the codebase.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Contents
This PR contains:
- Fixed grammar in comments and documentation:
  - Replaced "a evm" with "an evm" in `tests.rs`.
  - Replaced "an new instance" with "a new instance" in `storage.rs` and `transient_storage.rs`.
  - Replaced "a Ethereum block" with "an Ethereum block" in `geth_types.rs`.
  - Replaced "a RPC node" with "an RPC node" in `readme.md`.